### PR TITLE
[besu] update path for generating cactus-connector helm release file.

### DIFF
--- a/platforms/shared/configuration/roles/setup/cactus-connector/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/tasks/main.yaml
@@ -10,9 +10,9 @@
   include_tasks: nested_main.yaml
   vars:
     name: "{{ member.name | lower }}"
-  loop: "{{ members }}"
+  loop: "{{ item.services.validators if item.type == 'validator' else item.services.peers }}"
   loop_control:
     loop_var: member
   when: 
-  - member.cactus_connector is defined
-  - member.cactus_connector == "enabled"
+    - member.cactus_connector is defined
+    - member.cactus_connector == "enabled"

--- a/platforms/shared/configuration/roles/setup/cactus-connector/tasks/nested_main.yaml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/tasks/nested_main.yaml
@@ -6,7 +6,7 @@
 # This task ensures that the directory exists, and creates it, if it does not exist
 - name: "Ensures {{ values_dir }}/{{ name }} dir exists"
   file:
-    path: "{{ values_dir }}/{{ name }}"
+    path: "{{ values_dir }}/{{ item.name }}/{{ name }}"
     state: directory
 
 ###########################################################################################
@@ -17,7 +17,7 @@
 - name: "create value file for cactus-connector in {{ component_ns }}"
   template:
     src: "{{ helm_templates[network.type] | default('helm_component.tpl') }}"
-    dest: "{{ values_dir }}/{{ name }}/cactus-connector.yaml"
+    dest: "{{ values_dir }}/{{ item.name }}/{{ name }}/{{ name }}-cactus-connector.yaml"
 
 ###########################################################################################
 # This task tests the value file for syntax errors/ missing values
@@ -29,7 +29,7 @@
   vars:
     helmtemplate_type: "{{ network.type }}-connector"
     chart_path: "{{ charts_dir }}"
-    value_file: "{{ values_dir }}/{{ name }}/cactus-connector.yaml"
+    value_file: "{{ values_dir }}/{{ item.name }}/{{ name }}/{{ name }}-cactus-connector.yaml"
 
 # Git Push : Pushes the above generated files to git directory 
 - name: Git Push


### PR DESCRIPTION
### **Commit to be reviewed**
---
bug(besu): update path for generating cactus-connector helm release file
```
Description:

- The generated Helm release file for the Cactus connector is currently not stored in its own organization directory within the release folder for the Besu platform. As a result, improper resetting of the entire Besu network occurs.
- This pull request proposes an update to the path, ensuring that the cactus-connector Helm release file is generated within the respective organizations.

Solution:

- Update the path for generating the cactus-connector Helm release file to the appropriate organization directory within the release folder for the Besu platform.
- This adjustment will enable successful deletion and resetting of the Besu network.

```