### PR TITLE
[quorum]Remove download of whole quorum repo to build geth and bootnode

### DIFF
--- a/platforms/quorum/configuration/roles/setup/bootnode/Readme.md
+++ b/platforms/quorum/configuration/roles/setup/bootnode/Readme.md
@@ -16,40 +16,31 @@ This task check if bootnode is already installed or not
 ##### Output Variables
     bootnode_stat_result: This variable stores the info on availibility on bootnode binary
 
-#### 2. Check quorum repo dir exists
-This task check if bootnode is already installed or not
+#### 2. Create bootnode directory
+This task creates the bootnode directory
 
-**stat**: This module checks if quorum is cloned or not.
+**stat**: This module creates the bootnode directory
 
 ##### Output Variables
-    quorum_stat_result: This variable stores the info on availibility on quorum repo dir
+    bootnode_stat_result: This variable stores the info on availibility on bootnode binary
 
-#### 3. Clone the git repo
-This task clones the quorum git repository
-
-**git**: This module clones the quorum repository
+#### 3. Download bootnode tar
+This task downloads the bootnode tar
 
 ##### Input Variables
     repo: The path where the bootnode binary should be installed
-    dest: Path where the repository should be cloned
+    dest: Path where the repository should be placed
 
-**when**: It runs when *bootnode_stat_result.stat.exists* == False and *quorum_stat_result.stat.exists* == Flase i.e. when either bootnode is not installed or quorum dir is not there.
+**when**: It runs when *bootnode_stat_result.stat.exists* == False i.e. when either bootnode is not installed 
 
-#### 4. Make bootnode
-This task makes bootnode from the cloned repository and store the binary at build/bin
-
-**shell**: The task goes to the cloned repository.
-
-**when**: It runs when *bootnode_stat_result.stat.exists* == False, i.e. when bootnode is not installed.
-
-#### 5. Create bin directory
+#### 4. Create bin directory
 This task creates the bin directory if it does not exist.
 
 **file**: This module creates the bin directory if it does not exist.
 
 **when**: It runs when *bootnode_stat_result.stat.exists* == False, i.e. when bootnode is not installed.
 
-#### 6. Copy bootnode binary to destination directory
+#### 5. Copy bootnode binary to destination directory
 This task creates the bin directory if it does not exist.
 
 **copy**: This module copies the bootnode binary which is build in the above task and paste it in bin directory

--- a/platforms/quorum/configuration/roles/setup/bootnode/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/setup/bootnode/tasks/main.yaml
@@ -5,31 +5,24 @@
 ##############################################################################################
 
 # This task checks if the bootnode binary is already in place or not
-- name: Check bootnode
+- name: Check bootnode 
   stat:
     path: "{{ bin_install_dir }}/bootnode"
   register: bootnode_stat_result
 
-# This task checks if quorum repo directory exists
-- name: Check quorum repo dir exists
-  stat:
-    path: "{{ bin_install_dir }}/quorum"
-  register: quorum_stat_result
-
-# This task clones the quorum git repository
-- name: Clone the git repo
-  git:
-    repo: "{{ bootnode.repo }}"
-    version: master
-    force: yes
-    dest: "{{ bin_install_dir }}/quorum"
-  when: not ( quorum_stat_result.stat.exists and bootnode_stat_result.stat.exists )
-
-# This task builds the bootnode binary
-- name: Make bootnode
-  make:
-    chdir: "{{ bin_install_dir }}/quorum"
-    target: bootnode
+# This task creates the bootnode directory
+- name: Create bootnode directory
+  file:
+    path: "{{ bin_install_dir }}/bootnode"
+    state: directory
+  when: bootnode_stat_result.stat.exists == False
+  
+# This task downloads the bootnode tar 
+- name: Download bootnode tar 
+  get_url:
+    url: "https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.10.0-56dec25a.tar.gz"
+    dest: "{{ bin_install_dir }}/bootnode"
+    mode: 0777
   when: bootnode_stat_result.stat.exists == False
 
 # This task creates the bin directory, if it doesn't exist
@@ -42,8 +35,8 @@
 # This task puts the bootnode binary to the bin directory created in the above task
 - name: Copy bootnode binary to destination directory
   copy:
-    src: "{{ bin_install_dir }}/quorum/build/bin/bootnode"
-    dest: "{{ bin_install_dir }}/bootnode"
-    mode: 0755
+    src: "{{ bin_install_dir }}/bootnode"
+    dest: "{{ bin_install_dir }}"
+    mode: 0777
     remote_src: yes
   when: bootnode_stat_result.stat.exists == False

--- a/platforms/quorum/configuration/roles/setup/geth/Readme.md
+++ b/platforms/quorum/configuration/roles/setup/geth/Readme.md
@@ -16,40 +16,31 @@ This task check if geth is already installed or not
 ##### Output Variables
     geth_stat_result: This variable stores the info on availibility on geth binary
 
-#### 2. Check quorum repo dir exists
-This task check if geth is already installed or not
+#### 2. Create geth directory
+This task creates the geth directory
 
-**stat**: This module checks if geth is installed or not with path variable.
+**stat**: This module creates the geth directory
 
 ##### Output Variables
-    quorum_stat_result: This variable stores the info on availibility on geth binary
+    geth_stat_result: This variable stores the info on availibility on geth binary
 
-#### 2. Clone the git repo
-This task clones the quorum git repository
-
-**git**: This module clones the quorum repository
+#### 3. Download geth tar
+This task downloads the geth tar
 
 ##### Input Variables
     repo: The path where the geth binary should be installed
-    dest: Path where the repository should be cloned
+    dest: Path where the repository should be placed
 
-**when**: It runs when *geth_stat_result.stat.exists* == False, i.e. when geth is not installed.
+**when**: It runs when *geth_stat_result.stat.exists* == False i.e. when either geth is not installed 
 
-#### 4. Make geth
-This task makes geth from the cloned repository and store the binary at build/bin
-
-**shell**: The task goes to the cloned repository.
-
-**when**: It runs when *geth_stat_result.stat.exists* == False, i.e. when geth is not installed.
-
-#### 5. Create bin directory
+#### 4. Create bin directory
 This task creates the bin directory if it does not exist.
 
 **file**: This module creates the bin directory if it does not exist.
 
 **when**: It runs when *geth_stat_result.stat.exists* == False, i.e. when geth is not installed.
 
-#### 6. Copy geth binary to destination directory
+#### 5. Copy geth binary to destination directory
 This task creates the bin directory if it does not exist.
 
 **copy**: This module copies the geth binary which is build in the above task and paste it in bin directory

--- a/platforms/quorum/configuration/roles/setup/geth/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/setup/geth/tasks/main.yaml
@@ -10,26 +10,19 @@
     path: "{{ bin_install_dir }}/geth"
   register: geth_stat_result
 
-  # This task checks if quorum repo directory exists
-- name: Check quorum repo dir exists
-  stat:
-    path: "{{ bin_install_dir }}/quorum"
-  register: quorum_stat_result
+# This task creates the geth directory
+- name: Create geth directory
+  file:
+    path: "{{ bin_install_dir }}/geth"
+    state: directory
+  when: geth_stat_result.stat.exists == False
 
-# This task clones the quorum git repository
-- name: Clone the git repo
-  git:
-    repo: "{{ geth.repo }}"
-    version: master
-    force: yes
-    dest: "{{ bin_install_dir }}/quorum"
-  when: not ( quorum_stat_result.stat.exists and geth_stat_result.stat.exists )
-
-# This task builds the geth binary
-- name: Make geth
-  make:
-    chdir: "{{ bin_install_dir }}/quorum"
-    target: geth
+# This task downloads the geth tar
+- name: Download geth tar 
+  get_url:
+    url: "https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.10.0-56dec25a.tar.gz"
+    dest: "{{ bin_install_dir }}/geth"
+    mode: 0777
   when: geth_stat_result.stat.exists == False
 
 # This task creates the bin directory, if it doesn't exist, for storing the geth binary
@@ -39,11 +32,11 @@
     state: directory
   when: geth_stat_result.stat.exists == False
 
-# This task puts the geth binary to above created bin directory
+# This task puts the geth binary to the bin directory created in the above task
 - name: Copy geth binary to destination directory
   copy:
-    src: "{{ bin_install_dir }}/quorum/build/bin/geth"
-    dest: "{{ bin_install_dir }}/geth"
-    mode: 0755
+    src: "{{ bin_install_dir }}/geth"
+    dest: "{{ bin_install_dir }}"
+    mode: 0777
     remote_src: yes
   when: geth_stat_result.stat.exists == False


### PR DESCRIPTION
Signed-off-by: nikhilayadav <nikhila.golla@accenture.com>

- Add  logic to remove download of whole quorum repo to build geth and bootnode

 

**Reviewed by**
@sownak @suvajit-sarkar @jagpreetsinghsasan 

 

**Linked issue**
#1836 
