### PR TITLE
[fabric] Fix add-new-organization playbook

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml
@@ -86,6 +86,7 @@
   loop: "{{ item.services.orderers }}"
   loop_control:
     loop_var: orderer
+  when: item.services.orderers is defined and item.services.orderers | length > 0
 
 # This task wait for ambassador key exists in vault.
 - name: Wait for ambassador key exists in vault.
@@ -98,7 +99,9 @@
   loop: "{{ item.services.orderers }}"
   loop_control:
     loop_var: orderer
-  when: network.env.proxy == 'ambassador'
+  when: 
+    - network.env.proxy == 'ambassador'
+    - item.services.orderers is defined and item.services.orderers | length > 0
 
 #####################################################################################################################
 # This task creates the Ambassador TLS credentials for orderers
@@ -113,7 +116,9 @@
   loop: "{{ item.services.orderers }}"
   loop_control:
     loop_var: orderer
-  when: network.env.proxy == 'ambassador'
+  when: 
+    - network.env.proxy == 'ambassador'
+    - item.services.orderers is defined and item.services.orderers | length > 0
 
 ############################################################################################
 # This task copies the msp admincerts from vault
@@ -187,7 +192,8 @@
     VAULT_TOKEN: "{{ vault.root_token }}"
   loop: "{{ item.services.orderers }}"
   loop_control:
-    loop_var: orderer  
+    loop_var: orderer
+  when: item.services.orderers is defined and item.services.orderers | length > 0  
 
 ###########################################################################################
 # This task Create the certs directory if it does not exist

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/nested_create_cli.yaml
@@ -30,15 +30,28 @@
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
     orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
 
-
 # Start the cli using the value file created in the previous step
 - name: "start cli"
   shell: |
     KUBECONFIG={{ org.k8s.config_file }} helm upgrade --install -f ./build/{{ org.name }}/orderer_cli_job.yaml {{ orderer.name }}-{{ org.name }}-cli {{playbook_dir}}/../../../{{org.gitops.chart_source}}/fabric_cli
 
+############################################################################################
+# This task gets cli pod 
+- name: Gets the cli pod 
+  shell: |
+    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
+    echo $PEER_CLI
+  register: get_pod
+
+# This task gets the name of the cli pod 
+- name: Gets the name of the cli pod
+  set_fact:
+    pod_name={{ get_pod.stdout_lines | first }}
+
 # waiting for fabric cli
 - name: "Check if fabric cli is present"
   k8s_info:
+    name: "{{ pod_name }}"
     kind: Pod
     namespace: "{{ org.name }}-net"
     kubeconfig: "{{ org.k8s.config_file }}"


### PR DESCRIPTION
Signed-off-by: mgCepeda <marina.gomez.cepeda@accenture.com>

**Changelog**
- Add some conditions in  platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml to avoid error when executing the playbook to add an organization with only peers in its configuration
- Add tasks to get the correct desired cli pod name in platforms/hyperledger-fabric/configuration/roles/create/ca-tools/orderer/tasks/main.yaml

**Reviewed by**
@suvajit-sarkar @jagpreetsinghsasan 

 
