### PR TITLE
[ci-skip] Pods crashes post Kubernetes cluster nodes are restarted

### DIFF
--- a/platforms/quorum/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
+++ b/platforms/quorum/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: vault-reviewer
   namespace: {{ component_name }}
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: {{ component_name }}

--- a/platforms/r3-corda-ent/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: vault-reviewer
   namespace: {{ component_name }}
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: {{ component_name }}

--- a/platforms/r3-corda/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
+++ b/platforms/r3-corda/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: vault-reviewer
   namespace: {{ component_name }}
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: {{ component_name }}

--- a/platforms/r3-corda/configuration/roles/delete/vault_secrets/tasks/nested_main.yaml
+++ b/platforms/r3-corda/configuration/roles/delete/vault_secrets/tasks/nested_main.yaml
@@ -47,7 +47,7 @@
 # This task deletes the policies
 - name: Delete policy
   shell: |
-    vault policy delete vault-crypto-{{ service.value['name'] }}-ro
+    vault policy delete vault-crypto-{{ component_name }}-{{ service.value['name'] }}-ro
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"
     VAULT_TOKEN: "{{ item.vault.root_token }}"


### PR DESCRIPTION
Primary Changes
--------------
1. Fixed permission denied error for vault.
2. Fixed vault-auth bug 
3. Fixed removal of vault policies for r3-corda

Modifications in roles and tpl files
-----------------------
platforms/quorum/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl 
platforms/r3-corda-ent/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl 
platforms/r3-corda/configuration/roles/create/k8_component/templates/reviewer_rbac.tpl 
platforms/r3-corda/configuration/roles/delete/vault_secrets/tasks/nested_main.yaml