### PR TITLE
[fabric] Test automated deployment of latest fabric go chaincode

### DIFF
--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -185,7 +185,12 @@ spec:
 
             #chaincode path
             CC_SRC_PATH="github.com/chaincode/${CHAINCODE_NAME}/${CHAINCODE_MAINDIR}"
-            
+
+            if ! [ -d "vendor" ];then
+              GO111MODULE=on go mod vendor
+              CC_SRC_PATH="${PWD}"
+            fi
+
           elif [ ${CC_RUNTIME_LANGUAGE} = "java" ]
           then
             ## Copying desired chaincode to a location 


### PR DESCRIPTION
Signed-off-by: mgCepeda <marina.gomez.cepeda@accenture.com>

**Changelog**
- Add a new condition in platforms/hyperledger-fabric/charts/install_chaincode , for both chaincodes to work

This is the configuration used in the network.yaml for the network display with the chain code:
github.com/hyperledger/fabric-samples/tree/main/asset-transfer-basic/chaincode-go
![image](https://user-images.githubusercontent.com/83813093/153394301-10aa50bd-79ff-4680-b4f5-93affdc01e55.png)


**Reviewed by**
@suvajit-sarkar
@jagpreetsinghsasan
 

**Linked issue**
#1797 

