### PR TITLE
mixed-org fixes base code

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrderer_default.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrderer_default.tpl
@@ -53,6 +53,6 @@ Orderer: &OrdererDefaults
       Rule: "MAJORITY Admins"
     BlockValidation:
       Type: ImplicitMeta
-      Rule: "ANY Orderers"
+      Rule: "ANY Writers"
   Capabilities:
     <<: *OrdererCapabilities

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-mixed.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-mixed.tpl
@@ -15,11 +15,7 @@ spec:
         kind: GitRepository
         name: flux-{{ network.env.type }}
         namespace: flux-{{ network.env.type }}
-      chart: {{ charts_dir }}/ca
-{% if git_protocol == 'https' %}
-    secretRef:
-      name: gitcredentials
-{% endif %}    
+      chart: {{ charts_dir }}/ca  
   values:
 {% if network.env.annotations is defined %}
     deployment:


### PR DESCRIPTION
Signed-off-by: mgCepeda <marina.gomez.cepeda@accenture.com>

**Changelog**
- Fix platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-mixed.tpl. The secretRef field has been removed, because it causes the error shown in the following image.
<img width="678" alt="https-error in ca" src="https://user-images.githubusercontent.com/83813093/185910473-413b8121-671a-4b23-9917-b57826105261.png">

- Update platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrderer_default.tpl. The value of the BlockValidation field has been modified because it produced an error in the approvechaincode job.
 


 

**Reviewed by**
@suvajit-sarkar @jagpreetsinghsasan 

 