### PR TITLE
[fabric] update flux to flux v2 setup

### DIFF
--- a/platforms/hyperledger-fabric/configuration/reset-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/reset-network.yaml
@@ -31,10 +31,7 @@
     # remove this if not needed
     - name: Uninstall flux
       shell: |
-        KUBECONFIG={{ kubernetes.config_file }} kubectl delete secret git-auth-{{ network.env.type }} -n flux-{{ network.env.type }}
-        KUBECONFIG={{ kubernetes.config_file }} helm uninstall flux-{{ network.env.type }} -n flux-{{ network.env.type }}
-        KUBECONFIG={{ kubernetes.config_file }} helm uninstall flux-{{ network.env.type }}-helm-operator -n flux-{{ network.env.type }}
-        KUBECONFIG={{ kubernetes.config_file }} kubectl delete namespace flux-{{ network.env.type }}
+        yes | KUBECONFIG={{ kubernetes.config_file }} flux uninstall --namespace=flux-{{ network.env.type }}
       vars:
         kubernetes: "{{ item.k8s }}"
       loop: "{{ network['organizations'] }}"
@@ -66,6 +63,7 @@
       vars:
         gitops: "{{ item.gitops }}"
         release_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name|lower }}"
+        flux_mainfest_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/flux-{{ network.env.type }}"
       loop: "{{ network['organizations'] }}"
 
     # delete orderer certs directory

--- a/platforms/hyperledger-fabric/configuration/roles/delete/gitops_files/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/gitops_files/tasks/main.yaml
@@ -15,6 +15,11 @@
     path: "{{ release_dir }}/"
     state: absent
 
+- name: Delete release files
+  file:
+    path: "{{ flux_mainfest_dir }}/"
+    state: absent
+
 #Git Push : Pushes the above generated files to git directory 
 - name: Git Push
   include_role: 

--- a/platforms/shared/configuration/kubernetes-env-setup.yaml
+++ b/platforms/shared/configuration/kubernetes-env-setup.yaml
@@ -29,7 +29,7 @@
       git_protocol: "{{ item.gitops.git_protocol | default('https') }}"
       git_url: "{{ item.gitops.git_url }}"
       git_key: "{{ item.gitops.private_key | default() }}"
-      helm_operator_version: "1.2.0"
+      flux_version: "0.30.2"
     with_items: "{{ network.organizations }}"
   - name: Prepare nodes and clients ports for ambassador
     vars:

--- a/platforms/shared/configuration/roles/git_push/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/git_push/tasks/main.yaml
@@ -19,6 +19,7 @@
     export GIT_SSH_COMMAND='ssh -i {{ gitops.private_key }}'
     git config user.email {{ gitops.email }}
     git config user.name {{ gitops.username }}
+    git --git-dir={{ GIT_DIR }}/.git pull
     git --git-dir={{ GIT_DIR }}/.git add -A .
     
     # To ignore a directory add it add reset path
@@ -44,6 +45,7 @@
     echo "---------------GIT PUSH---------------"
     git config user.email {{ gitops.email }}
     git config user.name {{ gitops.username }}
+    git --git-dir={{ GIT_DIR }}/.git pull
     git --git-dir={{ GIT_DIR }}/.git add -A .
     
     # To ignore a directory add it add reset path

--- a/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
@@ -5,83 +5,49 @@
 ##############################################################################################
 
 ---
-- name: Checking if the namespace flux-{{ network.env.type }} already exists
-  k8s_info:
-    kind: "Namespace"
-    name: "flux-{{ network.env.type }}"
-    kubeconfig: "{{ kubeconfig_path }}"
-    context: "{{ kubecontext }}"
-  register: result
+- name: Install flux cli
+  shell: |
+    curl -s https://fluxcd.io/install.sh | bash
+  environment:
+    FLUX_VERSION: "{{ flux_version }}"
 
-# This task creates the value file of Namespace for flux
-- name: Create namespaces  flux-{{ network.env.type }}
+- name: Update the ssh host to known hosts
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl create namespace flux-{{ network.env.type }} 
-  when: result.resources|length == 0
-  
-- name: Check if Flux is running
-  k8s_info:
-    kind: Pod
-    namespace: flux-{{ network.env.type }}
-    kubeconfig: "{{ kubeconfig_path }}"
-    context: "{{ kubecontext }}"
-    label_selectors:
-      - app = flux
-      - release = flux-{{ network.env.type }}
-    field_selectors:
-      - status.phase=Running
-  register: flux_service
-  tags:
-    - flux
-- name: Get ssh known hosts
-  shell: |
-    ssh-keyscan {{ git_host }} > flux_known_hosts
-    chmod -R 777 flux_known_hosts
-  when: flux_service.resources|length == 0 and git_protocol == "ssh"
+    mkdir -p ~/.ssh/
+    ssh-keygen -R {{ git_host }}
+    ssh-keyscan {{ git_host }} >> ~/.ssh/known_hosts
+  when: git_protocol == "ssh"
   tags:
     - molecule-idempotence-notest
 
-- name: Helm repo add
+- name: Install flux cli and bootstrap flux v2
   shell: |
-    helm repo add fluxcd https://charts.fluxcd.io
-  when: flux_service.resources|length == 0
+    flux bootstrap git \
+    --url={{ git_url }} \
+    --branch={{ git_branch }} \
+    --username={{ git_username }} \
+    --password={{ git_password }} \
+    --token-auth=true \
+    --path={{ git_path }} \
+    --namespace=flux-{{ network.env.type }}
+  when: git_protocol == "https"
+  environment:
+    KUBECONFIG: "{{ item.k8s.config_file }}"
   tags:
     - flux
     - molecule-idempotence-notest
 
-- name: Install flux for over https connection
+- name: Install flux cli and bootstrap flux v2
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl create secret generic git-auth-{{ network.env.type }} --from-literal=GIT_AUTHUSER={{ git_username }}  --from-literal=GIT_AUTHKEY={{ git_password }} --namespace flux-{{ network.env.type }}
-    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/{{ helm_operator_version }}/deploy/crds.yaml --context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }} {{ playbook_dir }}/../../../platforms/shared/charts/flux --namespace flux-{{ network.env.type }} --set git.secretName=git-auth-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='https://{{ git_username }}:{{ git_password }}@{{ git_repo }}' --set git.branch={{ git_branch }} --set git.label='sync-{{ network.env.type }}' --set git.path="{{ git_path }}"  --set registry.insecureHosts="{{ network.docker.url }}" --kube-context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }}-helm-operator fluxcd/helm-operator --namespace flux-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='https://{{ git_username }}:{{ git_password }}@{{ git_repo }}' --set git.ssh.secretName=git-auth-{{ network.env.type }} --set helm.versions=v3 --kube-context="{{ kubecontext }}"
-  when: flux_service.resources|length == 0 and git_protocol == "https" 
+    yes | flux bootstrap git \
+    --url={{ git_url }} \
+    --branch={{ git_branch }} \
+    --path={{ git_path }} \
+    --private-key-file={{ git_key }} \
+    --namespace=flux-{{ network.env.type }}
+  when: git_protocol == "ssh"
+  environment:
+    KUBECONFIG: "{{ item.k8s.config_file }}"
   tags:
     - flux
     - molecule-idempotence-notest
-
-- name: Install flux for over ssh connection
-  shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl create secret generic git-auth-{{ network.env.type }} --from-file=identity={{ git_key }} --namespace flux-{{ network.env.type }}
-    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/{{ helm_operator_version }}/deploy/crds.yaml --context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }} {{ playbook_dir }}/../../../platforms/shared/charts/flux --namespace flux-{{ network.env.type }} --set git.secretName=git-auth-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='{{ git_url }}' --set git.branch={{ git_branch }} --set git.label='sync-{{ network.env.type }}' --set git.path="{{ git_path }}" --set-file ssh.known_hosts=flux_known_hosts --set registry.insecureHosts="{{ network.docker.url }}" --kube-context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }}-helm-operator fluxcd/helm-operator --namespace flux-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='{{ git_url }}' --set git.ssh.secretName=git-auth-{{ network.env.type }} --set-file git.ssh.known_hosts=flux_known_hosts --set helm.versions=v3 --kube-context="{{ kubecontext }}"
-  when: flux_service.resources|length == 0 and git_protocol == "ssh" 
-  tags:
-    - flux
-    - molecule-idempotence-notest
-
-# Wait for flux pod to start running
-- name: wait for pods to come up
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/helm_component"
-  vars:
-    namespace: flux-{{ network.env.type }}
-    kubeconfig: "{{ kubeconfig_path }}"
-    context: "{{ kubecontext }}"
-    component_name: flux
-    component_type: "Pod"
-    label_selectors:
-      - app = flux
-      - release = flux-{{ network.env.type }}
-  when: flux_service.resources|length == 0


### PR DESCRIPTION
Signed-off-by: suvajit-sarkar <suvajit.sarkar@accenture.com>

**Changelog**
- Update the setup flux role to setup flux-v2
  - Installs flux cli
  - In case the git protocol is ssh, it updates the git host
  - Bootstraps the flux (this creates the flux namespace as well)
- Update reset network of fabric to uninstall flux
  - Added task to delete the flux manifest on reset of network
 

- **The installations are idempotent in itself so don't require checks before installation**

 

**Reviewed by**
@sownak 

 

**Linked issue**
#1898
