### PR TITLE
[shared] fixed flux uninstall in reset-network.yaml

### DIFF
--- a/platforms/hyperledger-besu/configuration/reset-network.yaml
+++ b/platforms/hyperledger-besu/configuration/reset-network.yaml
@@ -28,7 +28,73 @@
 
     # Uninstalling Flux is needed so that everything is clean
     # remove this if not needed
-    - name: Uninstall flux
+    ##Delete the Flux deployments
+    - name: Delete flux deployments
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Deployment
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        force: yes
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+    
+    ##Delete services related to flux
+    - name: Delete flux services
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Service
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["webhook-receiver","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Delete Network Policies related to flux  
+    - name: Delete flux Network Policies
+      k8s:
+        state: absent
+        api_version: v1
+        kind: NetworkPolicy
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["allow-egress","allow-scraping","allow-webhooks"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Delete serviceAccounts related to flux  
+    - name: Delete flux ServiceAccount
+      k8s:
+        state: absent
+        api_version: v1
+        kind: ServiceAccount
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Delete Flux namespace 
+    - name: delete flux namespace
       k8s:
         name: flux-{{ network.env.type }}
         api_version: v1
@@ -39,6 +105,7 @@
         kubernetes: "{{ item.k8s }}"
       loop: "{{ network['organizations'] }}"
       ignore_errors: yes
+
 
     # Delete Helmreleases
     # Change this rile if you have new Helreleases to delete

--- a/platforms/hyperledger-fabric/configuration/reset-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/reset-network.yaml
@@ -29,7 +29,73 @@
 
     # Uninstalling Flux is needed so that everything is clean
     # remove this if not needed
-    - name: Uninstall flux
+    ##Deletes Deployments related to flux
+    - name: Delete flux deployments
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Deployment
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        force: yes
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes services related to flux  
+    - name: Delete flux services
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Service
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["webhook-receiver","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Delete Network Policies related to flux
+    - name: Delete flux Network Policies
+      k8s:
+        state: absent
+        api_version: v1
+        kind: NetworkPolicy
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["allow-egress","allow-scraping","allow-webhooks"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes serviceAccount related to flux
+    - name: Delete flux ServiceAccount
+      k8s:
+        state: absent
+        api_version: v1
+        kind: ServiceAccount
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes flux namespace 
+    - name: delete flux namespace
       k8s:
         name: flux-{{ network.env.type }}
         api_version: v1

--- a/platforms/hyperledger-indy/configuration/cleanup.yaml
+++ b/platforms/hyperledger-indy/configuration/cleanup.yaml
@@ -31,7 +31,73 @@
       loop_var: organizationItem
   # Uninstalling Flux is needed so that everything is clean
   # remove this if not needed
-  - name: Uninstall flux
+  ##Deletes Deployments related to flux
+  - name: Delete flux deployments
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Deployment
+      namespace: flux-{{ network.env.type }}
+      name: "{{ item[0] }}"
+      force: yes
+      kubeconfig: "{{ kubernetes.config_file }}"
+    vars:
+      kubernetes: "{{ item[1].k8s }}"
+    with_nested:
+      - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+      - "{{ network['organizations'] }}"
+    ignore_errors: yes
+
+  ##Deletes Services related to flux
+  - name: Delete flux services
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Service
+      namespace: flux-{{ network.env.type }}
+      name: "{{ item[0] }}"
+      kubeconfig: "{{ kubernetes.config_file }}"
+    vars:
+      kubernetes: "{{ item[1].k8s }}"
+    with_nested:
+      - ["webhook-receiver","notification-controller","source-controller"]
+      - "{{ network['organizations'] }}"
+    ignore_errors: yes
+
+  ##Deletes Network Policies related to flux
+  - name: Delete flux Network Policies
+    k8s:
+      state: absent
+      api_version: v1
+      kind: NetworkPolicy
+      namespace: flux-{{ network.env.type }}
+      name: "{{ item[0] }}"
+      kubeconfig: "{{ kubernetes.config_file }}"
+    vars:
+      kubernetes: "{{ item[1].k8s }}"
+    with_nested:
+      - ["allow-egress","allow-scraping","allow-webhooks"]
+      - "{{ network['organizations'] }}"
+    ignore_errors: yes
+
+  ##Deletes ServiceAccount related to flux
+  - name: Delete flux ServiceAccount
+    k8s:
+      state: absent
+      api_version: v1
+      kind: ServiceAccount
+      namespace: flux-{{ network.env.type }}
+      name: "{{ item[0] }}"
+      kubeconfig: "{{ kubernetes.config_file }}"
+    vars:
+      kubernetes: "{{ item[1].k8s }}"
+    with_nested:
+      - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+      - "{{ network['organizations'] }}"
+    ignore_errors: yes
+
+  ##Deletes flux namespace
+  - name: delete flux namespace
     k8s:
       name: flux-{{ network.env.type }}
       api_version: v1
@@ -39,12 +105,10 @@
       state: absent
       kubeconfig: "{{ kubernetes.config_file }}"
     vars:
-      kubernetes: "{{ organizationItem.k8s }}"
-      bin_install_dir: "~/bin" # Default to /bin install directory for binaries
+      kubernetes: "{{ item.k8s }}"
     loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: organizationItem
     ignore_errors: yes
+
 
   # Delete the Flux Helm release from all organizations's K8S clusters (including the Git secret)
   - name: Delete Flux

--- a/platforms/quorum/configuration/reset-network.yaml
+++ b/platforms/quorum/configuration/reset-network.yaml
@@ -28,7 +28,73 @@
 
     # Uninstalling Flux is needed so that everything is clean
     # remove this if not needed
-    - name: Uninstall flux
+    ##Deletes Deployments related to flux
+    - name: Delete flux deployments
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Deployment
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        force: yes
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes services related to flux
+    - name: Delete flux services
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Service
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["webhook-receiver","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes Network policies related to flux
+    - name: Delete flux Network Policies
+      k8s:
+        state: absent
+        api_version: v1
+        kind: NetworkPolicy
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["allow-egress","allow-scraping","allow-webhooks"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes serviceaccount related to flux
+    - name: Delete flux ServiceAccount
+      k8s:
+        state: absent
+        api_version: v1
+        kind: ServiceAccount
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes flux namespace
+    - name: delete flux namespace
       k8s:
         name: flux-{{ network.env.type }}
         api_version: v1

--- a/platforms/r3-corda-ent/configuration/reset-network.yaml
+++ b/platforms/r3-corda-ent/configuration/reset-network.yaml
@@ -52,7 +52,73 @@
     # ----------------------------------------------------------------------
     # Uninstalling Flux is needed so that everything is clean
     # remove this if not needed
-    - name: Uninstall flux
+    ##Deletes deployments related to flux
+    - name: Delete flux deployments
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Deployment
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        force: yes
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes services related to flux
+    - name: Delete flux services
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Service
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["webhook-receiver","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes Network policies related to flux
+    - name: Delete flux Network Policies
+      k8s:
+        state: absent
+        api_version: v1
+        kind: NetworkPolicy
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["allow-egress","allow-scraping","allow-webhooks"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes Service Account related to flux
+    - name: Delete flux ServiceAccount
+      k8s:
+        state: absent
+        api_version: v1
+        kind: ServiceAccount
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes flux namespace
+    - name: delete flux namespace
       k8s:
         name: flux-{{ network.env.type }}
         api_version: v1
@@ -63,6 +129,7 @@
         kubernetes: "{{ item.k8s }}"
       loop: "{{ network['organizations'] }}"
       ignore_errors: yes
+
     # ----------------------------------------------------------------------
     # Uninstalling Flux is needed so that everything is clean
     - name: Uninstall flux from float cluster

--- a/platforms/r3-corda/configuration/reset-network.yaml
+++ b/platforms/r3-corda/configuration/reset-network.yaml
@@ -35,7 +35,73 @@
       loop: "{{ network['organizations'] }}"
     # Uninstalling Flux is needed so that everything is clean
     # remove this if not needed
-    - name: Uninstall flux
+    ##Deletes Deployments related to flux
+    - name: Delete flux deployments
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Deployment
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        force: yes
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes services related to flux
+    - name: Delete flux services
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Service
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["webhook-receiver","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes Network Policies related to flux
+    - name: Delete flux Network Policies
+      k8s:
+        state: absent
+        api_version: v1
+        kind: NetworkPolicy
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["allow-egress","allow-scraping","allow-webhooks"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    ##Deletes serivceaccount related to flux
+    - name: Delete flux ServiceAccount
+      k8s:
+        state: absent
+        api_version: v1
+        kind: ServiceAccount
+        namespace: flux-{{ network.env.type }}
+        name: "{{ item[0] }}"
+        kubeconfig: "{{ kubernetes.config_file }}"
+      vars:
+        kubernetes: "{{ item[1].k8s }}"
+      with_nested:
+        - ["helm-controller","kustomize-controller","notification-controller","source-controller"]
+        - "{{ network['organizations'] }}"
+      ignore_errors: yes
+
+    #Deletes flux namespace
+    - name: delete flux namespace
       k8s:
         name: flux-{{ network.env.type }}
         api_version: v1
@@ -46,6 +112,7 @@
         kubernetes: "{{ item.k8s }}"
       loop: "{{ network['organizations'] }}"
       ignore_errors: yes
+
     # Delete Helmreleases
     - include_role:
         name: "delete/flux_releases"


### PR DESCRIPTION
**Changelog**
Fixed flux uninstall by removing the individual k8s components and then deleting namespace in reset-network.yaml instead of directly removing the namespace


 

**Reviewed by**
@suvajit-sarkar @sownak 

 

**Linked issue**
#2039 
