### PR TITLE
[fabric] Multiple operations fix after ansible decoupling changes

### DIFF
--- a/platforms/hyperledger-fabric/configuration/add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-orderer.yaml
@@ -33,21 +33,21 @@
       orderers: "{{ item.services.orderers }}"
     loop: "{{ network['organizations'] }}"
     when: item.type == 'orderer'
-    
-  # Create Orderer crypto materials
-  - name: "Generate crypto for new orderer"
+  
+  # Create CA Tools helm-value files and check-in
+  - name: Create CA tools for each organization
     include_role:
-      name: "create/crypto/orderer"
+      name: "create/ca-tools/orderer"
     vars:
       component_name: "{{ item.name | lower}}-net"
+      component: "{{ item.name | lower}}"
       component_type: "{{ item.type | lower}}"
-      org_name: "{{ item.name }}"
-      services: "{{ item.services }}"
-      subject: "{{ item.subject }}"
-      ca_url: "{{ item.ca_data.url }}"
-      cert_subject: "{{ item.subject | regex_replace('/', ';') | regex_replace(',', '/') | regex_replace(';', ',') }}" # replace , to / and / to , for certpath
+      component_services: "{{ item.services }}"
       kubernetes: "{{ item.k8s }}"
       vault: "{{ item.vault }}"
+      ca: "{{ item.services.ca }}"
+      gitops: "{{ item.gitops }}"
+      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
     loop: "{{ network['organizations'] }}"
     when: item.type == 'orderer'
 

--- a/platforms/hyperledger-fabric/configuration/add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-peer.yaml
@@ -56,10 +56,18 @@
       release_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
     loop: "{{ network['organizations'] }}"
 
+  # Create generate_crypto script for new organization
+  - include_role:
+      name: "create/add_new_peer/crypto_script"
+    vars:
+      component_type: "{{ item.type | lower}}"
+      orderers: "{{ item.services.orderers }}"
+    loop: "{{ network['organizations'] }}"
+
   # Create CA Tools helm-value files and check-in
   - name: Create CA tools for each organization
     include_role:
-      name: "create/ca-tools"
+      name: "create/ca-tools/peer"
     vars:
       component_name: "{{ item.name | lower}}-net"
       component: "{{ item.name | lower}}"
@@ -71,29 +79,7 @@
       gitops: "{{ item.gitops }}"
       values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
     loop: "{{ network['organizations'] }}"
-  # Create generate_crypto script for new organization
-  - include_role:
-      name: "create/add_new_peer/crypto_script"
-    vars:
-      component_type: "{{ item.type | lower}}"
-      orderers: "{{ item.services.orderers }}"
-    loop: "{{ network['organizations'] }}"
-
-  # Create Organization crypto materials for new organization
-  - include_role:
-      name: "create/crypto/peer"
-    vars:
-      component_name: "{{ item.name | lower}}-net"
-      component_type: "{{ item.type | lower}}"
-      org_name: "{{ item.name }}"
-      services: "{{ item.services }}"
-      subject: "{{ item.subject }}"
-      ca_url: "{{ item.ca_data.url }}"
-      cert_subject: "{{ item.subject | regex_replace('/', ';') | regex_replace(',', '/') | regex_replace(';', ',') }}" # replace , to / and / to , for certpath
-      kubernetes: "{{ item.k8s }}"
-      vault: "{{ item.vault }}"
-    loop: "{{ network['organizations'] }}"
-    when: item.type == 'peer'    
+    when: item.type == 'peer'
 
   # This role fetches block 0 and joins peers of new organizaion to the channel
   - include_role:

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml
@@ -119,7 +119,8 @@
 # to the Ansible container
 - name: Copy the msp folder from the ca tools
   shell: |
-    export CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    export CA_TOOL_CLI
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ component_name }}/${CA_TOOL_CLI}:crypto-config/{{ component_type }}Organizations/{{ component_name }}/msp ./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/msp
 
 ############################################################################################
@@ -127,7 +128,8 @@
 # to the build directory
 - name: Copy the tls server.crt file from the ca tools
   shell: |
-    export CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    export CA_TOOL_CLI
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ component_name }}/${CA_TOOL_CLI}:crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{ orderer.name }}.{{ component_name }}/tls/server.crt ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{ orderer.name }}.{{ component_name }}/tls/server.crt
   loop: "{{ network.orderers }}"
   loop_control:
@@ -138,7 +140,8 @@
 # to the address specified in network.yaml
 - name: Copy the tls ca.crt file from the ca tools
   shell: |
-    export CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    export CA_TOOL_CLI
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ component_name }}/${CA_TOOL_CLI}:crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{ orderer.name }}.{{ component_name }}/tls/ca.crt  {{ orderer.certificate }}
   loop: "{{ network.orderers }}"
   loop_control:

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/peer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/peer/tasks/main.yaml
@@ -186,7 +186,8 @@
 # to the build directory
 - name: Copy the msp folder from the ca tools
   shell: |
-    export CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    CA_TOOL_CLI=$(KUBECONFIG={{ kubernetes.config_file }}  kubectl get po -n {{ component_name }} | grep "ca-tools" | awk '{print $1}')
+    export CA_TOOL_CLI
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ component_name }}/${CA_TOOL_CLI}:crypto-config/{{ component_type }}Organizations/{{ component_name }}/msp ./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/msp
 
 ############################################################################################

--- a/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/main.yaml
@@ -62,7 +62,7 @@
     loop_var: participant
   when:
     - participant.type != 'creator'
-    - participant.org_status == 'existing'
+    - participant.org_status != 'new' # existing and delete orgs are signing
     - remove_org is defined
     - remove_org == "True"
 


### PR DESCRIPTION
**Changelog**
- **Add peer to org:** 
    - `platforms/hyperledger-fabric/configuration/add-peer.yaml`: "create/crypto/peer" role was no more available & replaced
    - `platforms/hyperledger-fabric/charts/catools/templates/configmap.yaml`: store-vault-peer.sh logic fix: If peer status is not "new" or "", then move on to next peer.
    - `platforms/hyperledger-fabric/configuration/roles/create/ca-tools/peer/tasks/main.yaml`:  The export syntax: 
    `export VARIABLE=$VALUE` does not seem to work in the sh used in bevel. Instead two line approach works `VARIABLE=$VALUE; export VARIABLE`. Ref: [Link](https://stackoverflow.com/questions/7328223/unix-export-command)
    
- **Add raft orderer to org:**
    - `platforms/hyperledger-fabric/configuration/add-orderer.yaml`: "create/crypto/orderer" role was no more available & replaced
    - `platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml`: Export syntax change
    
- **Removing org:**
    - `platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/main.yaml`: Changed condition to also involve the org being deleted to sign the config update block. 
    In a 3 org setup `{supplychain (orderer), carrier, manufacturer}`, removing one of the peer orgs lead to error indicating channel update policy not being met. Making the above change fixes this.

