### PR TITLE
[ci-skip] enable cactus connector.

### DIFF
--- a/platforms/quorum/charts/quorum-connector/.helmignore
+++ b/platforms/quorum/charts/quorum-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/platforms/quorum/charts/quorum-connector/Chart.yaml
+++ b/platforms/quorum/charts/quorum-connector/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: quorum_connector
+description: A Helm chart for Cactus GoQuorum Connector
+type: application
+version: '0.14.0'
+# For Cactus release 1.1.3
+appVersion: "1.1.3"

--- a/platforms/quorum/charts/quorum-connector/README.md
+++ b/platforms/quorum/charts/quorum-connector/README.md
@@ -1,0 +1,186 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "deploy-quorum-cactus-connector"></a>
+# Deploy GoQuorum Cactus connector
+
+- [Quorum Connector Helm Chart](#quorum-connector-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+
+<a name = "quorum-connector-helm-chart"></a>
+## Quorum Connector Helm Chart
+---
+This Helm chart deploys the Cactus GoQuorum Connector, which connects to a GoQuorum node and exposes its functionality through an API server. The chart includes deployment configurations, services, config maps, and other resources required for deploying the connector.
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- GoQuorum platform/network should be up and running.
+- Members and Validators nodes should be in running state.
+- Helm installed
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The Helm chart consists of the following files:
+- `deployment.yaml`: Deploys the Cactus connector as a Kubernetes deployment.
+- `service.yaml`: Creates a Kubernetes service for accessing the connector.
+- `chart.yaml`: Contains metadata and version information about the Helm chart.
+- `values.yaml`: Defines the configurable values for the Helm chart.
+- `configmap.yaml`: Creates a config map that provides plugin details for the connector.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `.helmignore`: Specifies patterns to ignore when packaging the Helm chart.
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/quorum-coonector/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Metadata
+
+| Name                        | Description                                             | Default Value         |
+| --------------------------- | ------------------------------------------------------- | --------------------- |
+| namespace                   | Namespace where the deployment will be created          | default               |
+
+### Replica Count
+
+| Name                     | Description                          | Default Value |
+| ------------------------ | ------------------------------------ | ------------- |
+| replicaCount             | Number of replicas                   | 1             |
+
+### Image
+
+| Name                     | Description                           | Default Value                                   |
+| ------------------------ | ------------------------------------  | ----------------------------------------------  |
+| repository               | Docker image of the API server        | ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3 |
+| pullPolicy               | Pull policy of the docker image       | IfNotPresent                                    |
+
+### Service
+
+| Name                     | Description                            | Default Value         |
+| ------------------------ | ------------------------------------   | --------------------- |
+| type                     | Service type for the Cactus API server | ClusterIP             |
+| port                     | Port for the above service             | ""                    |
+
+### Plugins
+
+| Name                              | Description                                                 | Default Value                                        |
+| --------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- |
+| quorumNode                        | Existing GoQuorum node name where the plugin will connect   | ""                                                   | 
+| packageName                       | Package name for the GoQuorum connector plugin              | @hyperledger/cactus-plugin-ledger-connectorbesu      |  
+| type                              | Type of import for the GoQuorum connector                   | org.hyperledger.cactus.plugin_import_type.LOCAL      |
+| action                            | Action to be performed by the GoQuorum connector            | org.hyperledger.cactus.plugin_import_action.INSTALL  |
+| instanceId                        | Unique instance ID in case multiple connectors are deployed | 12345678                                             |
+| rpcApiHttpHost                    | Existing GoQuorum node RPC API HTTP host address            | 8545                                                 |
+| rpcApiWsHost                      | Existing GoQuorum node RPC API WS host address              | 8545                                                 |
+
+### Envs
+
+| Name                            | Description                                                  | Default Value |
+| ------------------------------- | ------------------------------------------------------------ | ------------- |
+| authorizationProtocol           | Authorization protocol for the connector                     | "NONE"        |
+| authorizationConfigJson         | JSON configuration for the authorization                     | "{}"          |
+| grpcTlsEnabled                  | Whether gRPC TLS is enabled for the connector                | "false"       |
+
+### Proxy
+
+| Name                | Description                                                   | Default Value                           |
+| ------------------- | ------------------------------------------------------------  | --------------------------------------- |
+| provider            | Provider for exposing the Connector service over the internet | ambassador                              |
+| external_url        | Complete external URL for accessing the Connector service     | https://<quorumNode_name>.<external_url>|
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the Quorum Connector using this Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/quorum-coonector/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./quorum-connector
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the Quorum Connector to the Kubernetes cluster based on the provided configurations.
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/quorum-coonector/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./quorum-connector
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the Quorum Connector is up to date.
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the Quorum Connector Helm chart, please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/quorum-connector/templates/_helpers.tpl
+++ b/platforms/quorum/charts/quorum-connector/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/quorum/charts/quorum-connector/templates/configmap.yaml
+++ b/platforms/quorum/charts/quorum-connector/templates/configmap.yaml
@@ -1,0 +1,30 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-plugins
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-plugins
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "labels.custom" . | nindent 2 }}
+data:
+  PLUGINS: |
+    {
+      "packageName": {{ .Values.plugins.packageName | quote }},
+      "type": {{ .Values.plugins.type | quote }},
+      "action": {{ .Values.plugins.action | quote }},
+      "options": {
+        "instanceId": {{ .Values.plugins.instanceId | quote }},
+        "rpcApiHttpHost": {{ .Values.plugins.rpcApiHttpHost | quote }},
+        "rpcApiWsHost": {{ .Values.plugins.rpcApiWsHost | quote }}
+      }
+    }

--- a/platforms/quorum/charts/quorum-connector/templates/deployment.yaml
+++ b/platforms/quorum/charts/quorum-connector/templates/deployment.yaml
@@ -1,0 +1,55 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-connector
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }} 
+    {{- include "labels.custom" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-cactus-connector
+      app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }} 
+      {{- include "labels.custom" . | nindent 2 }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-cactus-connector
+        app.kubernetes.io/name: {{ .Release.Name }}-cactus-connector
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }} 
+        {{- include "labels.custom" . | nindent 2 }}
+    spec:
+      containers:
+      - name: cactus-connector
+        image: {{ .Values.image.repository | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy}}
+        ports:
+        - name: http
+          containerPort: 4000
+          protocol: TCP
+        env:
+        - name: AUTHORIZATION_PROTOCOL
+          value: {{  .Values.envs.authorizationProtocol | quote  }}
+        - name: AUTHORIZATION_CONFIG_JSON
+          value: {{  .Values.envs.authorizationConfigJson | quote  }}
+        - name: GRPC_TLS_ENABLED
+          value: {{  .Values.envs.grpcTlsEnabled | quote  }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-plugins

--- a/platforms/quorum/charts/quorum-connector/templates/service.yaml
+++ b/platforms/quorum/charts/quorum-connector/templates/service.yaml
@@ -1,0 +1,48 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Release.Name }}-svc
+  annotations:
+    {{- if eq $.Values.proxy.provider "ambassador" }}
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v2
+      kind: Mapping
+      name: {{ .Release.Name }}-svc-mapping
+      prefix: /
+      service: {{ .Release.Name }}-svc.{{ .Values.metadata.namespace }}:{{ .Values.service.port }}
+      host: {{ .Values.plugins.quorumNode }}.{{ .Values.proxy.external_url }}
+      tls: false
+      ---
+      apiVersion: ambassador/v2
+      kind: TLSContext
+      name: {{ .Release.Name }}_mapping_tlscontext
+      hosts:
+      - {{ .Values.plugins.quorumNode }}.{{ .Values.proxy.external_url }}
+      secret: {{ .Values.plugins.quorumNode }}-ambassador-certs.{{ .Values.metadata.namespace }}
+      secret_namespacing: true
+      min_tls_version: v1.2
+    {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-svc
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }} 
+    {{- include "labels.custom" . | nindent 2 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.service.port }}
+    targetPort: http
+  selector:
+    name: {{ .Release.Name }}-cactus-connector

--- a/platforms/quorum/charts/quorum-connector/values.yaml
+++ b/platforms/quorum/charts/quorum-connector/values.yaml
@@ -1,0 +1,47 @@
+
+metadata:
+  # Namespace where this deployment will be created
+  namespace: carrier-quo
+
+# Number of replicas
+replicaCount: 1
+
+image:
+  # Docker image of the API server
+  repository: ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3
+  # Pull policy of the docker image
+  pullPolicy: IfNotPresent
+
+service:
+  # Service type for the Cactus API server
+  type: ClusterIP
+  # Port for the above service
+  port: 4000
+
+# Cactus connector plugin details for GoQuorum
+plugins:
+  # Existing GoQuorum node name where the plugin will connect
+  quorumNode: carrier
+  # Package name, type and action for the GoQuorum connector
+  packageName: "@hyperledger/cactus-plugin-ledger-connector-besu"
+  type: org.hyperledger.cactus.plugin_import_type.LOCAL
+  action: org.hyperledger.cactus.plugin_import_action.INSTALL
+  # Unique instance id in case multiple connectors are deployed
+  instanceId: "12345678"
+  # Existing GoQuorum node RPC addess. can be local or public url
+  rpcApiHttpHost: http://carrier.carrier-quo:8545
+  # Existing GoQuorum node WS addess. can be local or public url
+  rpcApiWsHost: ws://carrier.carrier-quo:8545
+
+# Additional env details for Cactus connector
+envs:
+  authorizationProtocol: "NONE"
+  authorizationConfigJson: "{}"
+  grpcTlsEnabled: "false"
+
+# Proxy details to expose Connector service over Internet
+proxy:
+  # Only ambassador is supported
+  provider: "ambassador"
+  # Complete external url will be https://<quorumNode>.<external_url>
+  external_url: quo.demo.aws.blockchaincloudpoc.com

--- a/platforms/quorum/configuration/setup-cactus-connector.yaml
+++ b/platforms/quorum/configuration/setup-cactus-connector.yaml
@@ -1,0 +1,32 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+#######################################
+# Playbook to setup the environment for running Hyperledger Bevel configurations
+#  - checks and installs kubectl, helm and vault clients
+#  - If cloud platform is AWS, checks and installs aws-cli and aws-authenticator
+#######################################
+- hosts: ansible_provisioners
+  gather_facts: yes
+  no_log: "{{ no_ansible_log | default(false) }}"
+  tasks:
+  - include_role:
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/cactus-connector"
+    vars:
+      component_ns: "{{ item.name | lower }}-quo"
+      # members: "{{ item.services.peers is defined | ternary(item.services.peers, item.services.validators) }}"
+      members: "{{ item.services.peers }}" # changed
+      vault: "{{ item.vault }}"
+      gitops: "{{ item.gitops }}"
+      charts_dir: "platforms/quorum/charts"
+      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}"
+    with_items: "{{ network.organizations }}"
+  vars: #These variables can be overriden from the command line
+    privilege_escalate: false           #Default to NOT escalate to root privledges
+    install_os: "linux"                 #Default to linux OS
+    install_arch:  "amd64"              #Default to amd64 architecture
+    bin_install_dir:  "~/bin"           #Default to ~/bin install directory for binaries

--- a/platforms/shared/configuration/roles/helm_lint/vars/main.yaml
+++ b/platforms/shared/configuration/roles/helm_lint/vars/main.yaml
@@ -73,3 +73,4 @@ charts:
   fabric-connector: fabric-connector
   besu-connector: besu-connector
   node_key_mgmt: node_key_mgmt
+  quorum-connector: quorum-connector

--- a/platforms/shared/configuration/roles/setup/cactus-connector/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/tasks/main.yaml
@@ -4,9 +4,11 @@
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
 
-# This role calls nested_main.yaml for each member/peer
+
 ---
-- name: Create Cactus connector
+# create cactus connector for Besu
+# This role calls nested_main.yaml for each member/peer
+- name: Create Cactus connector for Besu
   include_tasks: nested_main.yaml
   vars:
     name: "{{ member.name | lower }}"
@@ -16,3 +18,18 @@
   when: 
     - member.cactus_connector is defined
     - member.cactus_connector == "enabled"
+    - network.type == 'besu'
+
+# create cactus connector for GoQuorum
+# This role calls nested_main.yaml for each peer
+- name: Create Cactus connector for GoQuorum
+  include_tasks: nested_main.yaml
+  vars:
+    name: "{{ member.name | lower }}"
+  loop: "{{ item.services.peers }}"
+  loop_control:
+    loop_var: member
+  when: 
+    - member.cactus_connector is defined
+    - member.cactus_connector == "enabled"
+    - network.type == 'quorum'

--- a/platforms/shared/configuration/roles/setup/cactus-connector/templates/quorum-connector.tpl
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/templates/quorum-connector.tpl
@@ -1,0 +1,35 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: {{ name }}-cactus
+  namespace: {{ component_ns }}
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: {{ name }}-cactus
+  interval: 1m
+  chart:
+   spec:
+    chart: {{ charts_dir }}/quorum-connector
+    sourceRef:
+      kind: GitRepository
+      name: flux-{{ network.env.type }}
+      namespace: flux-{{ network.env.type }}
+  values:
+    metadata:
+      namespace: {{ component_ns }}
+      labels:
+    replicaCount: 1
+    images:
+      repository: ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3
+    plugins:
+      quorumNode: {{ member.name }}
+      instanceId: 12345678
+      rpcApiHttpHost: http://{{ member.name }}.{{ component_ns }}:{{ member.rpc.port }}
+    envs:
+      authorizationProtocol: "NONE"
+      authorizationConfigJson: "{}"
+      grpcTlsEnabled: "false"
+    proxy:
+      provider: {{ network.env.proxy }}
+      external_url: {{ item.external_url_suffix }}

--- a/platforms/shared/configuration/roles/setup/cactus-connector/vars/main.yml
+++ b/platforms/shared/configuration/roles/setup/cactus-connector/vars/main.yml
@@ -1,3 +1,4 @@
 helm_templates:
   fabric: fabric-connector.tpl
   besu: besu-connector.tpl
+  quorum: quorum-connector.tpl


### PR DESCRIPTION
### **Commit to be reviewed**
---

**feat(quorum): enable Cactus connector for the GoQuorum platform**

```
This commit introduces the integration of the Cactus connector into the GoQuorum platform. Key highlights of this integration include:
 • Added Cactus connector to the Quorum platform
 • The connector promotes interoperability between different decentralized networks, furthering the growth and adoption of blockchain technology.
 • The integration improves the overall functionality of the system.
```

fixes #2253