### PR TITLE
[ci-skip] Revert "flux optimisation"

### DIFF
--- a/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
@@ -29,9 +29,7 @@
     --password={{ git_password }} \
     --token-auth=true \
     --path={{ git_path }} \
-    --namespace=flux-{{ network.env.type }} \
-    --watch-all-namespaces=false \
-    --version=v{{ flux_version }}
+    --namespace=flux-{{ network.env.type }}
   when: git_protocol == "https"
   environment:
     KUBECONFIG: "{{ item.k8s.config_file }}"
@@ -46,9 +44,7 @@
     --branch={{ git_branch }} \
     --path={{ git_path }} \
     --private-key-file={{ git_key }} \
-    --namespace=flux-{{ network.env.type }} \
-    --watch-all-namespaces=false \
-    --version=v{{ flux_version }}
+    --namespace=flux-{{ network.env.type }}
   when: git_protocol == "ssh"
   environment:
     KUBECONFIG: "{{ item.k8s.config_file }}"


### PR DESCRIPTION
Reverts hyperledger/bevel#2224

Helm releases are not getting installed post this change, reverting the PR. Kindly test and and create PR. 