### PR TITLE
[ci-skip] reset fixes

### DIFF
--- a/platforms/hyperledger-fabric/configuration/reset-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/reset-network.yaml
@@ -94,18 +94,39 @@
         - "{{ network['organizations'] }}"
       ignore_errors: yes
 
-    ##Deletes flux namespace 
-    - name: delete flux namespace
-      k8s:
-        name: flux-{{ network.env.type }}
-        api_version: v1
-        kind: Namespace
-        state: absent
-        kubeconfig: "{{ kubernetes.config_file }}"
-      vars:
-        kubernetes: "{{ item.k8s }}"
-      loop: "{{ network['organizations'] }}"
-      ignore_errors: yes
+    # Delete ClusterRole related to flux
+    - include_role:
+        name: "delete/clusterrole"
+
+    # Delete ClusterRoleBinding related to flux
+    - include_role:
+        name: "delete/clusterrolebindings"
+
+    # Patching and Deleting GitRepository resources
+    - include_role:
+        name: "delete/gitrepositories"
+
+    # Patching and Deleting Kustomization resources
+    - include_role:
+        name: "delete/kustomization"
+
+    # Patching and Deleting HelmChart resources
+    - include_role:
+        name: "delete/helm_charts"
+    
+    # Patching and Deleting HelmRelease resources
+    - include_role:
+        name: "delete/helm_releases"
+
+    # Patching and Deleting organization namespaces
+    - include_role:
+        name: "delete/organizations_namespaces"
+
+    # Checking if namespce is present or not
+    # If namespace is present only then patching and deletion will happen for the namespace
+    # If namespace is absent then there is no need to patch and delete the namespace
+    - include_role:
+        name: "delete/flux_namespaces"
 
     # Delete Helmreleases
     # Change this file if you have new Helreleases to delete

--- a/platforms/hyperledger-fabric/configuration/roles/delete/clusterrole/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/clusterrole/tasks/main.yaml
@@ -1,0 +1,19 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Delete flux ClusterRole resources
+- name: Delete flux ClusterRole resources
+  k8s:
+    state: absent
+    api_version: v1
+    kind: ClusterRole
+    namespace: flux-{{ network.env.type }}
+    name: "{{ item[0] }}"
+    kubeconfig: "{{ kubernetes.config_file }}"
+  vars:
+    kubernetes: "{{ item[1].k8s }}"
+  with_nested:
+      - ["crd-controller-flux-{{ network.env.type }}"]
+      - "{{ network['organizations'] }}"

--- a/platforms/hyperledger-fabric/configuration/roles/delete/clusterrolebindings/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/clusterrolebindings/tasks/main.yaml
@@ -1,0 +1,33 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Delete flux related ClusterRoleBinding resources
+- name: Delete flux related ClusterRoleBinding resources
+  k8s:
+    state: absent
+    api_version: v1
+    kind: ClusterRoleBinding
+    namespace: flux-{{ network.env.type }}
+    name: "{{ item[0] }}"
+    kubeconfig: "{{ kubernetes.config_file }}"
+  vars:
+    kubernetes: "{{ item[1].k8s }}"
+  with_nested:
+    - ["crd-controller-flux-{{ network.env.type }}","cluster-reconciler-flux-{{ network.env.type }}"]
+    - "{{ network['organizations'] }}"
+  ignore_errors: false
+
+# Delete organizations related ClusterRoleBinding resources
+- name: Delete organizations related ClusterRoleBinding resources
+  k8s:
+    state: absent
+    api_version: v1
+    kind: ClusterRoleBinding
+    namespace: flux-{{ network.env.type }}
+    name: "{{ item.name | lower }}-net-role-tokenreview-binding"
+    kubeconfig: "{{ kubernetes.config_file }}"
+  vars:
+    kubernetes: "{{ item.k8s }}"
+  loop: "{{ network['organizations'] }}"

--- a/platforms/hyperledger-fabric/configuration/roles/delete/flux_namespaces/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/flux_namespaces/tasks/main.yaml
@@ -1,0 +1,41 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Checking if namespce is present or not
+- include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
+  vars:
+    component_type: flux-{{ network.env.type }}
+    component_name: Namespace
+    kubernetes: "{{ item.k8s }}"
+    type: "no_retry"
+  register: namespace_check
+  loop: "{{ network['organizations'] }}"
+
+# Patching flux namespace only if namespace is present
+- name: Patching flux namespace
+  k8s:
+    api_version: v1
+    kind: Namespace
+    name: flux-{{ network.env.type }}
+    state: present
+    definition:
+      metadata:
+        finalizers: []
+  loop: "{{ network['organizations'] }}"
+  when: namespace_check.results | length > 0
+
+# Delete flux namespace only if namespace is present
+- name: Delete flux namespace
+  k8s:
+    name: flux-{{ network.env.type }}
+    api_version: v1
+    kind: Namespace
+    state: absent
+    kubeconfig: "{{ kubernetes.config_file }}"
+  vars:
+    kubernetes: "{{ item.k8s }}"
+  loop: "{{ network['organizations'] }}"
+  when: namespace_check.results | length > 0

--- a/platforms/hyperledger-fabric/configuration/roles/delete/gitrepositories/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/gitrepositories/tasks/main.yaml
@@ -1,0 +1,41 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# List GitRepositories in namespace
+- name: List GitRepositories in namespace
+  k8s_info:
+    api_version: source.toolkit.fluxcd.io/v1beta2
+    kind: GitRepository
+    namespace: flux-{{ network.env.type }}
+  loop: "{{ network['organizations'] }}"
+  register: gitrepo_list
+
+# Patching GitRepository resources only if it exists
+- name: Patching GitRepository resources
+  k8s:
+    api_version: source.toolkit.fluxcd.io/v1beta2
+    kind: GitRepository
+    namespace: flux-{{ network.env.type }}
+    name: flux-{{ network.env.type }}
+    state: present
+    definition:
+      metadata:
+        finalizers: []
+  register: patch_result
+  loop: "{{ network['organizations'] }}"
+  when: ( gitrepo_list.results | json_query('[].resources') | flatten | length ) > 0
+
+# Deleting GitRepository resources only if it exists
+- name: Delete GitRepository resource
+  k8s:
+    api_version: source.toolkit.fluxcd.io/v1beta2
+    kind: GitRepository
+    namespace: flux-{{ network.env.type }}
+    name: flux-{{ network.env.type }}
+    state: absent
+  loop: "{{ network['organizations'] }}"
+  when:
+    - patch_result is succeeded
+    - ( gitrepo_list.results | json_query('[].resources') | flatten | length ) > 0

--- a/platforms/hyperledger-fabric/configuration/roles/delete/helm_charts/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/helm_charts/tasks/main.yaml
@@ -1,0 +1,37 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Get all helm charts resources in the namespace
+- name: Get all Helm Charts
+  k8s_info:
+    api_version: source.toolkit.fluxcd.io/v1beta2
+    kind: HelmChart
+    namespace: flux-{{ network.env.type }}
+  register: helm_charts
+
+# Patch all helm charts resources in the namespace
+- name: Patching all Helm Charts resources
+  k8s:
+    api_version: source.toolkit.fluxcd.io/v1beta2
+    kind: HelmChart
+    namespace: flux-{{ network.env.type }}
+    name: "{{ item.metadata.name }}"
+    state: present
+    definition:
+      metadata:
+        finalizers: []
+  loop: "{{ helm_charts.resources }}"
+  register: patch_result
+  
+# Delete all Helm Charts resources in the namespace
+- name: Delete all Helm charts resources
+  k8s:
+    api_version: source.toolkit.fluxcd.io/v1beta2
+    kind: HelmChart
+    namespace: flux-{{ network.env.type }}
+    name: "{{ item.metadata.name }}"
+    state: absent
+  loop: "{{ helm_charts.resources }}"
+  when: patch_result is succeeded

--- a/platforms/hyperledger-fabric/configuration/roles/delete/helm_releases/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/helm_releases/tasks/main.yaml
@@ -1,0 +1,50 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Get all Helm Releases resources in the namespace
+- name: Get all Helm Releases
+  k8s_info:
+    api_version: helm.toolkit.fluxcd.io/v2beta1
+    kind: HelmRelease
+    namespace: "{{ item.name | lower }}-net"
+  register: helm_releases_raw
+  loop: "{{ network['organizations'] }}"
+
+# Using array to store helm release name and its namespace
+- name: Set fact
+  set_fact: 
+    helm_result: []
+
+# Making a list of all Helm Releases resources in the namespace
+- name: Making a list of all Helm Releases resources
+  include_tasks: nested.yaml
+  loop: "{{ helm_releases_raw.results | list }}"
+  loop_control:
+    loop_var: resources
+
+# Patching all Helm Releases resources in the namespace
+- name: Patching Helm Releases resources
+  k8s:
+    api_version: helm.toolkit.fluxcd.io/v2beta1
+    kind: HelmRelease
+    namespace: "{{ item.ns }}"
+    name: "{{ item.release_name }}"
+    state: present
+    definition:
+      metadata:
+        finalizers: []
+  with_items: "{{ helm_result }}"
+  register: patch_result
+
+# Deleting all Helm Releases resources in the namespace
+- name: Delete all Helm Releases resources
+  k8s:
+    api_version: helm.toolkit.fluxcd.io/v2beta1
+    kind: HelmRelease
+    namespace: "{{ item.ns }}"
+    name: "{{ item.release_name }}"
+    state: absent
+  with_items: "{{ helm_result }}"
+  when: patch_result is succeeded

--- a/platforms/hyperledger-fabric/configuration/roles/delete/helm_releases/tasks/nested.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/helm_releases/tasks/nested.yaml
@@ -1,0 +1,12 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Storing release name and its namespace in an array
+- name: Nested loop for helm releases
+  set_fact:
+    helm_result={{ helm_result | default([]) + [{'release_name':helm_resource.spec.releaseName, 'ns':helm_resource.metadata.namespace}] }}
+  loop: "{{ resources.resources | list }}"
+  loop_control:
+    loop_var: helm_resource

--- a/platforms/hyperledger-fabric/configuration/roles/delete/kustomization/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/kustomization/tasks/main.yaml
@@ -1,0 +1,41 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# List Kustomizations in namespace
+- name: List Kustomizations in namespace
+  k8s_info:
+    api_version: kustomize.toolkit.fluxcd.io/v1beta2
+    kind: Kustomization
+    namespace: flux-{{ network.env.type }}
+  loop: "{{ network['organizations'] }}"
+  register: kustomization_list
+
+# Patching Kustomization resources
+- name: Patching Kustomization resources
+  k8s:
+    api_version: kustomize.toolkit.fluxcd.io/v1beta2
+    kind: Kustomization
+    namespace: flux-{{ network.env.type }}
+    name: flux-{{ network.env.type }}
+    state: present
+    definition:
+      metadata:
+        finalizers: []
+  register: patch_result
+  loop: "{{ network['organizations'] }}"
+  when: ( kustomization_list.results | json_query('[].resources') | flatten | length ) > 0
+
+# Delete Kustomization resources
+- name: Delete Kustomization resources
+  k8s:
+    api_version: kustomize.toolkit.fluxcd.io/v1beta2
+    kind: Kustomization
+    namespace: flux-{{ network.env.type }}
+    name: flux-{{ network.env.type }}
+    state: absent
+  loop: "{{ network['organizations'] }}"
+  when:
+    - patch_result is succeeded
+    - ( kustomization_list.results | json_query('[].resources') | flatten | length ) > 0

--- a/platforms/hyperledger-fabric/configuration/roles/delete/organizations_namespaces/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/organizations_namespaces/tasks/main.yaml
@@ -1,0 +1,30 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Patch organizations namespaces
+- name: Patching organizations namespaces
+  k8s:
+    api_version: v1
+    kind: Namespace
+    name: "{{ item.name | lower }}-net"
+    state: present
+    definition:
+      metadata:
+        finalizers: []
+  register: patch_result
+  loop: "{{ network['organizations'] }}"
+
+# Delete organizations namespace 
+- name: Delete organizations namespaces
+  k8s:
+    name: "{{ item.name | lower }}-net"
+    api_version: v1
+    kind: Namespace
+    state: absent
+    kubeconfig: "{{ kubernetes.config_file }}"
+  vars:
+    kubernetes: "{{ item.k8s }}"
+  loop: "{{ network['organizations'] }}"
+  when: patch_result is succeeded


### PR DESCRIPTION
Changes:
 Updated the reset-network.yaml to have new roles under roles/delete, there new roles would delete  the  cluster roles, clusterrolebindings, patch and delete gitrepositories, patch and delete kustomizations, helm charts, helm releases and the namespaces

         "delete/clusterrole"
         "delete/clusterrolebindings"
         "delete/gitrepositories"
         "delete/kustomization" 
         "delete/helm_charts"
         "delete/helm_releases"
         "delete/organizations_namespaces"
         "delete/flux_namespaces"

Reviewers:
@suvajit-sarkar @sownak @jagpreetsinghsasan 

Fixes:
#2157 