### PR TITLE
[fabric] Fix Install chaincode doesn't fail when invalid git details are provided

### DIFF
--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -169,7 +169,13 @@ spec:
           apk add curl openssh
           ssh-keyscan {{ $.Values.chaincode.repository.hostname }} > /root/.ssh/known_hosts
           git_password=$(cat /opt/gopath/src/github.com/hyperledger/fabric/crypto/user_cred)
-          cd /tmp && git clone https://{{ $.Values.chaincode.repository.git_username }}:$git_password@{{ $.Values.chaincode.repository.url }} -b {{ $.Values.chaincode.repository.branch }} chaincode
+          cd /tmp && git clone https://{{ $.Values.chaincode.repository.git_username }}:$git_password@{{ $.Values.chaincode.repository.url }} -b {{ $.Values.chaincode.repository.branch }} chaincode > git.log 2>&1
+          ## Check if the repository was cloned correctly
+          if [[ ! $? -eq 0 ]];
+          then
+            cat git.log
+            exit 1
+          fi
           ls
           echo $GOPATH
           if [ ${CC_RUNTIME_LANGUAGE} = "golang" ]


### PR DESCRIPTION
**Changelog**

- Fix install chaincode doesn't fail when invalid git details are provided


 

**Reviewed by**
@suvajit-sarkar
@jagpreetsinghsasan 

 

**Linked issue**
#1952 
