### PR TITLE
[shared] Molecule: Remove flux  v2 installation test

### DIFF
--- a/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
@@ -54,23 +54,6 @@
         src: "{{ playbook_dir }}/../../../../shared/configuration/roles"
         dest: "{{ playbook_dir }}/../../shared/configuration"
   roles:
-    - role: setup/flux
-      vars:
-        item:
-          cloud_provider: "aws"
-          k8s:
-            config_file: "/tmp/molecule/kind-default/kubeconfig"
-            context: "kind"
-        git_url: "https://github.com/hyperledger/bevel.git"
-        git_key: "test_rsa.pem"
-        git_username: "hyperledger-labs"
-        git_password: "to-be-configured"
-        git_repo: "github.com/hyperledger/bevel.git"
-        git_branch: "develop"
-        git_path: "platforms/r3-corda/releases/test"
-        git_host: "github.com"
-        git_protocol: "https"
-        flux_version: "0.30.2"
     - role: setup/ambassador
       vars:
         item:

--- a/platforms/shared/configuration/molecule/kubernetes-corda/verify.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/verify.yml
@@ -16,22 +16,6 @@
       env:
         type: test
   tasks:
-  # Assert Flux is installed on Kubernetes
-  - name: Check Flux on Kubernetes clusters
-    k8s_info:
-      kind: Pod
-      namespace: flux-{{ network.env.type }}
-      kubeconfig: "{{ kubeconfig_path }}"
-      context: "{{ kubecontext }}"
-      label_selectors:
-        - app = flux
-        - release = flux-{{ network.env.type }}
-      field_selectors:
-        - status.phase=Running
-    register: flux_service
-  - name: Assert Flux has been installed
-    assert:
-      that: flux_service.resources|length == 1
   # Assert Ambassador is installed on Kubernetes
   - name: Check Ambassador on Kubernetes clusters
     k8s_info:

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
@@ -50,23 +50,6 @@
         src: "{{ playbook_dir }}/../../../../shared/configuration/roles"
         dest: "{{ playbook_dir }}/../../shared/configuration"
   roles:
-    - role: setup/flux
-      vars:
-        item:
-          cloud_provider: "aws"
-          k8s:
-            config_file: "/tmp/molecule/kind-default/kubeconfig"
-            context: "kind"
-        git_url: "https://github.com/hyperledger/bevel.git"
-        git_key: "test_rsa.pem"
-        git_username: "hyperledger-labs"
-        git_password: "to-be-configured"
-        git_repo: "github.com/hyperledger/bevel.git"
-        git_branch: "develop"
-        git_path: "platforms/r3-corda/releases/test"
-        git_host: "github.com"
-        git_protocol: "https"
-        flux_version: "0.30.2"
     - role: setup/haproxy-ingress
       vars:
         item:

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/verify.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/verify.yml
@@ -16,22 +16,6 @@
       env:
         type: test
   tasks:
-  # Assert Flux is installed on Kubernetes
-  - name: Check Flux on Kubernetes clusters
-    k8s_info:
-      kind: Pod
-      namespace: flux-{{ network.env.type }}
-      kubeconfig: "{{ kubeconfig_path }}"
-      context: "{{ kubecontext }}"
-      label_selectors:
-        - app = flux
-        - release = flux-{{ network.env.type }}
-      field_selectors:
-        - status.phase=Running
-    register: flux_service
-  - name: Assert Flux has been installed
-    assert:
-      that: flux_service.resources|length == 1
   - name: Check Haproxy on Kubernetes clusters
     k8s_info:
       kind: Pod

--- a/platforms/shared/configuration/molecule/kubernetes-indy/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-indy/converge.yml
@@ -73,23 +73,6 @@
         src: "{{ playbook_dir }}/../../../../shared/configuration/roles"
         dest: "{{ playbook_dir }}/../../shared/configuration"
   roles:
-    - role: setup/flux
-      vars:
-        item:
-          cloud_provider: "aws"
-          k8s:
-            config_file: "/tmp/molecule/kind-default/kubeconfig"
-            context: "kind"
-        git_url: "https://github.com/hyperledger/bevel.git"
-        git_key: "test_rsa.pem"
-        git_username: "hyperledger-labs"
-        git_password: "to-be-configured"
-        git_repo: "github.com/hyperledger/bevel.git"
-        git_branch: "develop"
-        git_path: "platforms/r3-corda/releases/test"
-        git_host: "github.com"
-        git_protocol: "https"
-        flux_version: "0.30.2"
     - role: setup/ambassador
       vars:
         item:

--- a/platforms/shared/configuration/molecule/kubernetes-indy/verify.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-indy/verify.yml
@@ -16,22 +16,6 @@
       env:
         type: test
   tasks:
-  # Assert Flux is installed on Kubernetes
-  - name: Check Flux on Kubernetes clusters
-    k8s_info:
-      kind: Pod
-      namespace: flux-{{ network.env.type }}
-      kubeconfig: "{{ kubeconfig_path }}"
-      context: "{{ kubecontext }}"
-      label_selectors:
-        - app = flux
-        - release = flux-{{ network.env.type }}
-      field_selectors:
-        - status.phase=Running
-    register: flux_service
-  - name: Assert Flux has been installed
-    assert:
-      that: flux_service.resources|length == 1
   # Assert Ambassador is installed on Kubernetes
   - name: Check Ambassador on Kubernetes clusters
     k8s_info:


### PR DESCRIPTION
Signed-off-by: suvajit-sarkar <suvajit.sarkar@accenture.com>

**Changelog**
- Flux v2 installation requires valid repo and user creds, removing the flux installation test as the flux v2 installation is idempotent by default and difficult to do test