### PR TITLE
[fabric] Fix multiple orderers - MixedOrganization

### DIFF
--- a/platforms/hyperledger-fabric/charts/catools/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/templates/configmap.yaml
@@ -1225,8 +1225,7 @@ data:
                 }  
             }" > payload.json
           else
-            COUNTER=`expr "$COUNTER" + 1`
-            continue
+            break
           fi;
 
           # This command writes organization level certificates for orderers to vault

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-tools/tasks/main.yaml
@@ -90,6 +90,28 @@
     - peer.peerstatus is defined and peer.peerstatus == 'new'
     - add_peer is defined and add_peer == 'true'
 
+- set_fact:
+    new_orderer_list: []
+
+# This task loops over the peers and finds the number of new peers
+- name: Get orderers from the organization provided in the network.yaml
+  set_fact:
+    new_orderer_list={{ new_orderer_list + [orderer] }}
+  loop: "{{ network.orderers }}"
+  loop_control:
+    loop_var: orderer
+  when:
+    - item.priority == 'standard'
+    - item.orderer_org is defined
+    - item.orderer_org | lower == orderer.org_name | lower
+
+- name: Get orderers from the organization provided in the network.yaml
+  set_fact:
+    new_orderer_list={{ network.orderers }}
+  when:
+    - item.priority == 'high'
+    - item.orderer_org is not defined
+
 # This task delete the previously created ca-tools release file
 - name: Delete release file CA-Tools
   file:
@@ -153,7 +175,7 @@
     charts_dir: "{{ gitops.chart_source }}"
     orderers_list: "{{ item.services.orderers | default('') }}"
     peers_list: "{{ item.services.peers | default('') }}"
-    orderers_network_list: "{{ network.orderers }}"
+    orderers_network_list: "{{ new_orderer_list }}"
     peer_count: "{{ item.services.peers | default('') | length }}"
     new_peer_count: "{{ new_peer_list | length }}"
     add_peer_value: "{{ add_peer | default(false) | quote }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/configtx/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/configtx/tasks/main.yaml
@@ -93,13 +93,10 @@
     block: "{{ lookup('template', filename) }}"
     marker: "#"
   vars:
-    orderers: "{{ item.services.orderers }}"
-    consensus: "{{ item.services.consensus }}"
-    component_ns: "{{ item.name | lower }}-net"
+    orderers: "{{ network.orderers }}"
+    consensus: "{{ network.consensus }}"
     provider: "{{ network.env.proxy }}"
     filename: configtxOrderer_{{ 'custom' if network.configtx is defined and network.configtx.custom == true and cford.stat.exists else 'default' }}.tpl
-  loop: "{{ network['organizations'] }}"
-  when: item.services.orderers is defined and item.services.orderers | length > 0
   tags:
     - molecule-idempotence-notest
 
@@ -115,13 +112,11 @@
     block: "{{ lookup('template', filename) }}"
     marker: "#"
   vars:
-    orderers: "{{ item.services.orderers }}"
-    consensus: "{{ item.services.consensus }}"
-    component_ns: "{{ item.name | lower }}-net"
+    orderers: "{{ network.orderers }}"
+    consensus: "{{ network.consensus }}"
     provider: "{{ network.env.proxy }}"
     filename: configtxProfile_{{ 'custom' if network.configtx is defined and network.configtx.custom == true and cfprofile.stat.exists else 'default' }}.tpl
-  loop: "{{ network['organizations'] }}"
-  when: network.channels is defined and item.services.orderers is defined and item.services.orderers | length > 0
+  when: network.channels is defined
   tags:
     - molecule-idempotence-notest
 

--- a/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrderer_default.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrderer_default.tpl
@@ -7,9 +7,9 @@ Orderer: &OrdererDefaults
   Addresses:
 {% for orderer in orderers %}
 {% if provider == 'none' %}
-    - {{orderer.name}}.{{ component_ns }}:7050
+    - {{ orderer.name }}.{{ orderer.org_name | lower }}-net:7050
 {% else %}
-    - {{orderer.name}}.{{ item.external_url_suffix }}:8443
+    - {{ orderer.uri }}
 {% endif %}
 {% endfor %}
 
@@ -21,19 +21,25 @@ Orderer: &OrdererDefaults
 {% if consensus.name == 'kafka' %}
   Kafka:
     Brokers:
+{% for org in network.organizations %}
+{% if org.services.orderers is defined and org.services.orderers|length > 0 %}
 {% for i in range(consensus.replicas) %}
-      - {{ consensus.name }}-{{ i }}.{{ consensus.type }}.{{ component_ns }}.svc.cluster.local:{{ consensus.grpc.port }}
+      - {{ consensus.name }}-{{ i }}.{{ consensus.type }}.{{ org.name |lower }}-net.svc.cluster.local:{{ consensus.grpc.port }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if consensus.name == 'raft' %}
   EtcdRaft:
     Consenters:
 {% for orderer in orderers %}
+{% set component_ns = orderer.org_name.lower() + '-net' %}
 {% if provider == 'none' %}
       - Host: {{orderer.name}}.{{ component_ns }}
         Port: 7050
 {% else %}
-      - Host: {{ orderer.name }}.{{ item.external_url_suffix }}
+{% set path = orderer.uri.split(':') %}
+      - Host: {{ path[0] }}
         Port: 8443
 {% endif %}
         ClientTLSCert: ./crypto-config/{{ component_ns }}/orderers/{{ orderer.name }}.{{ component_ns }}/tls/server.crt

--- a/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxProfile_default.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxProfile_default.tpl
@@ -9,11 +9,13 @@ Profiles:
       EtcdRaft:
         Consenters:
 {% for orderer in orderers %}
+{% set component_ns = orderer.org_name.lower() + '-net' %}
 {% if provider == 'none' %}
         - Host: {{orderer.name}}.{{ component_ns }}
           Port: 7050
 {% else %}
-        - Host: {{ orderer.name }}.{{ item.external_url_suffix }}
+{% set path = orderer.uri.split(':') %}
+        - Host: {{ path[0] }}
           Port: 8443
 {% endif %}
           ClientTLSCert: ./crypto-config/{{ component_ns }}/orderers/{{ orderer.name }}.{{ component_ns }}/tls/server.crt
@@ -21,7 +23,9 @@ Profiles:
 {% endfor %}
 {% endif %}
       Organizations:
-        - *{{ channel.orderer.name }}Org
+{% for orderer in channel.orderers %}
+        - *{{ orderer }}Org
+{% endfor %}
     Consortiums:
       {{channel.consortium}}:
         Organizations:

--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -18,6 +18,7 @@
                 "version":{ "type": "string","enum":["1.4.8","2.2.0","2.2.2"]},
                 "env": { "$ref":"#/definitions/shared_environment"},
                 "frontend": { "type": "string", "enum": ["enabled","disabled"]},
+                "consensus":{ "$ref":"#/definitions/fabric_service_consensus"},
                 "orderers": { "type":"array","items":{ "$ref":"#/definitions/fabric_orderer"}},
                 "channels": { "type":"array","items":{ "$ref":"#/definitions/fabric_channel"}},
                 "organizations": { "type":"array","minItems": 1,"items":{"$ref":"#/definitions/fabric_organization"}}
@@ -435,14 +436,11 @@
                 "name": { "type": "string","pattern": "^[A-Za-z0-9-]{1,30}$","description": "Name of the genesis block"}},
               "required": [ "name"], "additionalProperties": false
             },
-            "orderer": { "type": "object", "properties": {
-                "name": { "type": "string","pattern": "^[a-z0-9-]{1,30}$","description": "Organization name to which the orderer belongs"}},
-              "required": [ "name"], "additionalProperties": false
-           },
+           "orderers": { "type":"array", "items":{ "type": "string","pattern": "^[a-z0-9-]{1,30}$","description": "Organization name to which the orderer belongs"}},
            "endorsers": { "type":"array","items":{ "$ref":"#/definitions/fabric_channel_endorsers"}},
            "participants": { "type":"array","items":{ "$ref":"#/definitions/fabric_channel_participant"}}
           },
-          "required": [ "channel","consortium","channel_name","genesis","orderer","participants"],
+          "required": [ "channel","consortium","channel_name","genesis","orderers","participants"],
           "additionalProperties": false
         },
         "fabric_channel_participant":{
@@ -491,7 +489,12 @@
             "location": { "type": "string","description":"Location of the organization"},
             "subject":  { "type": "string","description":"Subject format can be referred at OpenSSL Subject"},
             "external_url_suffix":  { "type": "string","description":"Public url suffix of the cluster. This is the configured path for the Ambassador Service on the DNS provider."},
+            "priority": { "type": "string","enum": ["standard","high"]},
             "org_status": { "type": "string","enum": ["new","existing","delete"]},
+            "if": {"properties": { "type": { "const": "peer" } } },"then":{
+              "properties": {
+                "orderer_org": { "type": "string","pattern": "^[a-z0-9-]{1,30}$","description": "Name of the organization providing the ordering service"}
+            }},
             "ca_data": {  "type":"object", "description":"Contains the certificate authority url and certificate path; this has not been implemented yet","properties": {
                "url": { "type": "string","pattern": "^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?::[0-9]{2,5})?$","description":"Gossip address of the peer"},
                "certificate": { "type": "string","pattern":"^\/?([^\/ ]*\/)+[^\/ ]+\\.crt$","description":"Path to certificate"}},


### PR DESCRIPTION
Signed-off-by: mgCepeda <marina.gomez.cepeda@accenture.com>

**Changelog**
- Add the following fields in the network.yaml:
*network.consensus
*network.channels[*].orderer.name (is a list)
*network.organizations[*].orderer_org (This field should only be added in peer organizations. Indicate from which
organization takes the orderers)

- Update create/configtx and create/ca-tools roles to perform deployments with multiple orderer organizations
- Update Network-schema.json

- Fix bug in ca-tools chart that causes an infinite loop in the case of having two organizations with orderer

 

**Reviewed by**
@suvajit-sarkar @jagpreetsinghsasan @sownak 

 

**Linked issue**
#2038 
