### PR TITLE
[besu] Add cactus-connectors and Add pre-configured accounts

### DIFF
--- a/platforms/hyperledger-besu/charts/besu-connector/.helmignore
+++ b/platforms/hyperledger-besu/charts/besu-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/platforms/hyperledger-besu/charts/besu-connector/Chart.yaml
+++ b/platforms/hyperledger-besu/charts/besu-connector/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: besu_connector
+description: A Helm chart for Cactus Besu Connector
+type: application
+version: 0.1.0
+# For Cactus release 1.1.3
+appVersion: "1.1.3"

--- a/platforms/hyperledger-besu/charts/besu-connector/templates/_helpers.tpl
+++ b/platforms/hyperledger-besu/charts/besu-connector/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/hyperledger-besu/charts/besu-connector/templates/configmap.yaml
+++ b/platforms/hyperledger-besu/charts/besu-connector/templates/configmap.yaml
@@ -1,0 +1,30 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-plugins
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-plugins
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "labels.custom" . | nindent 2 }}
+data:
+  PLUGINS: |
+    {
+      "packageName": {{ .Values.plugins.packageName | quote }},
+      "type": {{ .Values.plugins.type | quote }},
+      "action": {{ .Values.plugins.action | quote }},
+      "options": {
+        "instanceId": {{ .Values.plugins.instanceId | quote }},
+        "rpcApiHttpHost": {{ .Values.plugins.rpcApiHttpHost | quote }},
+        "rpcApiWsHost": {{ .Values.plugins.rpcApiWsHost | quote }}
+      }
+    }

--- a/platforms/hyperledger-besu/charts/besu-connector/templates/deployment.yaml
+++ b/platforms/hyperledger-besu/charts/besu-connector/templates/deployment.yaml
@@ -1,0 +1,55 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-cactus-connector
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }} 
+    {{- include "labels.custom" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-cactus-connector
+      app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }} 
+      {{- include "labels.custom" . | nindent 2 }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-cactus-connector
+        app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }} 
+        {{- include "labels.custom" . | nindent 2 }}
+    spec:
+      containers:
+      - name: cactus-connector
+        image: {{ .Values.image.repository | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy}}
+        ports:
+        - name: http
+          containerPort: 4000
+          protocol: TCP
+        env:
+        - name: AUTHORIZATION_PROTOCOL
+          value: {{  .Values.envs.authorizationProtocol | quote  }}
+        - name: AUTHORIZATION_CONFIG_JSON
+          value: {{  .Values.envs.authorizationConfigJson | quote  }}
+        - name: GRPC_TLS_ENABLED
+          value: {{  .Values.envs.grpcTlsEnabled | quote  }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-plugins

--- a/platforms/hyperledger-besu/charts/besu-connector/templates/service.yaml
+++ b/platforms/hyperledger-besu/charts/besu-connector/templates/service.yaml
@@ -1,0 +1,48 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Release.Name }}-svc
+  annotations:
+    {{- if eq $.Values.proxy.provider "ambassador" }}
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v2
+      kind: Mapping
+      name: {{ .Release.Name }}-svc-mapping
+      prefix: /
+      service: {{ .Release.Name }}-svc.{{ .Values.metadata.namespace }}:{{ .Values.service.port }}
+      host: {{ .Values.plugins.besuNode }}.{{ .Values.proxy.external_url }}
+      tls: false
+      ---
+      apiVersion: ambassador/v2
+      kind: TLSContext
+      name: {{ .Release.Name }}_mapping_tlscontext
+      hosts:
+      - {{ .Values.plugins.besuNode }}.{{ .Values.proxy.external_url }}
+      secret: {{ .Values.plugins.besuNode }}-ambassador-certs.{{ .Values.metadata.namespace }}
+      secret_namespacing: true
+      min_tls_version: v1.2
+    {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-svc
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }} 
+    {{- include "labels.custom" . | nindent 2 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.service.port }}
+    targetPort: http
+  selector:
+    name: {{ .Release.Name }}-cactus-connector

--- a/platforms/hyperledger-besu/charts/besu-connector/values.yaml
+++ b/platforms/hyperledger-besu/charts/besu-connector/values.yaml
@@ -1,0 +1,47 @@
+
+metadata:
+  # Namespace where this deployment will be created
+  namespace: supplychain-bes
+
+# Number of replicas
+replicaCount: 1
+
+image:
+  # Docker image of the API server
+  repository: ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3
+  # Pull policy of the docker image
+  pullPolicy: IfNotPresent
+
+service:
+  # Service type for the Cactus API server
+  type: ClusterIP
+  # Port for the above service
+  port: 4000
+
+# Cactus connector plugin details for Besu
+plugins:
+  # Existing Besu node name where the plugin will connect
+  besuNode: validator1
+  # Package name, type and action for the besu connector
+  packageName: "@hyperledger/cactus-plugin-ledger-connector-besu"
+  type: org.hyperledger.cactus.plugin_import_type.LOCAL
+  action: org.hyperledger.cactus.plugin_import_action.INSTALL
+  # Unique instance id in case multiple connectors are deployed
+  instanceId: "12345678"
+  # Existing Besu node RPC addess. can be local or public url
+  rpcApiHttpHost: http://validator1.supplychain-bes:8545
+  # Existing Besu node WS addess. can be local or public url
+  rpcApiWsHost: ws://validator1.supplychain-bes:8546
+
+# Additional env details for Cactus connector
+envs:
+  authorizationProtocol: "NONE"
+  authorizationConfigJson: "{}"
+  grpcTlsEnabled: "false"
+
+# Proxy details to expose Connector service over Internet
+proxy:
+  # Only ambassador is supported
+  provider: "ambassador"
+  # Complete external url will be https://<besuNode>.<external_url>
+  external_url: bes.demo.aws.blockchaincloudpoc.com

--- a/platforms/hyperledger-besu/charts/generate_ambassador_certs/templates/job.yaml
+++ b/platforms/hyperledger-besu/charts/generate_ambassador_certs/templates/job.yaml
@@ -50,7 +50,7 @@ spec:
       initContainers:
       - name: init-check-certificates
         image: "{{ $.Values.image.alpineutils }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         env:
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}
@@ -148,7 +148,7 @@ spec:
       containers:
       - name:  "generate-certs"
         image: "{{ $.Values.image.alpineutils }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         env:
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}
@@ -250,7 +250,7 @@ spec:
             mountPath: /certificates
       - name:  "store-certs"
         image: "{{ $.Values.image.alpineutils }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         env:
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}

--- a/platforms/hyperledger-besu/charts/node_besu/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_besu/values.yaml
@@ -73,7 +73,7 @@ proxy:
 images:
   # Provide the alpine utils image.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
+  # Eg. alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
   alpineutils: 
   # Provide the Hyperledger-Besu node image.
   # Eg. node: hyperledger/besu:1.4.4

--- a/platforms/hyperledger-besu/charts/node_besu/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_besu/values.yaml
@@ -73,7 +73,7 @@ proxy:
 images:
   # Provide the alpine utils image.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
+  # Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
   alpineutils: 
   # Provide the Hyperledger-Besu node image.
   # Eg. node: hyperledger/besu:1.4.4

--- a/platforms/hyperledger-besu/charts/node_orion/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_orion/values.yaml
@@ -77,7 +77,7 @@ proxy:
 images:
   # Provide the alpine utils image.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
+  # Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
   alpineutils: 
   # Provide the Hyperledger-Besu node image.
   # Eg. node: hyperledger/besu:1.4.4

--- a/platforms/hyperledger-besu/charts/node_orion/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_orion/values.yaml
@@ -77,7 +77,7 @@ proxy:
 images:
   # Provide the alpine utils image.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
+  # Eg. alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
   alpineutils: 
   # Provide the Hyperledger-Besu node image.
   # Eg. node: hyperledger/besu:1.4.4

--- a/platforms/hyperledger-besu/charts/node_tessera/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_tessera/values.yaml
@@ -25,8 +25,8 @@ metadata:
 #These are the various docker images being used by this chart. update them as needed
 images:  
   #Provide the valid image name and version to read certificates from vault server 
-  #Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
-  alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
+  #Eg. alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
+  alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
   #Provide the valid image name and version for tessera
   #Eg. tessera: quorumengineering/tessera:0.9.2
   tessera: quorumengineering/tessera:0.9.2

--- a/platforms/hyperledger-besu/charts/node_tessera/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_tessera/values.yaml
@@ -25,8 +25,8 @@ metadata:
 #These are the various docker images being used by this chart. update them as needed
 images:  
   #Provide the valid image name and version to read certificates from vault server 
-  #Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
-  alpineutils: hyperledgerlabs/alpine-utils:1.0
+  #Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
+  alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
   #Provide the valid image name and version for tessera
   #Eg. tessera: quorumengineering/tessera:0.9.2
   tessera: quorumengineering/tessera:0.9.2

--- a/platforms/hyperledger-besu/charts/node_validator/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_validator/values.yaml
@@ -77,7 +77,7 @@ proxy:
 images:
   # Provide the alpine utils image.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
+  # Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
   alpineutils: 
   # Provide the Hyperledger-Besu node image.
   # Eg. node: hyperledger/besu:1.4.4

--- a/platforms/hyperledger-besu/charts/node_validator/values.yaml
+++ b/platforms/hyperledger-besu/charts/node_validator/values.yaml
@@ -77,7 +77,7 @@ proxy:
 images:
   # Provide the alpine utils image.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. alpineutils: ghcr.io/hyperledger/alpine-utils:1.1
+  # Eg. alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
   alpineutils: 
   # Provide the Hyperledger-Besu node image.
   # Eg. node: hyperledger/besu:1.4.4

--- a/platforms/hyperledger-besu/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-besu/configuration/deploy-network.yaml
@@ -95,7 +95,7 @@
       build_path: "{{ playbook_dir }}/build"
     when: network.config.consensus == 'ibft'
   
-    # This role generates the genesis.json and nodekey/enode for all orgs of the network
+  # This role generates the genesis.json and nodekey/enode for all orgs of the network
   - name: "Generate crypto for the QBFT network"
     include_role:
       name: create/crypto/qbft

--- a/platforms/hyperledger-besu/configuration/generate-crypto.yaml
+++ b/platforms/hyperledger-besu/configuration/generate-crypto.yaml
@@ -102,6 +102,15 @@
     vars:
       build_path: "{{ playbook_dir }}/build"
     when: network.config.consensus == 'ethash'
+
+  # This role generates the genesis.json and nodekey/enode for all orgs of the network
+  - name: "Generate crypto for the QBFT network"
+    include_role:
+      name: create/crypto/qbft
+    vars:
+      build_path: "{{ playbook_dir }}/build"
+    when: network.config.consensus == 'qbft'
+
   # This role generates the crypto materials for orion tm
   - name: "Generate crypto for the Orion transaction manager"
     include_role:

--- a/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
@@ -11,10 +11,9 @@
 # Ensures the ambassador tls directory
 - name: "Ensure ambassadortls dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ ambassadortls }}"
-    check: "ensure_dir"
 
 # Create ambassador certs helmrelease file
 - name: "Create ambassador certs helmrelease file"

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/clique/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/clique/tasks/main.yaml
@@ -29,10 +29,9 @@
 # This task creates the build directory
 - name: Create the build directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/build"
-    check: "ensure_dir"
   when: generate_crypto is defined and generate_crypto == True
 
 # This task creates the bin directory if it doesn't exist, for storing the geth binary
@@ -86,15 +85,24 @@
     mode: 0755
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
-# This task creates the cliqueConfigFile.json file from the template
-- name: Create cliqueConfigFile.json
+# This task creates the cliqueConfigFile.yaml file from the template
+- name: Create cliqueConfigFile.yaml
   template:
     src: "cliqueConfigFile.tpl"
-    dest: "{{ build_path }}/cliqueConfigFile.json"
+    dest: "{{ build_path }}/cliqueConfigFile.yaml"
   vars:
     total_peer_count: "{{ node_list | length }}"
     chain_id: "{{ network.config.chain_id | default(2018) | int }}"
   when:
+    - generate_crypto is defined and generate_crypto == True
+    - add_new_org is not defined or add_new_org|bool == False
+
+# This task converts the above yaml into json format and writes it in the json file
+- name: Create cliqueConfigFile.json file
+  copy:
+    content: "{{ lookup('file', '{{ build_path }}/cliqueConfigFile.yaml') | from_yaml | to_nice_json }}"
+    dest: "{{ build_path }}/cliqueConfigFile.json"
+  when: 
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
@@ -112,7 +120,7 @@
   shell: |
     {{ bin_install_dir }}/besu/besu-{{ network.version }}/besu operator generate-blockchain-config --config-file={{ build_path }}/cliqueConfigFile.json --to={{ build_path }}/crypto --private-key-file-name=key
   when:
-    - network.config.consensus == "clique" and generate_crypto is defined and generate_crypto == True
+    - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
 # This task gets the list of folders
@@ -125,7 +133,7 @@
   when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
-  
+
 # This task renames the above created directories to the org_name/node_name
 - name: Rename the directories created above with the elements of node_list
   copy: src={{ file.path }}/ dest={{ build_path }}/crypto/{{ node_list[index].org }}/{{ node_list[index].node }}/data
@@ -140,10 +148,9 @@
 # This task creates the organization directory for crypto material if it does not exist
 - name: Create organization directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/{{ build_path }}/crypto/{{ item[1].org }}/{{ item[1].node }}/data"
-    check: "ensure_dir"
   with_indexed_items: "{{ node_list }}"
   when:
     - generate_crypto is defined and generate_crypto == True

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/clique/templates/cliqueConfigFile.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/clique/templates/cliqueConfigFile.tpl
@@ -1,23 +1,21 @@
-{
- "genesis": {
-   "config": {
-     "chainId": {{ chain_id }},
-     "constantinoplefixblock": 0,
-     "contractSizeLimit": 2147483647,
-     "clique":{
-      "blockperiodseconds":15,
-      "epochlength":30000
-    }
-   },
-   "nonce": "0x0",
-   "timestamp": "0x58ee40ba",
-   "gasLimit": "0x1fffffffffffff",
-   "difficulty": "0x1"
- },
- "blockchain": {
- "nodes": {
-   "generate": true,
-   "count": {{ total_peer_count }}
-   }
- }
-}
+genesis:
+  config:
+    chainId: {{ chain_id }}
+    constantinoplefixblock: 0
+    contractSizeLimit: 2147483647
+    clique:
+      blockperiodseconds: 15
+      epochlength: 30000
+  alloc:
+{% for key in network.config.accounts %}
+    {{ key | quote }}:
+      balance: '90000000000000000000000'
+{% endfor %}
+  nonce: '0x0'
+  timestamp: '0x58ee40ba'
+  gasLimit: '0x1fffffffffffff'
+  difficulty: '0x1'
+blockchain:
+  nodes:
+    generate: true
+    count: {{ total_peer_count }}

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/ethash/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/ethash/tasks/main.yaml
@@ -30,10 +30,9 @@
 # This task creates the build directory
 - name: Create the build directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/build"
-    check: "ensure_dir"
   when: generate_crypto is defined and generate_crypto == True
 
 # This task creates the bin directory if it doesn't exist, for storing the geth binary
@@ -87,15 +86,24 @@
     mode: 0755
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
-# This task creates the ethashConfigFile.json file from the template
-- name: Create ethashConfigFile.json
+# This task creates the ethashConfigFile.yaml file from the template
+- name: Create ethashConfigFile.yaml
   template:
     src: "ethashConfigFile.tpl"
-    dest: "{{ build_path }}/ethashConfigFile.json"
+    dest: "{{ build_path }}/ethashConfigFile.yaml"
   vars:
     total_peer_count: "{{ node_list | length }}"
     chain_id: "{{ network.config.chain_id | default(2018) | int }}"
   when:
+    - generate_crypto is defined and generate_crypto == True
+    - add_new_org is not defined or add_new_org|bool == False
+
+# This task converts the above yaml into json format and writes it in the json file
+- name: Create ethashConfigFile.json file
+  copy:
+    content: "{{ lookup('file', '{{ build_path }}/ethashConfigFile.yaml') | from_yaml | to_nice_json }}"
+    dest: "{{ build_path }}/ethashConfigFile.json"
+  when: 
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
@@ -113,7 +121,7 @@
   shell: |
     {{ bin_install_dir }}/besu/besu-{{ network.version }}/besu operator generate-blockchain-config --config-file={{ build_path }}/ethashConfigFile.json --to={{ build_path }}/crypto --private-key-file-name=key
   when:
-    - network.config.consensus == "ethash" and generate_crypto is defined and generate_crypto == True
+    - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
 # This task gets the list of folders
@@ -141,10 +149,9 @@
 # This task creates the organization directory for crypto material if it does not exist
 - name: Create organization directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/{{ build_path }}/crypto/{{ item[1].org }}/{{ item[1].node }}/data"
-    check: "ensure_dir"
   with_indexed_items: "{{ node_list }}"
   when:
     - generate_crypto is defined and generate_crypto == True

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/ethash/templates/ethashConfigFile.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/ethash/templates/ethashConfigFile.tpl
@@ -1,22 +1,20 @@
-{
- "genesis": {
-   "config": {
-     "chainId": {{ chain_id }},
-     "constantinoplefixblock": 0,
-     "contractSizeLimit": 2147483647,
-     "ethash": {
-      "fixeddifficulty": 1000
-    }
-   },
-   "nonce": "0x0",
-   "timestamp": "0x58ee40ba",
-   "gasLimit": "0x1fffffffffffff",
-   "difficulty": "0x1"
- },
- "blockchain": {
- "nodes": {
-   "generate": true,
-   "count": {{ total_peer_count }}
-   }
- }
-}
+genesis:
+  config:
+    chainId: {{ chain_id }}
+    constantinoplefixblock: 0
+    contractSizeLimit: 2147483647
+    ethash:
+      fixeddifficulty: 1000
+  alloc:
+{% for key in network.config.accounts %}
+    {{ key | quote }}:
+      balance: '90000000000000000000000'
+{% endfor %}
+  nonce: '0x0'
+  timestamp: '0x58ee40ba'
+  gasLimit: '0x1fffffffffffff'
+  difficulty: '0x1'
+blockchain:
+  nodes:
+    generate: true
+    count: {{ total_peer_count }}

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/tasks/main.yaml
@@ -9,7 +9,7 @@
   set_fact:
     node_list: []
 
-# This tasks checks the crypto material in the vault
+# This task checks the crypto material in the vault
 - name: Check for the crypto material in the vault
   include_tasks: check_vault.yaml
   vars:
@@ -30,10 +30,9 @@
 # This task creates the build directory
 - name: Create build directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/build"
-    check: "ensure_dir"
   when: generate_crypto is defined and generate_crypto == True
 
 # This task creates the bin directory, if it doesn't exist, for storing the geth binary
@@ -44,7 +43,7 @@
   when: generate_crypto is defined and generate_crypto == True
 
 # Check if besu binary already exists
-- name: check besu binary
+- name: Check besu binary
   stat:
     path: "{{ bin_install_dir }}/besu/besu-{{ network.version }}/besu"
   register: besu_stat_result
@@ -58,14 +57,14 @@
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
 # This task fetches the besu tar file from the mentioned URL
-- name: "Geting the besu binary tar"
+- name: "Getting the besu binary tar"
   get_url:
     url: https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/{{ network.version }}/besu-{{ network.version }}.zip
     dest: "{{ tmp_directory.path }}"
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
 # This task unzips the above downloaded tar file
-- name: "Unziping the downloaded file"
+- name: "Unzipping the downloaded file"
   unarchive:
     src: "{{ tmp_directory.path }}/besu-{{ network.version }}.zip"
     dest: "{{ tmp_directory.path }}"
@@ -87,24 +86,33 @@
     mode: 0755
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
-# This task creates the ibftConfigFile.json file from the template
-- name: Create ibftConfigFile.json
+# This task creates the ibftConfigFile.yaml file from the template
+- name: Create ibftConfigFile.yaml
   template:
     src: "ibftConfigFile.tpl"
-    dest: "{{ build_path }}/ibftConfigFile.json"
+    dest: "{{ build_path }}/ibftConfigFile.yaml"
   vars:
     total_peer_count: "{{ node_list | length }}"
     chain_id: "{{ network.config.chain_id | default(2018) | int }}"
+  when:
+    - generate_crypto is defined and generate_crypto == True
+    - add_new_org is not defined or add_new_org|bool == False
+
+# This task converts the above yaml into json format and writes it in the json file
+- name: Create ibftConfigFile.json file
+  copy:
+    content: "{{ lookup('file', '{{ build_path }}/ibftConfigFile.yaml') | from_yaml | to_nice_json }}"
+    dest: "{{ build_path }}/ibftConfigFile.json"
   when: 
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
 # This task displays the ibftConfigFile file content
 - name: Display ibftConfigFile file contents
-  debug: 
+  debug:
     msg: "The ibftConfigFile file is: {{ lookup('file', '{{ playbook_dir }}/build/ibftConfigFile.json') }}"
     verbosity: 2
-  when: 
+  when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
@@ -112,8 +120,8 @@
 - name: Generate crypto for IBFT consensus
   shell: |
     {{ bin_install_dir }}/besu/besu-{{ network.version }}/besu operator generate-blockchain-config --config-file={{ build_path }}/ibftConfigFile.json --to={{ build_path }}/crypto --private-key-file-name=key
-  when: 
-    - network.config.consensus == "ibft" and generate_crypto is defined and generate_crypto == True
+  when:
+    - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
 # This task get the list of folders
@@ -123,7 +131,7 @@
     file_type: directory
     recurse: false
   register: folder
-  when: 
+  when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
@@ -141,12 +149,11 @@
 # This task creates the organization directories for crypto material if not exists
 - name: Create organization directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ build_path }}/crypto/{{item[1].org}}/{{item[1].node}}/data"
-    check: "ensure_dir"
   with_indexed_items: "{{ node_list }}"
-  when:  
+  when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == True
 

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/templates/ibftConfigFile.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/templates/ibftConfigFile.tpl
@@ -1,24 +1,22 @@
-{
- "genesis": {
-   "config": {
-     "chainId": {{ chain_id }},
-     "constantinoplefixblock": 0,
-     "contractSizeLimit": 2147483647,
-     "ibft2": {
-       "blockperiodseconds": 2,
-       "epochlength": 30000,
-       "requesttimeoutseconds": 10
-     }
-   },
-   "nonce": "0x0",
-   "timestamp": "0x58ee40ba",
-   "gasLimit": "0x1fffffffffffff",
-   "difficulty": "0x1"
- },
- "blockchain": {
- "nodes": {
-   "generate": true,
-   "count": {{ total_peer_count }}
-   }
- }
-}
+genesis:
+  config:
+    chainId: {{ chain_id }}
+    constantinoplefixblock: 0
+    contractSizeLimit: 2147483647
+    ibft2:
+      blockperiodseconds: 2
+      epochlength: 30000
+      requesttimeoutseconds: 10
+  alloc:
+{% for key in network.config.accounts %}
+    {{ key | quote }}:
+      balance: '90000000000000000000000'
+{% endfor %}
+  nonce: '0x0'
+  timestamp: '0x58ee40ba'
+  gasLimit: '0x1fffffffffffff'
+  difficulty: '0x1'
+blockchain:
+  nodes:
+    generate: true
+    count: {{ total_peer_count }}

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/qbft/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/qbft/tasks/main.yaml
@@ -9,7 +9,7 @@
   set_fact:
     node_list: []
 
-# This tasks checks the crypto material in the vault
+# This task checks the crypto material in the vault
 - name: Check for the crypto material in the vault
   include_tasks: check_vault.yaml
   vars:
@@ -30,10 +30,9 @@
 # This task creates the build directory
 - name: Create build directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/build"
-    check: "ensure_dir"
   when: generate_crypto is defined and generate_crypto == True
 
 # This task creates the bin directory, if it doesn't exist, for storing the geth binary
@@ -44,7 +43,7 @@
   when: generate_crypto is defined and generate_crypto == True
 
 # Check if besu binary already exists
-- name: check besu binary
+- name: Check besu binary
   stat:
     path: "{{ bin_install_dir }}/besu/besu-{{ network.version }}/besu"
   register: besu_stat_result
@@ -58,14 +57,14 @@
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
 # This task fetches the besu tar file from the mentioned URL
-- name: "Geting the besu binary tar"
+- name: "Getting the besu binary tar"
   get_url:
     url: https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/{{ network.version }}/besu-{{ network.version }}.zip
     dest: "{{ tmp_directory.path }}"
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
 # This task unzips the above downloaded tar file
-- name: "Unziping the downloaded file"
+- name: "Unzipping the downloaded file"
   unarchive:
     src: "{{ tmp_directory.path }}/besu-{{ network.version }}.zip"
     dest: "{{ tmp_directory.path }}"
@@ -87,24 +86,33 @@
     mode: 0755
   when: generate_crypto is defined and generate_crypto == True and besu_stat_result.stat.exists == False
 
-# This task creates the qbftConfigFile.json file from the template
-- name: Create qbftConfigFile.json
+# This task creates the qbftConfigFile.yaml file from the template
+- name: Create qbftConfigFile.yaml
   template:
     src: "qbftConfigFile.tpl"
-    dest: "{{ build_path }}/qbftConfigFile.json"
+    dest: "{{ build_path }}/qbftConfigFile.yaml"
   vars:
     total_peer_count: "{{ node_list | length }}"
     chain_id: "{{ network.config.chain_id | default(2018) | int }}"
+  when:
+    - generate_crypto is defined and generate_crypto == True
+    - add_new_org is not defined or add_new_org|bool == False
+
+# This task converts the above yaml into json format and writes it in the json file
+- name: Create qbftConfigFile.json file
+  copy:
+    content: "{{ lookup('file', '{{ build_path }}/qbftConfigFile.yaml') | from_yaml | to_nice_json }}"
+    dest: "{{ build_path }}/qbftConfigFile.json"
   when: 
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
 # This task displays the qbftConfigFile file content
 - name: Display qbftConfigFile file contents
-  debug: 
+  debug:
     msg: "The qbftConfigFile file is: {{ lookup('file', '{{ playbook_dir }}/build/qbftConfigFile.json') }}"
     verbosity: 2
-  when: 
+  when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
@@ -112,8 +120,8 @@
 - name: Generate crypto for QBFT consensus
   shell: |
     {{ bin_install_dir }}/besu/besu-{{ network.version }}/besu operator generate-blockchain-config --config-file={{ build_path }}/qbftConfigFile.json --to={{ build_path }}/crypto --private-key-file-name=key
-  when: 
-    - network.config.consensus == "qbft" and generate_crypto is defined and generate_crypto == True
+  when:
+    - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
 # This task get the list of folders
@@ -123,7 +131,7 @@
     file_type: directory
     recurse: false
   register: folder
-  when: 
+  when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == False
 
@@ -141,12 +149,11 @@
 # This task creates the organization directories for crypto material if not exists
 - name: Create organization directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ build_path }}/crypto/{{item[1].org}}/{{item[1].node}}/data"
-    check: "ensure_dir"
   with_indexed_items: "{{ node_list }}"
-  when:  
+  when:
     - generate_crypto is defined and generate_crypto == True
     - add_new_org is not defined or add_new_org|bool == True
 

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/qbft/templates/qbftConfigFile.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/qbft/templates/qbftConfigFile.tpl
@@ -1,24 +1,22 @@
-{
- "genesis": {
-   "config": {
-     "chainId": {{ chain_id }},
-     "constantinoplefixblock": 0,
-     "contractSizeLimit": 2147483647,
-     "qbft": {
-       "blockperiodseconds": 2,
-       "epochlength": 30000,
-       "requesttimeoutseconds": 10
-     }
-   },
-   "nonce": "0x0",
-   "timestamp": "0x58ee40ba",
-   "gasLimit": "0x1fffffffffffff",
-   "difficulty": "0x1"
- },
- "blockchain": {
-   "nodes": {
-      "generate": true,
-      "count": {{ total_peer_count }}
-    }
- }
-}
+genesis:
+  config:
+    chainId: {{ chain_id }}
+    constantinoplefixblock: 0
+    contractSizeLimit: 2147483647
+    qbft:
+      blockperiodseconds: 2
+      epochlength: 30000
+      requesttimeoutseconds: 10
+  alloc:
+{% for key in network.config.accounts %}
+    {{ key | quote }}:
+      balance: '90000000000000000000000'
+{% endfor %}
+  nonce: '0x0'
+  timestamp: '0x58ee40ba'
+  gasLimit: '0x1fffffffffffff'
+  difficulty: '0x1'
+blockchain:
+  nodes:
+    generate: true
+    count: {{ total_peer_count }}

--- a/platforms/hyperledger-besu/configuration/roles/create/helm_component/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/helm_component/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This task ensures that the directory exists, and creates it, if it does not exist
 - name: "Ensures {{ values_dir }}/{{ name }} dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ values_dir }}/{{ name }}"
-    check: "ensure_dir"
 
 ############################################################################################
 # This task creates the value file for the helm release

--- a/platforms/hyperledger-besu/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: vault-reviewer
   namespace: {{ component_name }}
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: {{ component_name }}

--- a/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/validator_node/tasks/main.yaml
@@ -42,10 +42,9 @@
 # This task creates the build directory
 - name: Create build directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/build"
-    check: "ensure_dir"
   when: (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)
 
 # This task creates the bin directory, if it doesn't exist, for storing the geth binary
@@ -109,10 +108,9 @@
 # This task creates the organization directories for crypto material if not exists
 - name: Create organization directory if it does not exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ build_path }}/crypto/{{item[1].org}}/{{item[1].node}}/data"
-    check: "ensure_dir"
   with_indexed_items: "{{ enode_validator_list }}"
   when:  
     - (network.crypto_only is defined and network.crypto_only == true) or (network.crypto_only is undefined)

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-new-memberorg.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-new-memberorg.yaml
@@ -54,6 +54,10 @@ network:
     tm_trust: "ca-or-tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
     ## File location for saving the genesis file should be provided.
     genesis: "/home/user/bevel/build/besu_genesis"   # Location where genesis file will be fetched
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
     ## Transaction Manager nodes public addresses should be provided.
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com:15013"
     # The above domain name is formed by the (http or https)://(peer.name).(org.external_url_suffix):(ambassador orion node port)
@@ -120,6 +124,7 @@ network:
           subject: "O=Neworg,OU=Neworg,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           geth_passphrase: "12345"  # Passphrase to be used to generate geth account
           lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15020       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-new-validatornode.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-new-validatornode.yaml
@@ -54,6 +54,10 @@ network:
     tm_trust: "ca-or-tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
     ## File location for saving the genesis file should be provided.
     genesis: "/home/user/bevel/build/besu_genesis"   # Location where genesis file will be fetched
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
     ## Transaction Manager nodes public addresses should be provided.
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com:15013"
     # The above domain name is formed by the (http or https)://(peer.name).(org.external_url_suffix):(ambassador orion node port)
@@ -114,6 +118,7 @@ network:
           name: validator1
           status: existing        # needed to know which  validator node exists
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: enabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -162,6 +167,7 @@ network:
           name: validator5
           status: new        # needed to know which  validator node exists
           bootnode: false          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15018       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-new-validatororg.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-new-validatororg.yaml
@@ -54,6 +54,10 @@ network:
     tm_trust: "ca-or-tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
     ## File location for saving the genesis file should be provided.
     genesis: "/home/user/bevel/build/besu_genesis"   # Location where genesis file will be fetched
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
     ## Transaction Manager nodes public addresses should be provided.
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com:15013"
     # The above domain name is formed by the (http or https)://(peer.name).(org.external_url_suffix):(ambassador orion node port)
@@ -114,6 +118,7 @@ network:
           name: validator1
           status: existing        # needed to know which  validator node exists
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -200,6 +205,7 @@ network:
           name: validator5
           status: new        # needed to know which  validator node exists
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: enabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15026       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-v22.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-v22.yaml
@@ -53,6 +53,10 @@ network:
     tm_trust: "tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
     ## File location for saving the genesis file should be provided.
     genesis: "/home/user/bevel/build/besu_genesis"   # Location where genesis file will be saved
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
     ## At least one Transaction Manager nodes public addresses should be provided.
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com:15022" for orion
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com" for tessera
@@ -104,6 +108,7 @@ network:
         - validator:
           name: validator1
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: enabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -115,6 +120,7 @@ network:
         - validator:
           name: validator2
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15012       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -189,6 +195,7 @@ network:
           subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           geth_passphrase: "12345"  # Passphrase to be used to generate geth account
           lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15020       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -250,6 +257,7 @@ network:
           subject: "O=Manufacturer,OU=Manufacturer,L=47.38/8.54/Zurich,C=CH"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
           geth_passphrase: "12345"  # Passphrase to be used to generate geth account
           lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15030       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -309,6 +317,7 @@ network:
           subject: "O=Store,OU=Store,L=40.73/-74/New York,C=US" # This is the node identity. L=lat/long is mandatory for supplychain sample app
           geth_passphrase: "12345"  # Passphrase to be used to generate geth account
           lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15040       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
@@ -61,6 +61,10 @@ network:
     tm_trust: "tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
     ## File location for saving the genesis file should be provided.
     genesis: "/home/user/bevel/build/besu_genesis"   # Location where genesis file will be saved
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
     ## At least one Transaction Manager nodes public addresses should be provided.
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com:15022" for orion
     #  - "https://node.test.besu.blockchaincloudpoc-develop.com" for tessera
@@ -112,6 +116,7 @@ network:
         - validator:
           name: validator1
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -197,6 +202,7 @@ network:
           subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           geth_passphrase: "12345"  # Passphrase to be used to generate geth account
           lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15020       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/hyperledger-besu/configuration/samples/network-proxy-none.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-proxy-none.yaml
@@ -62,6 +62,10 @@ network:
     tm_trust: "tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
     ## File location for saving the genesis file should be provided.
     genesis: "/home/bevel/build/besu_genesis"   # Location where genesis file will be saved
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
     ## At least one Transaction Manager nodes public addresses should be provided.
     #  - "https://carrier.carrier-bes:15022" for orion
     #  - "https://carrier-tessera.carrier-bes" for tessera
@@ -114,6 +118,7 @@ network:
         - validator:
           name: validator1
           bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -200,6 +205,7 @@ network:
           subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           geth_passphrase: "12345"  # Passphrase to be used to generate geth account
           lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
           p2p:
             port: 30303
             ambassador: 15020       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/hyperledger-besu/configuration/setup-cactus-connector.yaml
+++ b/platforms/hyperledger-besu/configuration/setup-cactus-connector.yaml
@@ -1,0 +1,31 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+#######################################
+# Playbook to setup the environment for running Hyperledger Bevel configurations
+#  - checks and installs kubectl, helm and vault clients
+#  - If cloud platform is AWS, checks and installs aws-cli and aws-authenticator
+#######################################
+- hosts: ansible_provisioners
+  gather_facts: yes
+  no_log: "{{ no_ansible_log | default(false) }}"
+  tasks:
+  - include_role:
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/cactus-connector"
+    vars:
+      component_ns: "{{ item.name | lower }}-bes"
+      members: "{{ item.services.peers is defined | ternary(item.services.peers, item.services.validators) }}"
+      vault: "{{ item.vault }}"
+      gitops: "{{ item.gitops }}"
+      charts_dir: "platforms/hyperledger-besu/charts"
+      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}"
+    with_items: "{{ network.organizations }}"
+  vars: #These variables can be overriden from the command line
+    privilege_escalate: false           #Default to NOT escalate to root privledges
+    install_os: "linux"                 #Default to linux OS
+    install_arch:  "amd64"              #Default to amd64 architecture
+    bin_install_dir:  "~/bin"           #Default to ~/bin install directory for binaries

--- a/platforms/hyperledger-fabric/charts/fabric-connector/.helmignore
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/platforms/hyperledger-fabric/charts/fabric-connector/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/Chart.yaml
@@ -1,0 +1,12 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+apiVersion: v2
+name: fabric-connector
+description: A Helm chart for Cactus Fabric Connector
+type: application
+version: 0.1.0
+# For Cactus release 1.1.3
+appVersion: "1.1.3"

--- a/platforms/hyperledger-fabric/charts/fabric-connector/templates/_helpers.tpl
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/hyperledger-fabric/charts/fabric-connector/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/templates/configmap.yaml
@@ -1,0 +1,55 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-plugins
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-plugins
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "labels.custom" . | nindent 2 }}
+data:
+  PLUGINS: |
+    {
+      "packageName": {{ .Values.plugins.packageName | quote }},
+      "type": {{ .Values.plugins.type | quote }},
+      "action": {{ .Values.plugins.action | quote }},
+      "options": {
+        "instanceId": {{ .Values.plugins.instanceId | quote }},
+        "dockerBinary": {{ .Values.plugins.dockerBinary | quote }},
+        "peerBinary": "not-required",
+        "connectionProfile": "{\"name\":\"test-network-org1\",\"version\":\"1.0.0\",\"client\":{\"organization\":\"{{ .Values.peer.localmspid }}\",\"connection\":{\"timeout\":{\"peer\":{\"endorser\":\"300\"}}}},\"organizations\":{\"{{ .Values.peer.localmspid }}\":{\"mspid\":\"{{ .Values.peer.localmspid }}\",\"peers\":[\"{{ .Values.peer.peerID }}\"],\"certificateAuthorities\":[\"{{ .Values.plugins.caName }}\"]}},\"peers\":{\"{{ .Values.peer.peerID }}\":{\"url\":\"grpcs://{ .Values.peer.address }}\",\"tlsCACerts\":{\"path\":\"{{ .Values.plugins.corePeerAdmincertFile }}\"},\"grpcOptions\":{\"ssl-target-name-override\":\"{{ .Values.peer.peerID }}\",\"hostnameOverride\":\"{{ .Values.peer.peerID }}\"}}},\"certificateAuthorities\":{\"{{ .Values.plugins.caName }}\":{\"url\":\"https://{ .Values.plugins.caAddress }}\",\"caName\":\"{{ .Values.plugins.caName }}\",\"tlsCACerts\":{\"path\":\"{{ .Values.plugins.corePeerTlsRootcertFile }}\"},\"httpOptions\":{\"verify\":false}}}}",
+        "logLevel": "DEBUG",
+        "sshConfig": {},
+        "cliContainerEnv": {},
+        "discoveryOptions": {
+          "enabled": {{ .Values.plugins.discoveryEnabled  | quote }},
+          "asLocalhost": {{ .Values.plugins.asLocalhost  | quote  }} 
+        },
+        "eventHandlerOptions": {
+          "strategy": "NETWORK_SCOPE_ALLFORTX",
+          "commitTimeout": "300"
+        }
+      }
+    },{
+      "packageName": "@hyperledger/cactus-plugin-keychain-vault",
+      "type": "org.hyperledger.cactus.plugin_import_type.LOCAL",
+      "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",
+      "options": {
+        "instanceId": "12345678",
+        "keychainId": "345891",
+        "logLevel": "DEBUG",
+        "endpoint": "{{ .Values.vault.address}}",
+        "apiVersion": "v1",
+        "kvSecretsMountPath": "secretsv2/data/",
+        "token": "VAULT_TOKEN"
+      }
+    }

--- a/platforms/hyperledger-fabric/charts/fabric-connector/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/templates/deployment.yaml
@@ -1,0 +1,167 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-cactus-connector
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }} 
+    {{- include "labels.custom" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-cactus-connector
+      app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }} 
+      {{- include "labels.custom" . | nindent 2 }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-cactus-connector
+        app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }} 
+        {{- include "labels.custom" . | nindent 2 }}
+    spec:
+      serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      volumes:
+      - name: certificates
+        emptyDir:
+          medium: Memory
+      {{ if .Values.vault.tls  }}
+      - name: vaultca
+        secret:
+          secretName: {{ $.Values.vault.tls }}
+          items:
+          - key: ca.crt.pem
+            path: ca-certificates.crt
+      {{ end  }}
+      initContainers:
+      - name: certificates-init
+        image: {{ $.Values.image.alpineutils }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VAULT_ADDR
+          value: {{ $.Values.vault.address }}
+        - name: KUBERNETES_AUTH_PATH
+          value: {{ $.Values.vault.authpath }}
+        - name: VAULT_APP_ROLE
+          value: {{ $.Values.vault.role }}
+        - name: VAULT_PEER_SECRET_PREFIX
+          value: "{{ $.Values.vault.adminsecretprefix }}"
+        - name: VAULT_ORDERER_SECRET_PREFIX
+          value: "{{ $.Values.vault.orderersecretprefix }}"
+        - name: MOUNT_PATH
+          value: "/secret"
+        command: ["sh", "-c"]
+        args:
+        - |-
+          #!/usr/bin/env sh
+          validateVaultResponse () {
+            if echo ${2} | grep "errors" || [ "${2}" = "" ]; then
+              echo "ERROR: unable to retrieve ${1}: ${2}"
+              exit 1
+            fi
+            if  [ "$3" == "LOOKUPSECRETRESPONSE" ]
+            then
+              http_code=$(curl -fsS -o /dev/null -w "%{http_code}" \
+              --header "X-Vault-Token: ${VAULT_CLIENT_TOKEN}" \
+              ${VAULT_ADDR}/v1/${vault_secret_key})
+              curl_response=$?
+              if test "$http_code" != "200" ; then
+                  echo "Http response code from Vault - $http_code"
+                  if test "$curl_response" != "0"; then
+                     echo "Error: curl command failed with error code - $curl_response"
+                     exit 1
+                  fi
+              fi
+            fi
+          }
+
+          KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          echo "Getting secrets from Vault Server: ${VAULT_ADDR}"
+          # Login to Vault and so I can get an approle token
+          VAULT_CLIENT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/${KUBERNETES_AUTH_PATH}/login \
+            -H "Content-Type: application/json" \
+            -d '{"role":"'"${VAULT_APP_ROLE}"'","jwt":"'"${KUBE_SA_TOKEN}"'"}' | \
+            jq -r 'if .errors then . else .auth.client_token end')
+          validateVaultResponse 'vault login token' "${VAULT_CLIENT_TOKEN}"
+
+          vault_secret_key="${VAULT_ORDERER_SECRET_PREFIX}/tls"
+          echo "Getting Orderer TLS certificates from Vault using key $vault_secret_key"
+
+          OUTPUT_PATH="${MOUNT_PATH}/orderer/tls"
+          LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_CLIENT_TOKEN}" ${VAULT_ADDR}/v1/${vault_secret_key} | jq -r 'if .errors then . else . end')
+
+          validateVaultResponse "secret (${vault_secret_key})" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
+
+          TLS_CA_CERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data.data["ca.crt"]')
+
+          mkdir -p ${OUTPUT_PATH}
+          echo "${TLS_CA_CERT}" >> ${OUTPUT_PATH}/ca.crt
+
+          vault_secret_key="${VAULT_PEER_SECRET_PREFIX}/msp"
+          echo "Getting MSP certificates from Vault using key $vault_secret_key"
+
+          OUTPUT_PATH="${MOUNT_PATH}/admin/msp"
+          LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_CLIENT_TOKEN}" ${VAULT_ADDR}/v1/${vault_secret_key} | jq -r 'if .errors then . else . end')
+          validateVaultResponse "secret (${vault_secret_key})" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
+
+          ADMINCERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data.data["admincerts"]')
+          CACERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data.data["cacerts"]')
+          KEYSTORE=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data.data["keystore"]')
+          SIGNCERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data.data["signcerts"]')
+          TLSCACERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data.data["tlscacerts"]')
+
+          mkdir -p ${OUTPUT_PATH}/admincerts
+          mkdir -p ${OUTPUT_PATH}/cacerts
+          mkdir -p ${OUTPUT_PATH}/keystore
+          mkdir -p ${OUTPUT_PATH}/signcerts
+          mkdir -p ${OUTPUT_PATH}/tlscacerts
+
+          echo "${ADMINCERT}" >> ${OUTPUT_PATH}/admincerts/admin.crt
+          echo "${CACERTS}" >> ${OUTPUT_PATH}/cacerts/ca.crt
+          echo "${KEYSTORE}" >> ${OUTPUT_PATH}/keystore/server.key
+          echo "${SIGNCERTS}" >> ${OUTPUT_PATH}/signcerts/server.crt
+          echo "${TLSCACERTS}" >> ${OUTPUT_PATH}/tlscacerts/tlsca.crt
+        volumeMounts:
+        - name: certificates
+          mountPath: /secret
+        {{ if .Values.vault.tls  }}
+        - name: vaultca
+          mountPath: "/etc/ssl/certs/"
+          readOnly: true
+        {{ end }}
+      containers:
+      - name: cactus-connector
+        image: {{ .Values.image.repository | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy}}
+        ports:
+        - name: http
+          containerPort: 4000
+          protocol: TCP
+        env:
+        - name: AUTHORIZATION_PROTOCOL
+          value: {{  .Values.envs.authorizationProtocol | quote  }}
+        - name: AUTHORIZATION_CONFIG_JSON
+          value: {{  .Values.envs.authorizationConfigJson | quote  }}
+        - name: GRPC_TLS_ENABLED
+          value: {{  .Values.envs.grpcTlsEnabled | quote  }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-plugins
+        volumeMounts:
+        - name: certificates
+          mountPath: /opt/gopath/src/github.com/hyperledger/fabric/crypto

--- a/platforms/hyperledger-fabric/charts/fabric-connector/templates/service.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/templates/service.yaml
@@ -1,0 +1,71 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Release.Name }}-svc
+  annotations:
+    {{- if eq $.Values.proxy.provider "ambassador" }}
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v2
+      kind: Mapping
+      name: {{ .Release.Name }}-svc-mapping
+      prefix: /
+      service: {{ .Release.Name }}-svc.{{ .Values.metadata.namespace }}:{{ .Values.service.port }}
+      host: {{ .Release.Name }}-svc.{{ .Values.proxy.external_url }}
+      tls: false
+      ---
+      apiVersion: ambassador/v2
+      kind: TLSContext
+      name: {{ .Release.Name }}_mapping_tlscontext
+      hosts:
+      - {{ .Release.Name }}-svc.{{ .Values.proxy.external_url }}
+      secret: {{ .Values.peer.name }}-cc-ambassador-certs.{{ .Values.metadata.namespace }}
+      secret_namespacing: true
+      min_tls_version: v1.2
+    {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-svc
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }} 
+    {{- include "labels.custom" . | nindent 2 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.service.port }}
+    targetPort: http
+  selector:
+    name: {{ .Release.Name }}-cactus-connector
+{{- if eq $.Values.proxy.provider "haproxy" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-svc
+  namespace:  {{ $.Values.metadata.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: "haproxy"
+    ingress.kubernetes.io/ssl-passthrough: "true"
+spec:
+  rules:
+  - host: {{ .Release.Name }}-svc.{{ .Values.proxy.external_url }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-svc
+            port:
+              number: {{ .Values.service.port }}
+{{- end }}

--- a/platforms/hyperledger-fabric/charts/fabric-connector/values.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/values.yaml
@@ -1,0 +1,86 @@
+
+metadata:
+  # Namespace where this deployment will be created
+  namespace: manufacturer-net
+
+# Number of replicas
+replicaCount: 1
+
+image:
+  # Docker image of the API server
+  repository: ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3
+  # Docker image of the alpine utils
+  alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
+  # Pull policy of the docker image
+  pullPolicy: IfNotPresent
+
+service:
+  # Service type for the Cactus API server
+  type: ClusterIP
+  # Port for the above service
+  port: 4000
+
+# Cactus connector plugin details for Fabric
+plugins:
+  # Package name, type and action for the besu connector
+  packageName: "@hyperledger/cactus-plugin-ledger-connector-fabric"
+  type: org.hyperledger.cactus.plugin_import_type.LOCAL
+  action: org.hyperledger.cactus.plugin_import_action.INSTALL
+  # Unique instance id in case multiple connectors are deployed
+  instanceId: "12345678"
+  # plugin parameters for cactus-plugin-ledger-connector-fabric
+  dockerBinary: "usr/local/bin/docker"
+  caName: ca.manufacturer-net
+  caAddress: ca.manufacturer-net:7054
+  corePeerMSPconfigpath: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp"
+  corePeerAdmincertFile: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt"
+  corePeerTlsRootcertFile: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt"
+  ordererTlsRootcertFile: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+  discoveryEnabled: "true"
+  asLocalhost: "true"
+
+# Additional env details for Cactus connector
+envs:
+  authorizationProtocol: "NONE"
+  authorizationConfigJson: "{}"
+  grpcTlsEnabled: "false"
+
+# Proxy details to expose Connector service over Internet
+proxy:
+  # Only haproxy is supported
+  provider: "haproxy"
+  # Complete external url will be https://<besuNode>.<external_url>
+  external_url: manufacturer-net.hf.demo.aws.blockchaincloudpoc.com
+
+vault:
+  #Provide the vaultrole for an organization
+  role: vault-role
+  #Provide the vault server address
+  address: http://vault.internal.demo.aws.blockchaincloudpoc.com:9001
+  #Provide the kubernetes auth backed configured in vault for an organization
+  authpath: demo-fabricmanufacturer-net-auth
+  #Provide the value for vault secretprefix
+  adminsecretprefix: secretsv2/data/crypto/peerOrganizations/manufacturer-net/users/admin
+  #Provide the value for vault secretprefix
+  orderersecretprefix: secretsv2/data/crypto/peerOrganizations/manufacturer-net/orderer
+  #Provide the serviceaccountname for vault
+  serviceaccountname: vault-auth
+  #Kuberenetes secret for vault ca.cert
+  #Enable or disable TLS for vault communication if value present or not
+  tls: false
+
+peer:
+  #Provide the name of the peer as per deployment yaml.
+  name: peer0
+  peerID: peer0.manufacturer-net
+  #Provide the localmspid for organization
+  localmspid: manufacturerMSP
+  #Provide the value for tlsstatus to be true or false for organization's peer
+  #Eg. tlsstatus: true
+  tlsstatus: true
+  #Provide the address for the peer
+  address: peer0.manufacturer-net:7051
+
+orderer:
+  #Provide the address for orderer
+  address: orderer1.supplychain-net:7050

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-server/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-server/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This task creates the folder to store crypto material
 - name: "creating the directory ./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca"
-    check: "ensure_dir"
 
 - name: Check if CA key already exists in vault.
   include_role:

--- a/platforms/hyperledger-fabric/configuration/roles/create/storageclass/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/storageclass/tasks/main.yaml
@@ -24,10 +24,9 @@
 # this task creates {{ component_type }} diretory if not exists
 - name: "creating {{ release_dir }}/{{ component_type }} directory"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir }}/{{ component_type }}"
-    check: "ensure_dir"
   when: get_sc.resources|length == 0
 
 #############################################################################################

--- a/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -46,7 +46,7 @@
     KUBECONFIG={{ kubernetes.config_file }} kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " "
   register: kubernetes_server_url
 
-- name: Check if CA key already exists in vault.
+- name: Check if vault policies already exists in vault.
   include_role:
     name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
   vars:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -304,7 +304,8 @@ network:
           type: anchor    # This can be anchor/nonanchor. Atleast one peer should be anchor peer.         
           gossippeeraddress: peer0.manufacturer-net:7051 # Internal Address of the other peer in same Org for gossip, same peer if there is only one peer 
           peerAddress: peer0.manufacturer-net.org2ambassador.blockchaincloudpoc.com:8443 # External URI of the peer 
-          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.   
+          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Fabric
           grpc:
             port: 7051         
           events:
@@ -391,7 +392,8 @@ network:
           type: anchor    # This can be anchor/nonanchor. Atleast one peer should be anchor peer.    
           gossippeeraddress: peer0.carrier-net:7051 # Internal Address of the other peer in same Org for gossip, same peer if there is only one peer
           peerAddress: peer0.carrier-net.org3ambassador.blockchaincloudpoc.com:8443 # External URI of the peer
-          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.          
+          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Fabric
           grpc:
             port: 7051         
           events:
@@ -477,7 +479,8 @@ network:
           type: anchor    # This can be anchor/nonanchor. Atleast one peer should be anchor peer. 
           gossippeeraddress: peer0.store-net:7051 # Internal Address of the other peer in same Org for gossip, same peer if there is only one peer 
           peerAddress: peer0.store-net.org4ambassador.blockchaincloudpoc.com:8443 # External URI of the peer
-          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.         
+          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Fabric
           grpc:
             port: 7051
           events:
@@ -564,7 +567,8 @@ network:
           type: anchor    # This can be anchor/nonanchor. Atleast one peer should be anchor peer.   
           gossippeeraddress: peer0.warehouse-net:7051 # Internal Address of the other peer in same Org for gossip, same peer if there is only one peer 
           peerAddress: peer0.warehouse-net.org5ambassador.blockchaincloudpoc.com:8443 # External URI of the peer 
-          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.        
+          cli: disabled      # Creates a peer cli pod depending upon the (enabled/disabled) tag.
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Fabric
           grpc:
             port: 7051       
           events:

--- a/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
@@ -247,7 +247,8 @@ network:
           gossippeeraddress: peer0.manufacturer-net:7051        # Internal Address of the other peer in same Org for gossip, same peer if there is only one peer  
           peerAddress: peer0.manufacturer-net:7051              # Internal URI of the peer
           certificate: /home/bevel/build/manufacturer/peer0.crt # Path to peer Certificate
-          cli: enabled                                          # Creates a peer cli pod depending upon the (enabled/disabled) tag. 
+          cli: enabled                                          # Creates a peer cli pod depending upon the (enabled/disabled) tag.
+          cactus_connector: enabled                             # set to enabled to create a cactus connector for Fabric
           grpc:
             port: 7051
           events:
@@ -344,7 +345,8 @@ network:
           gossippeeraddress: peer0.carrier-net:7051         # Internal Address of the other peer in same Org for gossip, same peer if there is only one peer  
           peerAddress: peer0.carrier-net:7051               # Internal URI of the peer
           certificate: /home/bevel/build/carrier/peer0.crt  # Path to peer Certificate
-          cli: disabled                                     # Creates a peer cli pod depending upon the (enabled/disabled) tag. 
+          cli: disabled                                     # Creates a peer cli pod depending upon the (enabled/disabled) tag.
+          cactus_connector: disabled                        # set to enabled to create a cactus connector for Fabric
           grpc:
             port: 7051
           events:

--- a/platforms/hyperledger-fabric/configuration/setup-cactus-connector.yaml
+++ b/platforms/hyperledger-fabric/configuration/setup-cactus-connector.yaml
@@ -1,0 +1,31 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+#######################################
+# Playbook to setup the environment for running Hyperledger Bevel configurations
+#  - checks and installs kubectl, helm and vault clients
+#  - If cloud platform is AWS, checks and installs aws-cli and aws-authenticator
+#######################################
+- hosts: ansible_provisioners
+  gather_facts: yes
+  no_log: "{{ no_ansible_log | default(false) }}"
+  tasks:
+  - include_role:
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/cactus-connector"
+    vars:
+      component_ns: "{{ item.name | lower }}-net"
+      members: "{{ item.services.peers }}"
+      vault: "{{ item.vault }}"
+      gitops: "{{ item.gitops }}"
+      charts_dir: "platforms/hyperledger-fabric/charts"
+      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
+    with_items: "{{ network.organizations }}"
+  vars: #These variables can be overriden from the command line
+    privilege_escalate: false           #Default to NOT escalate to root privledges
+    install_os: "linux"                 #Default to linux OS
+    install_arch:  "amd64"              #Default to amd64 architecture
+    bin_install_dir:  "~/bin"           #Default to ~/bin install directory for binaries

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/auth_job/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/auth_job/tasks/main.yaml
@@ -12,10 +12,9 @@
 # This tasks ensures the directory of auth job existance, if not exits it creates a new one
 - name: Ensures {{ release_dir }}/{{ component_type }}/{{ component_name }} dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir  }}/{{ component_type }}/{{ component_name }}"
-    check: "ensure_dir"
 
 ##############################################################################################
 # This tasks gets the kubernetes server url

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/crypto/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/crypto/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This tasks ensures the directory of crypto existance, if not exits it creates a new one
 - name: Ensures {{ release_dir }}/{{ component_type }}/{{ component_name }} dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir  }}/{{ component_type }}/{{ component_name }}"
-    check: "ensure_dir"
 
 ##############################################################################################
 # Generate Indy Crypto for trustee

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/ledger_txn/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/ledger_txn/tasks/main.yaml
@@ -12,10 +12,9 @@
 # This tasks ensures the directory of crypto existance, if not exits it creates a new one
 - name: Ensures {{ release_dir }}/{{ component_type }} dir exists
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir }}/{{ component_type }}/"
-    check: "ensure_dir" 
 
 - name: Create HelmRelease file
   include_tasks: nested_main.yaml

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/node/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/node/tasks/main.yaml
@@ -13,10 +13,9 @@
 ---
 - name: Ensures {{ release_dir }}/{{ organization }}/{{ component_name }} dir exists
   include_role:
-    name:  "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir  }}/{{ organization }}/{{ component_name }}"
-    check: "ensure_dir"
 
 ##############################################################################################
 # This task creates deployment file for stewards.

--- a/platforms/hyperledger-indy/configuration/roles/create/k8_component/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/k8_component/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This task ensures that the directory exists for each entity, if not, it creates them
 - name: Ensures {{ component_type_name }} dir exists
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir }}/{{ component_type_name }}"
-    check: "ensure_dir"
 
 ############################################################################################
 # This task creates the value file for the k8 components

--- a/platforms/hyperledger-indy/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -22,10 +22,9 @@
 # This task creates the build temp direcotry
 - name: Ensures build dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "./build"
-    check: "ensure_dir"
 
 # This task checks if the vault path already exists
 - name: Check if Kubernetes-auth already created for Organization

--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -602,6 +602,7 @@
             "peerstatus":{"type":"string","enum": ["new","existing"],"description":"Needed to add new peer organization to existing network."},
             "certificate": { "type": "string","pattern":"^(\/[^\/ ]*)+[^\/ ]+\\.crt$","description":"Certificate path for peer."},
             "cli":  { "type": "string","enum": ["enabled","disabled"],"description":"Optional field. If enabled will deploy the CLI pod for this Peer. Default is disabled."},
+            "cactus_connector":  { "type": "string","enum": ["enabled","disabled"],"description":"Optional field. If enabled will deploy the Cactus Connector for this Peer. Default is disabled."},
             "grpc":{ "$ref":"#/definitions/shared_port","description":"Grpc port"},
             "events":{ "$ref":"#/definitions/shared_port","description":"Events port"},
             "couchdb":{ "$ref":"#/definitions/shared_port","description":"Couchdb port"},
@@ -650,11 +651,12 @@
             "tm_tls": { "type": "boolean","description":"Options are True and False. This enables TLS for the transaction manager and Besu node. False is not recommended for production."},
             "tm_trust": { "type": "string","enum": ["ca-or-tofu","ca","tofu"],"description":"This is the trust relationships for the transaction managers."},
             "genesis":  { "type": "string","pattern":"^(\/[^\/ ]*)+[^\/ ]+$","description":"This is the path where genesis.json will be stored for a new network; for adding new node, the existing network's genesis.json should be available in json format in this file."},
-            "tm_nodes": { "type":"array",
+            "tm_nodes": { "type":"array", "description":"Array of the transaction manager node addresses that are available for the network",
                 "items":{"type":"string","pattern":"^https:\/\/(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?::[0-9]{2,5})?$" },"minItems": 1},
-            "besu_nodes": { "type":"array",
+            "besu_nodes": { "type":"array", "description":"Array of other Besu node addresses which will be used as bootnode",
                 "items":{"type":"string","pattern":"^(http|https):\/\/(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?::[0-9]{2,5})?$" },"minItems": 1},
-             "chain_id": {"type":"number", "description":"chainId for besu network, default value 2018"} 
+             "chain_id": {"type":"number", "description":"chainId for besu network, default value 2018"},
+             "accounts": { "type":"array", "minItems": 0, "description": "Array of accounts which start with default ETH"}
             },
           "required": [ "consensus","subject","transaction_manager","tm_version","tm_tls","tm_trust","genesis","tm_nodes"],
           "additionalProperties": false
@@ -698,6 +700,7 @@
             "name": { "type": "string","pattern": "^[a-z0-9-_]{1,30}$","description":"Name of the validator"},
             "bootnode": { "type": "boolean","description":"if the validator node is used also as bootnode for the network"},
             "status":{"type":"string","enum":["existing","new"],"description":"Used to add validator. needed to know which  validator node exists"},
+            "cactus_connector":  { "type": "string","enum": ["enabled","disabled"],"description":"Optional field. If enabled will deploy the Cactus Connector for this Validator. Default is disabled."},
             "p2p":  { "$ref":"#/definitions/shared_port_ambassador"},
             "rpc":  { "$ref":"#/definitions/shared_port_ambassador"},
             "ws": { "$ref":"#/definitions/shared_port"}
@@ -713,6 +716,7 @@
             "subject": { "type": "string", "description": "This is the alternative identity of the peer node"},
             "geth_passphrase": { "type": "string", "description": "This is the passphrase used to generate the geth account."},
             "lock":{"type":"boolean","description":"Sets Besu node to lock or unlock mode. Can be true or false"},
+            "cactus_connector":  { "type": "string","enum": ["enabled","disabled"],"description":"Optional field. If enabled will deploy the Cactus Connector for this member. Default is disabled."},
             "p2p":  { "$ref":"#/definitions/shared_port_ambassador"},
             "rpc":  { "$ref":"#/definitions/shared_port_ambassador"},
             "ws": { "$ref":"#/definitions/shared_port"},

--- a/platforms/quorum/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
@@ -11,18 +11,16 @@
 # Ensures the rootca dir directory
 - name: "Ensure rootca dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ rootca }}"
-    check: "ensure_dir"
 
 # Ensures the ambassador tls directory
 - name: "Ensure ambassadortls dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ ambassadortls }}"
-    check: "ensure_dir"
 
 # This task creates the value files for each node of organization
 - name: Create value file for ambassador job

--- a/platforms/quorum/configuration/roles/create/crypto/constellation/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/crypto/constellation/tasks/nested_main.yaml
@@ -19,10 +19,9 @@
 # This task creates the build directory if it does not exist
 - name: "Creating build directory"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "build/{{ component_name }}/{{ node.name }}"
-    check: "ensure_dir"
   when: vault_tm_result.failed == True
   tags:
     molecule-idempotence-notest

--- a/platforms/quorum/configuration/roles/create/genesis_nodekey/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/create/genesis_nodekey/tasks/main.yaml
@@ -30,10 +30,9 @@
 # This task creates the build directory if it does not exist
 - name: " Create build directory if it does not exist"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: build
-    check: "ensure_dir"
   when: vault_check|default(0)|int != 0
 
 # This task generates the istanbul files

--- a/platforms/quorum/configuration/roles/helm_component/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/helm_component/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This task ensures that the directory exists, and creates it, if it does not exist
 - name: "Ensures {{ values_dir }}/{{ name }} dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ values_dir }}/{{ name }}"
-    check: "ensure_dir"
 
 ############################################################################################
 # This task creates the value file for the helm release

--- a/platforms/quorum/configuration/roles/setup/istanbul/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/setup/istanbul/tasks/main.yaml
@@ -34,10 +34,9 @@
 # This task creates the bin directory, if it doesn't exist, for storing the istanbul binary
 - name: "Create bin directory"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ bin_install_dir }}"
-    check: "ensure_dir"
   when: istanbul_stat_result.stat.exists == False
 
 # This task puts the istanbul binary to above created bin directory

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/cenm/tasks/main.yaml
@@ -18,9 +18,8 @@
 # Create the ambassador directory if it doesn't exist
 - name: Create the Ambassador directory if it doesn't exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
-    check: "ensure_dir"
     path: "{{ tlscert_path }}"
   when: not ambassadordir_check.stat.exists
 

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/node/tasks/main.yaml
@@ -17,9 +17,8 @@
 # Create the ambassador directory if it doesn't exist
 - name: Create the Ambassador directory if it doesn't exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
-    check: "ensure_dir"
     path: "./build/ambassador/{{ node_name }}"
   when: not ambassadordir_check.stat.exists
 

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/notary/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/notary/tasks/main.yaml
@@ -17,9 +17,8 @@
 # Create the ambassador directory if it doesn't exist
 - name: Create the Ambassador directory if it doesn't exist
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
-    check: "ensure_dir"
     path: "./build/ambassador/{{ node_name }}"
   when: not ambassadordir_check.stat.exists
 

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This task ensures that the directory exists, and creates it, if it does not exist
 - name: "Ensures {{ values_dir }}/{{ name }} dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ values_dir }}/{{ name }}"
-    check: "ensure_dir"
 
 ############################################################################################
 # This task creates the value file for the helm release

--- a/platforms/r3-corda-ent/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -12,10 +12,9 @@
 # Ensures the build directory
 - name: "Creating the build directory"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "./build"
-    check: "ensure_dir"
 
 # This task checks if the vault path already exists
 - name: "Checking if the vault path already exists"

--- a/platforms/r3-corda/configuration/roles/create/certificates/ambassador/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/ambassador/tasks/main.yaml
@@ -16,9 +16,8 @@
 
 - name: Ensure ambassador tls dir exists
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
-    check: "ensure_dir"
     path: "{{ ambassadortls }}"
   when: not ambassadortlsdir_check.stat.exists
 

--- a/platforms/r3-corda/configuration/roles/create/certificates/doorman/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/doorman/tasks/main.yaml
@@ -17,10 +17,9 @@
 # create the root directory where CA root certificates and key will be placed
 - name: Ensure rootca dir exists
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ rootca }}"
-    check: "ensure_dir"
   when: not rootcadir_check.stat.exists
 
 # check if doormanca dir is there
@@ -32,10 +31,9 @@
 # create the doormanca  directory where doorman root certificates and key will be placed
 - name: Ensure doormanca dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ doormanca }}"
-    check: "ensure_dir"
   when: not doormancadir_check.stat.exists
 
 # check if mongorootca dir is there
@@ -46,10 +44,9 @@
 
 - name: Ensure mongorootca dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:  
     path: "{{ mongorootca }}"
-    check: "ensure_dir"
   when: services.doorman.tls == 'on' and (not mongorootcadir_check.stat.exists)
 
 # check if mongodbtca dir is there
@@ -60,10 +57,9 @@
 
 - name: Ensure mongodbca dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars: 
     path: "{{ mongodbca }}"
-    check: "ensure_dir"
   when: services.doorman.tls == 'on' and (not mongodbcadir_check.stat.exists)
 
 # Checks if certificates for doorman are already created and stored in vault or not

--- a/platforms/r3-corda/configuration/roles/create/certificates/nms/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/nms/tasks/main.yaml
@@ -10,32 +10,28 @@
 # create the root directory where CA root certificates and key will be placed
 - name: Ensure rootca dir exists
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ rootca }}"
-    check: "ensure_dir"
 
 - name: Ensure nmsca dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ nmsca }}"
-    check: "ensure_dir"
 
 - name: Ensure mongorootca dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars: 
     path: "{{ mongorootca }}"
-    check: "ensure_dir"
   when: services.nms.tls == 'on'
 
 - name: Ensure mongodbca dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars: 
     path: "{{ mongodbca }}"
-    check: "ensure_dir"
   when: services.nms.tls == 'on'
 
 - name: Check if root certs already created

--- a/platforms/r3-corda/configuration/roles/create/certificates/node/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/node/tasks/main.yaml
@@ -13,10 +13,9 @@
 ---
 - name: "Ensure build dir exists"
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ node_certs }}"
-    check: "ensure_dir"
 
 - name: Check if truststore already created
   shell: |

--- a/platforms/r3-corda/configuration/roles/create/certificates/notary/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/notary/tasks/main.yaml
@@ -13,10 +13,9 @@
 ---
 - name: "Ensure build dir exists"
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ notary_certs }}"
-    check: "ensure_dir"
     
 - name: Check if truststore already created
   shell: |

--- a/platforms/r3-corda/configuration/roles/create/k8_component/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/k8_component/tasks/main.yaml
@@ -21,10 +21,9 @@
 # Task to create and/or check if the target directory exists
 - name: "Ensures {{ release_dir }}/{{ component_name }} dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir }}/{{ component_name }}"
-    check: "ensure_dir"
   when: not value_file_exist.stat.exists
   
 

--- a/platforms/r3-corda/configuration/roles/create/node_component/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/node_component/tasks/main.yaml
@@ -13,10 +13,9 @@
 ---
 - name: Ensures {{ release_dir }}/{{ component_name }} dir exists
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ release_dir  }}/{{ component_name }}"
-    check: "ensure_dir" 
 
 ##############################################################################################
 # This task creates deployment file for notaries. It is executed only if is_notary is true

--- a/platforms/r3-corda/configuration/roles/setup/get_crypto/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/setup/get_crypto/tasks/main.yaml
@@ -11,10 +11,9 @@
 # Ensure admincerts directory is present in build
 - name: Ensure directory exists
   include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ cert_path }}"
-    check: "ensure_dir"
 
 # Save the cert file
 - name: Save cert

--- a/platforms/shared/charts/vault-k8s-mgmt/templates/job.yaml
+++ b/platforms/shared/charts/vault-k8s-mgmt/templates/job.yaml
@@ -119,12 +119,10 @@ spec:
                 done < /var/run/secrets/kubernetes.io/serviceaccount/ca.crt > ca_formatted.txt
 
                 KUBE_SA_CRT_ONELINE=$(cat ca_formatted.txt)
-                export REVIEWER_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token);
 
                 # This echo get the certificate for the cluster
                 echo "
                   {
-                    \"token_reviewer_jwt\": \"${REVIEWER_TOKEN}\",
                     \"kubernetes_host\": \"${KUBERNETES_URL}\",
                     \"kubernetes_ca_cert\": \"${KUBE_SA_CRT_ONELINE}\",
                     \"disable_iss_validation\": \"true\"

--- a/platforms/shared/configuration/network-schema-validator.yaml
+++ b/platforms/shared/configuration/network-schema-validator.yaml
@@ -23,10 +23,9 @@
         tempNetworkyaml: '{ "network": {{ network }} }'
     - name: "Ensures build dir exists"
       include_role:
-        name: "check/setup"
+        name: "check/directory"
       vars:
         path: "./build"
-        check: "ensure_dir"
     - name: "create tempNetwork yaml file"
       copy:
         content: |

--- a/platforms/shared/configuration/roles/check/directory/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/check/directory/tasks/main.yaml
@@ -1,0 +1,22 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+# This tasks ensures the directory existance and registers the result essential for idempotence test
+- name: "check if dir exists or not"
+  stat:
+    path: "{{ path }}"
+  register: dir_check
+
+# Check if directory is created
+# This task creates the directory
+- name: Ensures dir exists
+  file:
+    path: "{{ path }}"
+    recurse: yes
+    mode: '0755'
+    state: directory
+  when: not dir_check.stat.exists

--- a/platforms/shared/configuration/roles/check/setup/Readme.md
+++ b/platforms/shared/configuration/roles/check/setup/Readme.md
@@ -7,16 +7,6 @@
 This roles check if Namespace, Clusterrolebinding or StorageClass is created or not.
 
 ### Tasks
-(Variables with * are fetched from the playbook which is calling this role)
-#### 1. Ensures dir exists
-Task to ensure that a directory exists.
-##### Input Variables
-
-    *path: name and path of the directory
-
-**when**:  It runs when check == "ensure_dir" .
-
-
 #### 2. Check if Kubernetes-auth already created for Organization
 Task to check if kubernetes-auth is created and return the results back
 ##### Input Variables

--- a/platforms/shared/configuration/roles/check/setup/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/check/setup/tasks/main.yaml
@@ -5,23 +5,6 @@
 ##############################################################################################
 
 ---
-# This tasks ensures the directory existance and registers the result essential for idempotence test
-- name: "check if dir exists or not"
-  stat:
-    path: "{{ path }}"
-  register: dir_check
-  when: check == "ensure_dir"
-
-# Check if directory is created
-# This task creates the directory
-- name: Ensures dir exists
-  file:
-    path: "{{ path }}"
-    recurse: yes
-    mode: '0755'
-    state: directory
-  when: check == "ensure_dir" and (not dir_check.stat.exists)
-  
 # This task checks if the vault path already exists
 - name: Check if Kubernetes-auth already created for Organization
   shell: |
@@ -85,5 +68,6 @@
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
+  ignore_errors: yes
   register: certs_created
   when: check == "certs_created"

--- a/platforms/shared/configuration/roles/create/shared_helm_component/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/create/shared_helm_component/tasks/main.yaml
@@ -13,10 +13,9 @@
 # This task ensures that the directory exists, and creates it, if it does not exist
 - name: "Ensures {{ values_dir }}/{{ name }} dir exists"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ values_dir }}/{{ name }}"
-    check: "ensure_dir"
 
 ############################################################################################
 # This task creates the value file for the helm release

--- a/platforms/shared/configuration/roles/helm_lint/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/helm_lint/tasks/main.yaml
@@ -21,10 +21,9 @@
 # create temp test directory
 - name: "Check or create test directory"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "./build/test"
-    check: "ensure_dir"
   when: value_stat_result.stat.exists == True
 
 # create temp test directory

--- a/platforms/shared/configuration/roles/helm_lint/vars/main.yaml
+++ b/platforms/shared/configuration/roles/helm_lint/vars/main.yaml
@@ -65,3 +65,5 @@ charts:
   ambassador_besu: generate_ambassador_certs
   certs-ambassador-quorum: certs-ambassador-quorum
   crypto_raft_job: crypto_raft
+  fabric-connector: fabric-connector
+  besu-connector: besu-connector

--- a/platforms/shared/configuration/roles/setup/aws-cli/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/aws-cli/tasks/main.yaml
@@ -39,10 +39,9 @@
 
   - name: create bin directory
     include_role:
-      name: "check/setup"
+      name: "check/directory"
     vars:
       path: "{{ aws_cli.bin_directory }}"
-      check: "ensure_dir"
     when: not aws_cli_stat_result.stat.exists
     tags:
       - aws_cli

--- a/platforms/shared/configuration/roles/setup/cactus-connector/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/tasks/main.yaml
@@ -1,0 +1,18 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# This role calls nested_main.yaml for each member/peer
+---
+- name: Create Cactus connector
+  include_tasks: nested_main.yaml
+  vars:
+    name: "{{ member.name | lower }}"
+  loop: "{{ members }}"
+  loop_control:
+    loop_var: member
+  when: 
+  - member.cactus_connector is defined
+  - member.cactus_connector == "enabled"

--- a/platforms/shared/configuration/roles/setup/cactus-connector/tasks/nested_main.yaml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/tasks/nested_main.yaml
@@ -1,0 +1,41 @@
+# ############################################################################################
+# This role generates the value file for the helm release of cactus-connector chart 
+# ############################################################################################
+
+############################################################################################
+# This task ensures that the directory exists, and creates it, if it does not exist
+- name: "Ensures {{ values_dir }}/{{ name }} dir exists"
+  file:
+    path: "{{ values_dir }}/{{ name }}"
+    state: directory
+
+###########################################################################################
+
+# This task creates the value file for the helm release
+# This is done by consuming a template file which is passes as a variable by the role
+# including this helm_component role
+- name: "create value file for cactus-connector in {{ component_ns }}"
+  template:
+    src: "{{ helm_templates[network.type] | default('helm_component.tpl') }}"
+    dest: "{{ values_dir }}/{{ name }}/cactus-connector.yaml"
+
+###########################################################################################
+# This task tests the value file for syntax errors/ missing values
+# This is done by calling the helm_lint role and passing the value file parameter
+# When a new helm_component is added, changes should be made in helm_lint role as well
+- name: Helm lint
+  include_role: 
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/helm_lint"
+  vars:
+    helmtemplate_type: "{{ network.type }}-connector"
+    chart_path: "{{ charts_dir }}"
+    value_file: "{{ values_dir }}/{{ name }}/cactus-connector.yaml"
+
+# Git Push : Pushes the above generated files to git directory 
+- name: Git Push
+  include_role: 
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
+  vars:
+    GIT_DIR: "{{ playbook_dir }}/../../../"    
+    GIT_RESET_PATH: "platforms/shared/configuration"
+    msg: "[ci skip] Pushing cactus-connector release"

--- a/platforms/shared/configuration/roles/setup/cactus-connector/templates/besu-connector.tpl
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/templates/besu-connector.tpl
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: {{ name }}-cactus
+  namespace: {{ component_ns }}
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: {{ name }}-cactus
+  interval: 1m
+  chart:
+   spec:
+    chart: {{ charts_dir }}/besu-connector
+    sourceRef:
+      kind: GitRepository
+      name: flux-{{ network.env.type }}
+      namespace: flux-{{ network.env.type }}
+  values:
+    metadata:
+      namespace: {{ component_ns }}
+      labels:
+    replicaCount: 1
+    images:
+      repository: ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3
+    plugins:
+      besuNode: {{ member.name }}
+      instanceId: 12345678
+      rpcApiHttpHost: http://{{ member.name }}.{{ component_ns }}:{{ member.rpc.port }}
+      rpcApiWsHost: ws://{{ member.name }}.{{ component_ns }}:{{ member.ws.port }}      
+    envs:
+      authorizationProtocol: "NONE"
+      authorizationConfigJson: "{}"
+      grpcTlsEnabled: "false"
+    proxy:
+      provider: {{ network.env.proxy }}
+      external_url: {{ item.external_url_suffix }}

--- a/platforms/shared/configuration/roles/setup/cactus-connector/templates/fabric-connector.tpl
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/templates/fabric-connector.tpl
@@ -1,0 +1,58 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: {{ name }}-cactus
+  namespace: {{ component_ns }}
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: {{ name }}-cactus
+  interval: 1m
+  chart:
+   spec:
+    chart: {{ charts_dir }}/fabric-connector
+    sourceRef:
+      kind: GitRepository
+      name: flux-{{ network.env.type }}
+      namespace: flux-{{ network.env.type }}
+  values:
+    metadata:
+      namespace: {{ component_ns }}
+      labels:
+    replicaCount: 1
+    images:
+      repository: ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3
+    plugins:
+      instanceId: "12345678"
+      dockerBinary: "usr/local/bin/docker"
+      caName: ca.{{ component_ns }}
+      caAddress: ca.{{ component_ns }}:7054
+      corePeerMSPconfigpath: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp"
+      corePeerAdmincertFile: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt"
+      corePeerTlsRootcertFile: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt"
+      ordererTlsRootcertFile: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+      discoveryEnabled: "true"
+      asLocalhost: "true"
+    envs:
+      authorizationProtocol: "NONE"
+      authorizationConfigJson: "{}"
+      grpcTlsEnabled: "false"
+    proxy:
+      provider: {{ network.env.proxy }}
+      external_url: {{ item.external_url_suffix }}
+    vault:
+      role: vault-role
+      address: {{ vault.url }}
+      authpath: {{ network.env.type }}{{ component_ns }}-auth
+      adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/users/admin
+      orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/orderer
+      serviceaccountname: vault-auth
+      tls: false
+    peer:
+      name: {{ member.name }}
+      peerID: {{ member.name }}.{{ component_ns }}
+      localmspid: {{ item.name | lower}}MSP
+      tlsstatus: true
+      address: {{ member.name }}.{{ component_ns }}:7051
+    orderer:
+      address: {{ network.orderers[0].uri }}

--- a/platforms/shared/configuration/roles/setup/cactus-connector/vars/main.yml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/vars/main.yml
@@ -1,0 +1,4 @@
+
+helm_templates:
+  fabric: fabric-connector.tpl
+  besu: besu-connector.tpl

--- a/platforms/shared/configuration/roles/setup/helm/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/helm/tasks/main.yaml
@@ -42,10 +42,9 @@
 
   - name: create bin directory
     include_role:
-      name: "check/setup"
+      name: "check/directory"
     vars:
       path: "{{ helm.bin_directory }}"
-      check: "ensure_dir"
     when: not helm_stat_result.stat.exists
     tags:
       - helm

--- a/platforms/shared/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -41,10 +41,9 @@
 # Ensures the build directory
 - name: "Creating the build directory"
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
   vars:
     path: "{{ playbook_dir }}/build"
-    check: "ensure_dir"
 
 #####################################################################################################################
 # This task creates the access policy for various Substrate entity


### PR DESCRIPTION
[besu] Add cactus-connectors and Add pre-configured accounts
   - Add Cactus-Connectors for Besu and Fabric
   - Add pre-configured accounts for Besu via network.yaml
   - Fix vault-auth issue with Kubernetes restarts
   - Fix issue with `platforms/shared/configuration/roles/check/setup` resetting other ansible vars showing errors like <varname>.failed not found
   - Add new role `platforms/shared/configuration/roles/check/directory` to replace ensure_dir in `check/setup`


Fixes #1827
