### PR TITLE
[besu] fixed the helm ansible module for TLS cert creation using cert manager

### DIFF
--- a/platforms/hyperledger-besu/configuration/reset-network.yaml
+++ b/platforms/hyperledger-besu/configuration/reset-network.yaml
@@ -41,7 +41,7 @@
         loop_var: organizationItem
       when:
         - network.type == "besu"
-        - organizationItem.issuer|lower == "letsencrypt"
+        - (organizationItem.issuer is defined) and (organizationItem.issuer|lower == "letsencrypt")
 
     # Uninstalling Flux is needed so that everything is clean
     # remove this if not needed

--- a/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/main.yaml
@@ -84,7 +84,7 @@
   shell: |
     KUBECONFIG={{ kubernetes.config_file }} helm upgrade --install letsencrypt-clusterissuer --set namespace="{{ component_ns }}" --set email="{{ gitops.email }}" {{ playbook_dir }}/../../../platforms/shared/charts/letsencrypt-issuer
   when: 
-    - organizationItem.issuer|lower == "letsencrypt"
+    - (organizationItem.issuer is defined) and (organizationItem.issuer|lower == "letsencrypt")
 
 # Checks if ClusterIssuer is up and ready
 - name: check for an existing ClusterIssuer and wait for it to be ready
@@ -97,7 +97,7 @@
   delay: 20
   until: cissuer.resources[0].status.conditions[0].status|lower == "true"
   when: 
-    - organizationItem.issuer|lower == "letsencrypt"
+    - (organizationItem.issuer is defined) and (organizationItem.issuer|lower == "letsencrypt")
     
 - name: Create Ambassador certificates
   include_tasks: nested_main.yaml

--- a/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
@@ -17,11 +17,10 @@
 
 # Creates TLS certificate  
 - name: Create TLS certificate  
-  kubernetes.core.helm:
   shell: |
     KUBECONFIG={{ kubernetes.config_file }} helm upgrade --install "letsencrypt-cert-{{node_name}}" --set nodename="{{ node_name }}" --set namespace="{{ component_ns }}" --set externalurlsuffix="{{ organizationItem.external_url_suffix }}" {{ playbook_dir }}/../../../platforms/shared/charts/letsencrypt-cert
   when: 
-    - organizationItem.issuer|lower == "letsencrypt"
+    - (organizationItem.issuer is defined) and (organizationItem.issuer|lower == "letsencrypt")
 
 # Create ambassador certs helmrelease file
 - name: "Create ambassador certs helmrelease file"
@@ -35,7 +34,7 @@
     tm_clientport: "{{ node.tm_clientport.port | default('8888') }}"
     tls_enabled: "{{ network.config.tm_tls }}"
   when:
-    - (organizationItem.issuer|lower == "default") or (organizationItem.issuer is undefined)
+    - (organizationItem.issuer is undefined) or (organizationItem.issuer|lower == "default")
         
 # push the created deployment files to repository
 - name: "Push the created deployment files to repository"
@@ -55,7 +54,7 @@
     component_type: Job
     namespace: "{{ component_ns }}"
   when:
-    - (organizationItem.issuer|lower == "default") or (organizationItem.issuer is undefined)
+    - (organizationItem.issuer is undefined) or (organizationItem.issuer|lower == "default")
 
 # This task creates the Ambassador TLS credentials
 - name: "Create the Ambassador credentials"
@@ -67,4 +66,4 @@
     kubernetes: "{{ organizationItem.k8s }}"
     check: "ambassador_creds"
   when:
-    - (organizationItem.issuer|lower == "default") or (organizationItem.issuer is undefined)
+    - (organizationItem.issuer is undefined) or (organizationItem.issuer|lower == "default")

--- a/platforms/shared/configuration/roles/setup/certmanager/tasks/main.yml
+++ b/platforms/shared/configuration/roles/setup/certmanager/tasks/main.yml
@@ -20,5 +20,5 @@
   shell: |
     KUBECONFIG={{ kubeconfig_path }} helm upgrade --install cert-manager --namespace cert-manager --create-namespace --set installCRDs=true "{{ playbook_dir }}/../../shared/charts/cert-manager-v1.10.0.tgz" 
   when: 
-    - organization.issuer|lower == "letsencrypt"
+    - (organization.issuer is defined) and (organization.issuer|lower == "letsencrypt")
     - certmanager.resources[0] is undefined


### PR DESCRIPTION
changes:
Removed the helm module while creation of TLS cert by cert manager because we are deploying helm chart using shell module
changed the order of organization.issuer to check if it is defined/undefined and then to check the value if it is default/letsencrypt instead of first checking value and then checking if it is defined

Reviewers:
@suvajit-sarkar @sownak @jagpreetsinghsasan 

Fixes:
hotfix