### PR TITLE
updated platforms' README file to include all supported DLT platforms

### DIFF
--- a/platforms/README.md
+++ b/platforms/README.md
@@ -3,6 +3,7 @@
 [//]: # (SPDX-License-Identifier: Apache-2.0)
 [//]: # (##############################################################################################)
 
-There are three folders in this **platform** directory. They are **hyperledger-fabric**, **r3-corda** and **shared**. The **shared** folder contains various sub folders which in turn each has a certain type of files that will be used as **prerequisites**. Users then can run files in the **hyperledger-fabric** or **r3-corda** folder for running either a Hyperledger Fabric or R3 Corda platform depending on the users' decisions. 
+There are seven folders in this **platform** directory. They are: **hyperledger-besu**, **hyperledger-fabric**, **hyperledger-indy**, **quorum**,  **r3-corda-ent**, **r3-corda** and **shared**. The **shared** folder contains various sub folders which in turn each have certain types of files that will be used as **prerequisites**. 
+Users can run files from the selected folder in the platforms directory to deploy their network of choice. 
 
-For users new to this project, please go to the readme file in the **shared** folder first. For users who have already completed the **prerequisites**, they can go to either the **hyperledger-fabric** or **r3-corda** folder to read the specific readme file for more details of each platform.
+For users new to this project, please go to the readme file in the **shared** folder first. For users who have already completed the **prerequisites**, they can go to the specific DLT platform folder to read the specific readme file for more details on each platform.


### PR DESCRIPTION
Signed-off-by: kaverikhaneja <kaveri.khaneja@accenture.com>

**Changelog**

- Updated the platforms directory README.md to include all the DLT platforms supported by HL-Bevel.

 
**Reviewed by**
@sownak @suvajit-sarkar 

 

**Linked issue**
#1838 
