### PR TITLE
[besu] split crypto generation while adding validator nodes

### DIFF
--- a/platforms/hyperledger-besu/configuration/add-validator.yaml
+++ b/platforms/hyperledger-besu/configuration/add-validator.yaml
@@ -55,15 +55,18 @@
   # Setup Vault-Kubernetes accesses and Regcred for docker registry
   - name: "Setup vault"   
     include_role: 
-      name: "setup/vault_kubernetes"
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault_kubernetes"
     vars:
+      policy_type: "besu"
+      name: "{{ organizationItem.name | lower }}"
       component_ns: "{{ organizationItem.name | lower }}-bes"
+      component_name: "{{ organizationItem.name | lower }}-vaultk8s-job"
+      component_auth: "besu{{ organizationItem.name | lower }}"
+      component_type: "organization"
       kubernetes: "{{ organizationItem.k8s }}"
       vault: "{{ organizationItem.vault }}"
-      component_name: "{{ organizationItem.name | lower}}"
-      component_path: "{{ organizationItem.name | lower }}/"
-      component_auth: "besu{{ organizationItem.name | lower }}"
-      component_type: "besu"
+      gitops: "{{ organizationItem.gitops }}"
+      reset_path: "platforms/hyperledger-besu/configuration"
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: organizationItem
@@ -82,6 +85,9 @@
       component_name: "{{ organizationItem.name | lower }}"
       kubernetes: "{{ organizationItem.k8s }}"
       vault: "{{ organizationItem.vault }}"
+      gitops: "{{ organizationItem.gitops }}"
+      charts_dir: "{{ organizationItem.gitops.chart_source }}"
+      values_dir: "{{ playbook_dir }}/../../../{{organizationItem.gitops.release_dir}}/{{ organizationItem.name | lower }}"
     loop: "{{ network['organizations']}}"
     loop_control:
       loop_var: organizationItem

--- a/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/check_vault.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/check_vault.yaml
@@ -16,7 +16,21 @@
   register: vault_result
   ignore_errors: yes
 
-# This sets a fact generate_crypto
-- set_fact:
-    generate_crypto: True
-  when: vault_result.failed is defined and vault_result.failed == True
+- name: Ensure validator directory exist
+  file:
+    path: "{{ build_path }}/crypto/{{ org.name }}/{{ item.name  }}/data"
+    state: directory
+  with_items: "{{ org.services.peers is defined | ternary(org.services.peers, org.services.validators) }}"
+  when: item.status == 'new' and vault_result.failed is not defined
+
+- name: Get the crypto material from Vault
+  shell: |
+    vault kv get -field=key_pub {{ vault.secret_path | default('secretsv2') }}/{{ component_ns }}/crypto/{{ item.name }}/data > "{{ build_path }}/crypto/{{ org.name }}/{{ item.name  }}/data/key.pub"
+    vault kv get -field=nodeAddress {{ vault.secret_path | default('secretsv2') }}/{{ component_ns }}/crypto/{{ item.name }}/data > "{{ build_path }}/crypto/{{ org.name }}/{{ item.name  }}/data/nodeAddress"
+    vault kv get -field=key {{ vault.secret_path | default('secretsv2') }}/{{ component_ns }}/crypto/{{ item.name }}/data > "{{ build_path }}/crypto/{{ org.name }}/{{ item.name  }}/data/key"
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+  with_items: "{{ org.services.peers is defined | ternary(org.services.peers, org.services.validators) }}"
+  when: item.status == 'new' and vault_result.failed is not defined
+  ignore_errors: yes

--- a/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/main.yaml
@@ -24,6 +24,7 @@
   include_tasks: check_vault.yaml
   vars:    
     vault: "{{ org.vault }}"
+    component_ns: "{{ org.name | lower }}-bes"
   loop: "{{ network['organizations'] }}"
   loop_control:
     loop_var: org
@@ -35,7 +36,7 @@
   loop: "{{ network['organizations'] }}"
   loop_control:
     loop_var: org
-  when: generate_crypto is defined and generate_crypto == True and org.type == 'validator'
+  when: org.type == 'validator'
 
 # This task creates the build directory
 - name: Create build directory if it does not exist
@@ -44,42 +45,45 @@
   vars:
     path: "{{ playbook_dir }}/build"
     check: "ensure_dir"
-  when: generate_crypto is defined and generate_crypto == True
+  when: (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task creates the bin directory, if it doesn't exist, for storing the geth binary
 - name: Create bin directory
   file:
     path: "{{ bin_install_dir }}/besu/besu-{{ network.version }}"
     state: directory
-  when: generate_crypto is defined and generate_crypto == True
+  when: (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # Check if besu binary already exists
 - name: check besu binary
   stat:
     path: "{{ bin_install_dir }}/besu/besu-{{ network.version }}/besu"
   register: besu_stat_result
-  when: generate_crypto is defined and generate_crypto == True
 
 # Create a temporary directory to download and extract besu tar
 - name: register temporary directory
   tempfile:
     state: directory
   register: tmp_directory
-  when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
+  when: besu_stat_result is defined and besu_stat_result.stat.exists == False
 
 # This task fetches the besu tar file from the mentioned URL
 - name: "Geting the besu binary tar"
   get_url:
     url: https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/{{ network.version }}/besu-{{ network.version }}.zip
     dest: "{{ tmp_directory.path }}"
-  when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
+  when:
+    - besu_stat_result.stat.exists == False
+    - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task unzips the above downloaded tar file
 - name: "Unziping the downloaded file"
   unarchive:
     src: "{{ tmp_directory.path }}/besu-{{ network.version }}.zip"
     dest: "{{ tmp_directory.path }}"
-  when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
+  when:
+    - besu_stat_result.stat.exists == False
+    - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task extracts the besu binary and place it at appropriate path
 - name: "Moving the besu from the extracted folder and place in it path"
@@ -87,7 +91,9 @@
     src: "{{ tmp_directory.path }}/besu-{{ network.version }}/bin/besu"
     dest: "{{ bin_install_dir }}/besu/besu-{{ network.version }}"
     mode: 0755
-  when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
+  when:
+    - besu_stat_result.stat.exists == False
+    - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task extracts the supporting besu.bat and place it at appropriate path
 - name: "Moving the besu dependencies from the extracted folder and place in it path"
@@ -95,7 +101,9 @@
     src: "{{ tmp_directory.path }}/besu-{{ network.version }}/lib"
     dest: "{{ bin_install_dir }}/besu"
     mode: 0755
-  when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
+  when:
+    - besu_stat_result.stat.exists == False
+    - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task creates the organization directories for crypto material if not exists
 - name: Create organization directory if it does not exist
@@ -106,12 +114,13 @@
     check: "ensure_dir"
   with_indexed_items: "{{ enode_validator_list }}"
   when:  
-    - generate_crypto is defined and generate_crypto == True
+    - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task generates the enode for the new validator
 - name: "Creating the enode and pub key for the new validator"
   include_tasks: create_enode.yaml
-  when: generate_crypto is defined and generate_crypto == True
+  when:
+    - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This file stores the address of the validator nodes
 - name: Touch file to store information for validators
@@ -119,7 +128,7 @@
     path: "{{ build_path }}/validatorinfo"
     state: touch
   when:  
-    - generate_crypto is defined and generate_crypto == True
+    - (network.crypto_only is defined and network.crypto_only == false) or (network.crypto_only is undefined)
 
 # This file used by besu binary to generate the extra data information
 - name: Touch toEncode.json file
@@ -127,7 +136,7 @@
     path: "{{ build_path }}/toEncode.json"
     state: touch
   when:  
-    - generate_crypto is defined and generate_crypto == True
+    - (network.crypto_only is defined and network.crypto_only == false) or (network.crypto_only is undefined)
 
 # Create the validator address array
 - name: Get node data
@@ -136,7 +145,7 @@
   with_indexed_items: "{{ enode_validator_list }}"
   when:  
     - item[1].type == "validator"
-    - generate_crypto is defined and generate_crypto == True
+    - (network.crypto_only is defined and network.crypto_only == false) or (network.crypto_only is undefined)
     
 # This task converts the validator info to json format
 - name: Convert validatorInfo to json format
@@ -164,4 +173,3 @@
   with_together:
     - "{{ validator_address }}"
     - "{{ enode_validator_list }}"
-  when: generate_crypto is defined and generate_crypto == True

--- a/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/validator_vote.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/validator_vote.yaml
@@ -17,7 +17,9 @@
   loop: "{{ network['organizations'] }}"
   loop_control:
     loop_var: org
-  when: generate_crypto is defined and generate_crypto == True and org.type == 'validator' and peer | length>0
+  when: 
+  - org.type == 'validator' and peer | length>0
+  - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # Set enode_data_list to empty
 - name: Set enode_data_list to []
@@ -50,7 +52,9 @@
   loop: "{{ network['organizations'] }}"
   loop_control:
     loop_var: val
-  when: network.config.consensus == 'ibft' and val.type == 'validator' and peer | length>0
+  when:
+    - network.config.consensus == 'ibft' and val.type == 'validator' and peer | length>0
+    - (network.crypto_only is undefined or network.crypto_only == false)
 
 # Check for local genesis file
 - name: Check that the gensis file exists
@@ -67,13 +71,17 @@
     VAULT_TOKEN: "{{ vault.root_token }}"
   register: vault_genesis
   ignore_errors: yes
-  when: stat_result.stat.exists == False
+  when:
+    - stat_result.stat.exists == False
+    - (network.crypto_only is undefined or network.crypto_only == false)
 
 #This task only runs when there is no local genesis file
 - name: Copy genesis from vault to correct path
   shell: |
     echo {{ vault_genesis.stdout }} > {{ network.config.genesis }}
-  when: stat_result.stat.exists == False
+  when:
+    - stat_result.stat.exists == False
+    - (network.crypto_only is undefined or network.crypto_only == false)
 
 # Looping the validator orgs
 - name: Pushing files to Git and creating helm release files
@@ -99,4 +107,6 @@
   loop: "{{ network['organizations'] }}"
   loop_control:
     loop_var: org_val
-  when: network.config.consensus == 'ibft' and org_val.type == 'validator' and peer_result | length>0
+  when:
+    - network.config.consensus == 'ibft' and org_val.type == 'validator' and peer_result | length>0
+    - (network.crypto_only is undefined or network.crypto_only == false)


### PR DESCRIPTION
**Changelog**
- Changed made to split crypto generation and node joining process during validator addition
- Fixed the vault authention when adding a new org to the existing besu network

`add-validator.yaml` playbook can be invoked by setting up `crypto_only: true` in network.yaml.
 

**Reviewed by**
@developer_github_id

 

**Linked issue**
#2110 
