### PR TITLE
[ci-skip] Fix vault-auth when restart

### DIFF
--- a/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/job.yaml
+++ b/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/job.yaml
@@ -120,7 +120,6 @@ spec:
                 # This echo get the certificate for the cluster
                 echo "
                   {
-                    \"token_reviewer_jwt\": \"${REVIEWER_TOKEN}\",
                     \"kubernetes_host\": \"${KUBERNETES_URL}\",
                     \"kubernetes_ca_cert\": \"${KUBE_SA_CRT_ONELINE}\",
                     \"disable_iss_validation\": \"true\"

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-server/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-server/tasks/main.yaml
@@ -18,6 +18,14 @@
     path: "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca"
     check: "ensure_dir"
 
+- name: Check if CA key already exists in vault.
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+  vars:
+    vault_field: "{{ component_name }}-CA.key"
+    vault_path: "{{ vault.secret_path | default('secretsv2') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ca"
+    check: "certs_created"
+
 #####################################################################################################################
 # This tasks generates cacerts helmrelease file.
 - name: "Create value file for cacerts job"
@@ -37,6 +45,7 @@
     fabrictools_image: "hyperledger/fabric-tools:{{ network.version }}"
     alpine_image: "{{ docker_url }}/alpine-utils:1.0"
     values_dir: "{{playbook_dir}}/../../../{{ gitops.release_dir }}/{{ component }}"
+  when: certs_created.failed == True
 
 #Git Push : Pushes the above generated files to git directory 
 - name: Git Push
@@ -47,6 +56,7 @@
     gitops: "{{ item.gitops }}"
     GIT_RESET_PATH: "platforms/hyperledger-fabric/configuration"
     msg: "[ci skip] Pushing CA server files"
+  when: certs_created.failed == True
   tags:
     - notest
 
@@ -59,6 +69,7 @@
     namespace: "{{ component }}-net"
     component_name: "{{ component }}-cacerts-job"
     kubernetes: "{{ item.k8s }}"
+  when: certs_created.failed == True
   tags:
     - notest
 

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/reviewer_rbac.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/reviewer_rbac.tpl
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: vault-reviewer
   namespace: {{ component_name }}
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: {{ component_name }}

--- a/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -46,6 +46,15 @@
     KUBECONFIG={{ kubernetes.config_file }} kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " "
   register: kubernetes_server_url
 
+- name: Check if CA key already exists in vault.
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+  vars:
+    component_type: "{{ item.type | lower }}"
+    component_name: "{{ item.name | lower }}-net"
+    vault: "{{ item.vault }}"
+    check: "vault_policies"
+
 #####################################################################################################################
 # This tasks generate vault_kubernetes helmrelease file
 - name: "Create value file for vault_kubernetes "
@@ -66,6 +75,7 @@
     kubernetes_url: "{{ kubernetes_server_url.stdout }}"
     alpine_image: "{{ network.docker.url }}/alpine-utils:1.0"
     values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
+  when: vault_policy_result.failed == True
   
 #Git Push : Pushes the above generated files to git directory 
 - name: Git Push
@@ -76,6 +86,7 @@
     gitops: "{{ item.gitops }}"    
     GIT_RESET_PATH: "platforms/hyperledger-fabric/configuration"
     msg: "[ci skip] Pushing vault_kubernetes files"
+  when: vault_policy_result.failed == True
    
 # Check if vault_kubernetes is completed
 - name: Check if vault_kubernetes job is completed
@@ -86,6 +97,7 @@
     namespace: "{{ item.name | lower}}-net"
     component_name: "{{ item.name | lower}}-vaultkubenertes-job"
     kubernetes: "{{ item.k8s }}"
+  when: vault_policy_result.failed == True
 
 #############################################################################################
 # This task deletes the root token

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
@@ -49,10 +49,6 @@ network:
   # For RAFT consensus, have odd number (2n+1) of orderers for consensus agreement to have a majority.
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -265,10 +261,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-ordererorg.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-ordererorg.yaml
@@ -47,10 +47,6 @@ network:
   # Remote connection information for orderer (will be blank or removed for orderer hosting organization)
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -210,10 +206,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
@@ -48,10 +48,6 @@ network:
   # Remote connection information for orderer (will be blank or removed for orderer hosting organization)
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -210,10 +206,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml
@@ -43,10 +43,6 @@ network:
   # Remote connection information for orderer (will be blank or removed for orderer hosting organization)
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -282,10 +278,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
@@ -44,10 +44,6 @@ network:
   # Remote connection information for orderer (will be blank or removed for orderer hosting organization)
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -184,10 +180,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
@@ -45,10 +45,6 @@ network:
   # For RAFT consensus, have odd number (2n+1) of orderers for consensus agreement to have a majority.
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -191,10 +187,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -49,10 +49,6 @@ network:
   # For RAFT consensus, have odd number (2n+1) of orderers for consensus agreement to have a majority.
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer
@@ -220,10 +216,6 @@ network:
         
         consensus:
           name: raft
-          type: broker        #This field is not consumed for raft consensus
-          replicas: 4         #This field is not consumed for raft consensus
-          grpc:
-            port: 9092        #This field is not consumed for raft consensus
                 
         orderers:
         # This sample has multiple orderers as an example.

--- a/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
@@ -42,10 +42,6 @@ network:
   # For RAFT consensus, have odd number (2n+1) of orderers for consensus agreement to have a majority.
   consensus:
     name: raft
-    type: broker        #This field is not consumed for raft consensus
-    replicas: 4         #This field is not consumed for raft consensus
-    grpc:
-      port: 9092        #This field is not consumed for raft consensus
   orderers:
     - orderer:
       type: orderer

--- a/platforms/shared/configuration/roles/check/setup/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/check/setup/tasks/main.yaml
@@ -65,8 +65,8 @@
   register: get_gitcred
   when: check == "git_credentials"
 
-# This task check if certs exists in vault.
-- name: check if certs exists in vault.
+# This task waits until certs are stored in vault.
+- name: Wait for certs to be created.
   shell: |
     vault kv get -field={{ vault_field }} {{ vault_path }}
   environment:
@@ -77,3 +77,13 @@
   delay: 30
   until: vault_result.failed == False
   when: check == "crypto_materials"
+
+# This task check if certs exists in vault.
+- name: check if certs exists in vault.
+  shell: |
+    vault kv get -field={{ vault_field }} {{ vault_path }}
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+  register: certs_created
+  when: check == "certs_created"


### PR DESCRIPTION
**Changelog**
- remove reviewer token in Vault_Kubernetes chart
- Add vault-auth as system:auth-delegator
- Add checks for certificate creation so that job checks are not carried again (jobs vanish when cluster restarts)
- Remove unnecessary fields from network.yaml samples for raft consensus
