### PR TITLE
[ci-skip] Upgrade Hashicorp Vault version

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -95,7 +95,7 @@ Yes, you can specify tools versions like kubectl, helm, HashiCorp Vault, AWS-aut
 Honestly speaking, we don't know. The latest version Hyperledger Bevel has been tested on specific client versions of these tools, see below:
 (1) Kubectl: v1.19.8 for Kubernetes v1.19+ (tested upto v1.22)
 (2) Helm: v3.6.2
-(3) HashiCorp Vault: v1.7.1
+(3) HashiCorp Vault: v1.13.1
 (4) AWS-Authenticator: v1.10.3
 (5) Ansible 5.9.0, Ansible [core 2.12.6]
 

--- a/docs/source/prerequisites.md
+++ b/docs/source/prerequisites.md
@@ -43,7 +43,7 @@ Follow [official instructions](https://www.vaultproject.io/docs/install/) to dep
 ---
 **NOTE:** Recommended approach is to create one Vault deployment on one VM and configure the backend as a cloud storage.
 
-Vault version should be **1.7.1**
+Vault version should be **1.13.1**
 
 ---
 

--- a/platforms/shared/configuration/roles/setup/vault/defaults/main.yaml
+++ b/platforms/shared/configuration/roles/setup/vault/defaults/main.yaml
@@ -8,5 +8,5 @@
 tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
 
 default:
-  version: "1.7.1"
+  version: "1.13.1"
   checksum: ""


### PR DESCRIPTION
Primary Changes
--------------
1. Update Hashicorp Vault version to 1.13.1. To carry out the tests, a vault has been deployed following the steps in this video. https://www.youtube.com/watch?v=eKMDgKshjQ8&list=PL0MZ85B_96CFJUzic2ZF9rposfx2hr2rm.
Using  version of helm search repo hashicorp/vault --versions.
![image](https://github.com/hyperledger/bevel/assets/83813093/ea76cc54-e256-4914-8f33-19c83c42131a)

Modifications
-------------
docs/source/faq.md
docs/source/prerequisites.md
platforms/shared/configuration/roles/setup/vault/defaults/main.yaml

Fixes
#2282
