### PR TITLE
[ci-skip]: add README.md files.

### DIFF
--- a/platforms/quorum/charts/certs-ambassador-quorum/Chart.yaml
+++ b/platforms/quorum/charts/certs-ambassador-quorum/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm3 chart for Ambassador certificates creation
+description: A Helm3 chart for Ambassador certificates creation, the purpose of this Helm Chart is to generate SSL/TLS certificates using OpenSSL, including a root CA certificate and node certificates, and storing them in a Vault server. These certificates enable secure communication and authentication between servers and clients in a system.
 name: certs-ambassador-quorum
-version: 0.1.0
+version: '0.14.0'

--- a/platforms/quorum/charts/certs-ambassador-quorum/README.md
+++ b/platforms/quorum/charts/certs-ambassador-quorum/README.md
@@ -1,0 +1,216 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "deploy-certs-ambassador-quorum"></a>
+# Ambassador Certs GoQuorum Deployment
+
+- [Ambassador Certs GoQuorum Deployment Helm Chart](#ambassador-certs-goquorum-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "ambassador-certs-goquorum-deployment-helm-chart"></a>
+## Ambassador Certs GoQuorum Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/certs-ambassador-quorum) facilitates the deployment of Ambassador certificates using Kubernetes Jobs and stores them securely in HashiCorp Vault.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+certs-ambassador-quorum/
+  |- templates/
+      |- helpers.tpl
+      |- configmap.yaml
+      |- job.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: This directory contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `configmap.yaml`: A Kubernetes ConfigMap resource that holds the OpenSSL configuration file.
+- `job.yaml`: This file defines the Kubernetes Job resource for generating ambassador certificates and storing them in the Hashicorp Vault.
+- `Chart.yaml`: This file contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: This file contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/certs-ambassador-quorum/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Name
+
+| Name       | Description                                        | Default Value |
+| -----------| -------------------------------------------------- | ------------- |
+| name       | Provide the name of the node                       | node_1        |
+
+### Metadata
+
+| Name            | Description                                                                  | Default Value |
+| ----------------| ---------------------------------------------------------------------------- | ------------- |
+| namespace       | Provide the namespace for the quorum Certs Generator.                        | default       |
+| labels          | Provide any additional labels for the quorum Certs Generator                 | ""            |
+
+### Image
+
+| Name                     | Description                                                                                | Default Value   |
+| ------------------------ | -------------------------------------------------------                                    | --------------- |
+| initContainerName        | Provide the alpine utils image, which is used for all init-containers of deployments/jobs  | ""              |
+| certsContainerName       | Provide the image for the certs container                                                  | ""              |
+| imagePullSecret          | Provide the docker-registry secret created and stored in kubernetes cluster as a secret    | regcred         |
+| pullPolicy               | Pull policy to be used for the Docker image                                                | IfNotPresent    |
+
+### Vault
+
+| Name                      | Description                                                               | Default Value |
+| ------------------------- | --------------------------------------------------------------------------| ------------- |
+| address                   | Address/URL of the Vault server.                                          | ""            |
+| role                      | Role used for authentication with Vault                                   | vault-role    |
+| authpath                  | Authentication path for Vault                                             | quorumnode_1  |
+| serviceAccountName        | Provide the already created service account name autheticated to vault    | vault-auth    |
+| certSecretPrefix          | Provide the vault path where the certificates are stored                  | ""            |
+| retries                   | Number of retries to check contents from vault                            | 30            |
+
+### Subjects
+
+| Name                      | Description                        | Default Value |
+| ------------------------- | ---------------------------------- | ------------- |
+| root_subject              | Mention the subject for rootca     | ""            |
+| cert_subject              | Mention the subject for cert       | ""            |
+
+### OpenSSL Vars
+
+| Name                      | Description                                               | Default Value |
+| --------------------------| ----------------------------------------------------------| ------------- |
+| domain_name               | Provides the name for domain                              | ""            |
+| domain_name_api           | Provides the name for domain_name api endpoint            | ""            |
+| domain_name_web           | provides the name for domain_name web endpoint            | ""            |
+| domain_name_tessera       | provides the name for domain domain_name tessera endpoint | ""            |
+
+### Sleep
+
+| Name                      | Description                                              | Default Value |
+| ------------------------- | ---------------------------------------------------------| ------------- |
+| sleepTimeAfterError       | Sleep time in seconds when error while registration      | 120           |
+| sleepTime                 | custom sleep time in seconds                             | 20            |
+
+### Healthcheck
+
+| Name                        | Description                                                                   | Default Value |
+| ----------------------------| ------------------------------------------------------------------------------| ------------- |
+| readinesscheckinterval      | Provide the wait interval in seconds in fetching certificates from vault      | 5             |
+| readinessthreshold          | Provide the threshold number of retries in fetching certificates from vault   | 2             |
+
+### Volume
+
+| Name             | Description            | Default Value |
+| -----------------| -----------------------| ------------- |
+| baseDir          | Base directory         | /home/bevel   |
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the certs-ambassador-quorum Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/certs-ambassador-quorum/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./certs-ambassador-quorum
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the Quorum Connector to the Kubernetes cluster based on the provided configurations.
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/certs-ambassador-quorum/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./certs-ambassador-quorum
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the certs-ambassador-quorum node is up to date.
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Ambassador Certs GoQuorum Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/certs-ambassador-quorum), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/certs-ambassador-quorum/values.yaml
+++ b/platforms/quorum/charts/certs-ambassador-quorum/values.yaml
@@ -13,12 +13,12 @@
 #############################################################
 # Provide the name of the node
 # Eg. name:
-name:
+name: node_1
 # This section contains the quorum metadata.
 metadata:
   # Provide the namespace for the quorum Certs Generator.
   # Eg. namespace: cenm
-  namespace:
+  namespace: default
   # Provide any additional labels for the quorum Certs Generator.
   labels:
 
@@ -27,13 +27,13 @@ image:
   # Provide the alpine utils image, which is used for all init-containers of deployments/jobs.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
   # Eg. initContainerName: hyperledgerlabs/alpine-utils:1.0
-  initContainerName:
+  initContainerName: hyperledgerlabs/alpine-utils:1.0
   # Provide the image for the certs container.
   # Eg. certsContainerName: ghcr.io/hyperledger/bevel-doorman:latest
-  certsContainerName:
+  certsContainerName: ghcr.io/hyperledger/bevel-doorman:latest
   # Provide the docker-registry secret created and stored in kubernetes cluster as a secret.
   # Eg. imagePullSecret: regcred
-  imagePullSecret:
+  imagePullSecret: regcred
   # Pull policy to be used for the Docker image
   # Eg. pullPolicy: Always
   pullPolicy: IfNotPresent
@@ -51,18 +51,18 @@ vault:
   address:
   # Provide the vault role used.
   # Eg. role: vault-role
-  role:
+  role: vault-role
   # Provide the authpath configured to be used.
-  authpath:
+  authpath: quorumnode_1
   # Provide the service account name autheticated to vault.
   # NOTE: Make sure that the service account is already created and autheticated to use the vault.
   # Eg. serviceaccountname: vault-auth
-  serviceAccountName:
+  serviceAccountName: vault-auth
   # Provide the vault path where the certificates are stored
   # Eg. certsecretprefix: secret/cenm-org-name
   certSecretPrefix:
   # Number of retries to check contents from vault
-  retries:
+  retries: 30
 
 #############################################################
 #                  SUBJECT Details                          #

--- a/platforms/quorum/charts/crypto_ibft/Chart.yaml
+++ b/platforms/quorum/charts/crypto_ibft/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart to generate the crypto material for ibft consensus
+description: A Helm chart to generate the crypto materials for ibft consensus only if they are not already available in the vault.
 name: crypto_ibft
-version: 0.2.0
+version: '0.14.0'

--- a/platforms/quorum/charts/crypto_ibft/README.md
+++ b/platforms/quorum/charts/crypto_ibft/README.md
@@ -1,0 +1,195 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "ibft-crypto-goquorum-deployment"></a>
+# IBFT Crypto GoQuorum Deployment
+
+- [IBFT Crypto GoQuorum Deployment Helm Chart](#ibft-crypto-goquorum-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+<a name = "ibft-crypto-goquorum-deployment-helm-chart"></a>
+## IBFT Crypto GoQuorum Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_ibft) responsible for interacting with a Vault server to fetch and validate secrets, as well as generating and saving cryptographic materials in the vault.
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+crypto_ibft/
+    |- templates/
+            |- helpers.tpl
+            |- job.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `job.yaml`: Interacting with a Vault server to fetch and validate secrets, as well as generating and saving cryptographic materials in the vault.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes settings for the metadata, peer, image, and Vault configurations.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_ibft/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Metadata
+
+| Name            | Description                                                                             | Default Value         |
+| ----------------| --------------------------------------------------------------------------------------- | --------------------- |
+| namespace       | Provide the namespace for organization's peer                                           | default               |
+| name            | Provide the name for quorum-ibft-crypto job release                                     | quorum-crypto-ibft    |
+
+### Peer
+
+| Name            | Description                                                                             | Default Value |
+| ----------------| --------------------------------------------------------------------------------------- | ------------- |
+| name            | Provide the name of the peer                                                            | carrier       |
+| gethPassphrase  | Provide the passphrase for building the crypto files.<br>Eg. gethPassphrase: 12345      | 12345         |
+
+### Image
+
+| Name               | Description                                                                                  | Default Value                     |
+| -------------------| -------------------------------------------------------------------------------------------- | --------------------------------- |
+| initContainerName  | Provide the alpine utils image, which is used for all init-containers of deployments/jobs    | hyperledgerlabs/alpine-utils:1.0  |
+| pullPolicy         | Pull policy to be used for the Docker image                                                  | IfNotPresent                      |
+| node               | Pull quorum Docker image                                                                     | ""                                |
+
+### Vault
+
+| Name                | Description                                                             | Default Value |
+| ------------------- | ------------------------------------------------------------------------| ------------- |
+| address             | Provide the vault address/URL                                           | ""            |
+| role                | Provide the vault role used                                             | vault-role    |
+| authpath            | Provide the authpath configured to be used                              | ""            |
+| serviceAccountName  | Provide the already created service account name autheticated to vault  | vault-auth    |
+| certSecretPrefix    | Provide the vault path where the certificates are stored                | ""            |
+| retries             | Number of retries to check contents from vault                          | 30            |
+
+### Sleep
+
+| Name                      | Description                                              | Default Value |
+| ------------------------- | -------------------------------------------------------  | ------------- |
+| sleepTimeAfterError       | Sleep time in seconds when error while registration      | 120           |
+| sleepTime                 | custom sleep time in seconds                             | 20            |
+
+### Healthcheck
+
+| Name                        | Description                                                                                                 | Default Value |
+| ----------------------------| ----------------------------------------------------------------------------------------------------------- | ------------- |
+| readinesscheckinterval      | Provide the wait interval in seconds in fetching certificates from vault                                    | 5             |
+| readinessthreshold          | Provide the threshold number of retries in fetching certificates from vault                                 | 2             |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the crypto_ibft Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_ibft/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./crypto_ibft
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the ibft node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_ibft/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./crypto_ibft
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the ibft node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [IBFT Crypto GoQuorum Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_ibft) , please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/crypto_ibft/templates/_helpers.tpl
+++ b/platforms/quorum/charts/crypto_ibft/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/quorum/charts/crypto_ibft/values.yaml
+++ b/platforms/quorum/charts/crypto_ibft/values.yaml
@@ -18,19 +18,19 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: supplychain-quo
-  namespace:
+  namespace: default
 
   #Provide the name for quorum-ibft-crypto job release
   #Eg. name: quorum-crypto-ibft
-  name:
+  name: quorum-crypto-ibft
 
 peer:
   # Provide the name of the peer
   # Eg. name: carrier
-  name:
+  name: carrier
   # Provide the passphrase for building the crypto files
   # Eg. 12345
-  gethPassphrase:
+  gethPassphrase: 12345
 # This section contains the Quorum Crypto IBFT metadata.
 
 # Provide information regarding the Docker images used.
@@ -38,10 +38,10 @@ image:
   # Provide the alpine utils image, which is used for all init-containers of deployments/jobs.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
   # Eg. initContainerName: hyperledgerlabs/alpine-utils:1.0
-  initContainerName:
+  initContainerName: hyperledgerlabs/alpine-utils:1.0
   # Pull policy to be used for the Docker image
   # Eg. pullPolicy: Always
-  pullPolicy:
+  pullPolicy: IfNotPresent
   # Pull quorum Docker image
   node: 
 
@@ -58,18 +58,18 @@ vault:
   address: 
   # Provide the vault role used.
   # Eg. role: vault-role
-  role:
+  role: vault-role
   # Provide the authpath configured to be used.
   authpath:
   # Provide the service account name autheticated to vault.
   # NOTE: Make sure that the service account is already created and autheticated to use the vault.
   # Eg. serviceaccountname: vault-auth
-  serviceAccountName:
+  serviceAccountName: vault-auth
   # Provide the vault path where the certificates are stored
   # Eg. certsecretprefix: secret/cenm-org-name
   certSecretPrefix:
   # Number of retries to check contents from vault 
-  retries:
+  retries: 30
 
 #############################################################
 #                       Settings                            #

--- a/platforms/quorum/charts/crypto_raft/Chart.yaml
+++ b/platforms/quorum/charts/crypto_raft/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart to generate the crypto material for ibft consensus
+description: A Helm chart to generate the crypto material for raft consensus only if they are not already available in the vault.
 name: crypto_raft
-version: 0.2.0
+version: '0.14.0'

--- a/platforms/quorum/charts/crypto_raft/README.md
+++ b/platforms/quorum/charts/crypto_raft/README.md
@@ -1,0 +1,197 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "raft-crypto-goquorum-deployment"></a>
+# RAFT Crypto GoQuorum Deployment
+
+- [RAFT Crypto GoQuorum Deployment Helm Chart](#raft-crypto-goquorum-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "raft-crypto-goquorum-deployment-helm-chart"></a>
+## RAFT Crypto GoQuorum Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_raft) generate the crypto material for raft consensus.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+crypto_raft/
+    |- templates/
+            |- helpers.tpl
+            |- job.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `job.yaml`: Interacting with a Vault server to fetch and validate secrets, as well as generating and saving cryptographic materials in the vault.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes settings for the metadata, peer, image, and Vault configurations.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_raft/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Metadata
+
+| Name            | Description                                                                             | Default Value         |
+| ----------------| --------------------------------------------------------------------------------------- | --------------------- |
+| namespace       | Provide the namespace for organization's peer                                           | default               |
+| name            | Provide the name for quorum-raft-crypto job release                                     | quorum-crypto-raft    |
+
+### Peer
+
+| Name            | Description                                                                             | Default Value |
+| ----------------| --------------------------------------------------------------------------------------- | ------------- |
+| name            | Provide the name of the peer                                                            | carrier       |
+| gethPassphrase  | Provide the passphrase for building the crypto files                                    | 12345         |
+
+### Image
+
+| Name               | Description                                                                                  | Default Value                     |
+| -------------------| -------------------------------------------------------------------------------------------- | --------------------------------- |
+| initContainerName  | Provide the alpine utils image, which is used for all init-containers of deployments/jobs    | hyperledgerlabs/alpine-utils:1.0  |
+| pullPolicy         | Pull policy to be used for the Docker image                                                  | IfNotPresent                      |
+| node               | Pull quorum Docker image                                                                     | ""                                |
+
+### Vault
+
+| Name                | Description                                                             | Default Value |
+| ------------------- | ------------------------------------------------------------------------| ------------- |
+| address             | Provide the vault address/URL                                           | ""            |
+| role                | Provide the vault role used                                             | vault-role    |
+| authpath            | Provide the authpath configured to be used                              | ""            |
+| serviceAccountName  | Provide the already created service account name autheticated to vault  | vault-auth    |
+| certSecretPrefix    | Provide the vault path where the certificates are stored                | ""            |
+| retries             | Number of retries to check contents from vault                          | 30            |
+
+### Sleep
+
+| Name                      | Description                                              | Default Value |
+| ------------------------- | -------------------------------------------------------  | ------------- |
+| sleepTimeAfterError       | Sleep time in seconds when error while registration      | 120           |
+| sleepTime                 | custom sleep time in seconds                             | 20            |
+
+### Healthcheck
+
+| Name                        | Description                                                                                                 | Default Value |
+| ----------------------------| ----------------------------------------------------------------------------------------------------------- | ------------- |
+| readinesscheckinterval      | Provide the wait interval in seconds in fetching certificates from vault                                    | 5             |
+| readinessthreshold          | Provide the threshold number of retries in fetching certificates from vault                                 | 2             |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the crypto_raft Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_raft/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./crypto_raft
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the raft node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_raft/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./crypto_raft
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the raft node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [RAFT Crypto GoQuorum Deployment Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_raft), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/crypto_raft/templates/_helpers.tpl
+++ b/platforms/quorum/charts/crypto_raft/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/quorum/charts/crypto_raft/values.yaml
+++ b/platforms/quorum/charts/crypto_raft/values.yaml
@@ -18,19 +18,19 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: supplychain-quo
-  namespace:
+  namespace: default
 
   #Provide the name for quorum-raft-crypto job release
   #Eg. name: quorum-crypto-raft
-  name:
+  name: quorum-crypto-raft
 
 peer:
   # Provide the name of the peer
   # Eg. name: carrier
-  name:
+  name: carrier
   # Provide the passphrase for building the crypto files
   # Eg. 12345
-  gethPassphrase:
+  gethPassphrase: 12345
 # This section contains the Quorum Crypto IBFT metadata.
 
 # Provide information regarding the Docker images used.
@@ -38,10 +38,10 @@ image:
   # Provide the alpine utils image, which is used for all init-containers of deployments/jobs.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
   # Eg. initContainerName: hyperledgerlabs/alpine-utils:1.0
-  initContainerName:
+  initContainerName: hyperledgerlabs/alpine-utils:1.0
   # Pull policy to be used for the Docker image
   # Eg. pullPolicy: Always
-  pullPolicy:
+  pullPolicy: IfNotPresent
   # Pull quorum Docker image
   node:
 
@@ -58,18 +58,18 @@ vault:
   address:
   # Provide the vault role used.
   # Eg. role: vault-role
-  role:
+  role: vault-role
   # Provide the authpath configured to be used.
   authpath:
   # Provide the service account name autheticated to vault.
   # NOTE: Make sure that the service account is already created and autheticated to use the vault.
   # Eg. serviceaccountname: vault-auth
-  serviceAccountName:
+  serviceAccountName: vault-auth
   # Provide the vault path where the certificates are stored
   # Eg. certsecretprefix: secret/cenm-org-name
   certSecretPrefix:
   # Number of retries to check contents from vault
-  retries:
+  retries: 30
 
 #############################################################
 #                       Settings                            #

--- a/platforms/quorum/charts/node_constellation/README.md
+++ b/platforms/quorum/charts/node_constellation/README.md
@@ -1,0 +1,242 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "constellation-node-deployment"></a>
+# GoQuorum Constellation Node Deployment
+
+- [Constellation Node Deployment Helm Chart](#constellation-node-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+<a name = "constellation-node-deployment-helm-chart"></a>
+## Constellation Node Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_constellation) helps to deploy Quorum nodes with constellation transaction manager.
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+node_constellation/
+    |- templates/
+            |- _helpers.yaml
+            |- configmap.yaml
+            |- deployment.yaml
+            |- ingress.yaml
+            |- service.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `configmap.yaml`: The file defines a ConfigMap that stores the base64-encoded content of the "genesis.json" file under the key "genesis.json.base64" in the specified namespace.
+- `deployment.yaml`: This file is a configuration file for deploying a StatefulSet in Kubernetes. It creates a StatefulSet with a specified number of replicas and defines various settings for the deployment. It includes initialization containers for fetching secrets from a Vault server, an init container for initializing the Quorum blockchain network, and a main container for running the Quorum node. It also specifies volume mounts for storing certificates and data. The StatefulSet ensures stable network identities for each replica.
+- `ingress.yaml`: This file sets up HAProxy as the proxy provider for Kubernetes Ingress, with routing rules for multiple paths and hosts, and enables SSL passthrough for secure communication.
+- `service.yaml`: This file defines a Kubernetes Service with multiple ports for different protocols and targets, and supports Ambassador proxy annotations for specific configurations when using the "ambassador" proxy provider.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes configuration for the metadata, image, node, Vault, etc.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_constellation/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### replicaCount
+
+| Name                     | Description                          | Default Value |
+| ------------------------ | ------------------------------------ | ------------- |
+| replicaCount             | Number of replicas                   | 1             |
+
+### metadata
+
+| Name            | Description                                                                  | Default Value |
+| ----------------| ---------------------------------------------------------------------------- | ------------- |
+| namespace       | Provide the namespace for the Quorum node                                    | default       |
+| labels          | Provide any additional labels                                                | ""            |
+
+### image
+
+| Name           | Description                                                                      | Default Value                         |
+| ---------------| -------------------------------------------------------------------------------- | ------------------------------------- |
+| node           | Provide the valid image name and version for quorum node                         | quorumengineering/quorum:2.1.1        |
+| alpineutils    | Provide the valid image name and version to read certificates from vault server  | hyperledgerlabs/alpine-utils:1.0      |
+| constellation  | Provide the valid image name and version for quorum constellation                | quorumengineering/constellation:0.3.2 |
+
+### node
+
+| Name                     | Description                                                                    | Default Value     |
+| ------------------------ | ------------------------------------------------------------------------------ | ----------------- |
+| name                     | Provide the name for Quorum node                                               | node-1            |
+| status                   | Provide the status of the node as default,additional                           | additional        |
+| peer_id                  | Provide the id which is obtained when the new peer is added for raft consensus | 5                 |
+| consensus                | Provide the consesus for the Quorum network, values can be 'raft' or 'ibft'    | ibft              |
+| subject                  | Provide additional node identity                                               | ""                |
+| mountPath                | Provide the mountpath for Quorum pod                                           | /etc/quorum/qdata |
+| imagePullSecret          | Provide the docker secret name in the namespace                                | regcred           |
+| keystore                 | Provide the keystore file name                                                 | keystore_1        |
+| servicetype              | Provide the k8s service type                                                   | ClusterIP         |
+| ports.rpc                | Provide the rpc service ports                                                  | 8546              |
+| ports.raft               | Provide the raft service ports                                                 | 50401             |
+| ports.constellation      | Provide the constellation service ports                                        | 9001              |
+| ports.quorum             | Provide the Quorum port                                                        | 21000             |
+
+### vault
+
+| Name               | Description                                                              | Default Value             |
+| ----------------   | -------------------------------------------------------------------------| ------------------------- |
+| address            | Address/URL of the Vault server.                                         | ""                        |
+| secretprefix       | Provide the Vault secret path from where secrets will be read            | secret/org1/crypto/node_1 |
+| serviceaccountname | Provide the service account name verified with Vault                     | vault-auth                |
+| keyname            | Provide the key name from where Quorum secrets will be read              | quorum                    |
+| tm_keyname         | Provide the key name from where transaction manager secrets will be read | tm                        |
+| role               | Provide the service role verified with Vault                             | vault-role                |
+| authpath           | Provide the Vault auth path created for the namespace                    | quorumorg1                |
+
+
+### genesis
+
+| Name    | Description                                    | Default Value |
+| --------| ---------------------------------------------- | ------------- |
+| genesis | Provide the genesis.json file in base64 format | ""            |
+
+
+### staticnodes
+
+| Name            | Description                           | Default Value |
+| ----------------| --------------------------------------| ------------- |
+| staticnodes     | Provide the static nodes as an array  | ""            |
+
+### constellation
+
+| Name              | Description                                                           | Default Value                     |
+| ----------------  | --------------------------------------------------------------------- | --------------------------------- |
+| url               | Provide the Constellation URL that is reachable from other nodes      | ""                                |
+| storage           | Provide the Constellation persistent data storage                     | bdb:/etc/quorum/qdata/database    |
+| tls               | Provide if Constellation will use TLS (strict, off)                   | strict                            |
+| othernodes        | Provide one node to connect for bootstrap                             | ""                                |
+| trust             | Provide the server/client trust configuration for Constellation nodes | tofu                              |
+
+### proxy
+
+| Name                  | Description                                                           | Default Value |
+| --------------------- | --------------------------------------------------------------------- | ------------- |
+| provider              | The proxy/ingress provider (ambassador, haproxy)                      | ambassador    |
+| external_url_suffix   | The external URL suffix of the organization                           | ""            |
+| rpcport               | The RPC port exposed externally via the proxy                         | 15010         |
+| quorumport            | The Quorum port exposed externally via the proxy                      | 15011         |
+| portConst             | The Constellation port exposed externally via the proxy               | 15013         |
+| portRaft              | The Raft port exposed externally via the proxy                        | 15012         |
+
+### storage
+
+| Name                  | Description                               | Default Value     |
+| --------------------- | ------------------------------------------| ----------------- |
+| storageclassname      | The Kubernetes storage class for the node | awsstorageclass   |
+| storagesize           | The memory for the node                   | 1Gi               |
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the node_constellation Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_constellation/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./node_constellation
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the Constellation node to the Kubernetes cluster based on the provided configurations.
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_constellation/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./node_constellation
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the Constellation node is up to date.
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Constellation Node Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_constellation), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/node_constellation/values.yaml
+++ b/platforms/quorum/charts/node_constellation/values.yaml
@@ -9,12 +9,12 @@
 
 #Provide the number of replicas for pods
 #Eg. replicaCount: 1
-replicaCount: 
+replicaCount: 1
 
 metadata:
   #Provide the namespace for the Quorum node
   #Eg. namespace: example-quo
-  namespace: 
+  namespace: default
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -37,30 +37,30 @@ images:
 node:
   #Provide the name for Quorum node
   #Eg. name: node-1
-  name: 
+  name: node-1
   #Provide the status of the node as default,additional
   #Eg. status: additional
-  status:
+  status: additional
   #Provide the id which is obtained when the new peer is added for raft consensus
   #This field is only for RAFT consensus and only when a new node is added to existing network
   #Eg. peer_id: 5
-  peer_id: 
+  peer_id: 5
   #Provide the consesus for the Quorum network
   # values can be 'raft' or 'ibft'
   #Eg. consensus: raft 
-  consensus: 
+  consensus: ibft
   #Provide additional node identity
   #Eg. subject: "O=Warehouse,OU=Warehouse,L=42.36/-71.06/Boston,C=US"
   subject:
   #Provide the mountpath for Quorum pod
   #Eg. mountPath: /etc/quorum/qdata
-  mountPath: 
+  mountPath: /etc/quorum/qdata
   #Provide the docker secret name in the namespace
   #Eg. imagePullSecret: regcred
   imagePullSecret: regcred
   #Provide the keystore file name
   #Eg. keystore: keystore_1
-  keystore: 
+  keystore: keystore_1
   #Provide the k8s service type
   servicetype: ClusterIP
   #Provide the container and service ports
@@ -76,22 +76,22 @@ vault:
   address: 
   #Provide the Vault secret path from where secrets will be read
   #Eg. secretprefix: secret/org1/crypto/node_1
-  secretprefix: 
+  secretprefix: secret/org1/crypto/node_1
   #Provide the serviceaccount which is verified with Vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname: 
+  serviceaccountname: vault-auth
   #Provide the key name from where quorum secrets will be read
   #Eg. keyname: quorum
-  keyname: 
+  keyname: quorum
   #Provide the key name from where transaction-manager secrets will be read
   #Eg. tm_keyname: tm
-  tm_keyname: 
+  tm_keyname: tm
   #Provide the service role which is verified with Vault
   #Eg. role: vault-role
-  role: 
+  role: vault-role
   #Provide the Vault auth-path which is created for the namespace
   #Eg. authpath: quorumorg1
-  authpath: 
+  authpath: quorumorg1
 
 #Provide the genesis.json file in base64 format
 #Eg. genesis: ewogICAgImFsbG9jIjogewogICAgICAgICIwOTg2Nzk2ZjM0ZDhmMWNkMmI0N2M3MzQ2YTUwYmY2
@@ -113,7 +113,7 @@ constellation:
   url:
   #Provide the constellation persistent data storage
   #Eg. storage: 'bdb:/etc/quorum/qdata/database'  # bdb:path (BerkeleyDB)
-  storage: 
+  storage: "bdb:/etc/quorum/qdata/database"
   #Provide if constellation will use tls. 
   # Options:
   ##   - strict: All connections to and from this node must use TLS with mutual
@@ -123,14 +123,14 @@ constellation:
   ##     still possible. This should only be used if another transport security
   ##     mechanism like WireGuard is in place.
   #Eg. tls: 'strict'
-  tls: 
+  tls: "strict"
   #Provide one node to connect for bootstrap. This should be reachable from this node
   #Eg. othernodes: 'http://node1.quo.demo.aws.blockchaincloudpoc.com:15013/'
   othernodes: 
   #Provide the server/client  trust configuration for constellation nodes. 
   # options are: "ca-or-tofu", "ca", "tofu"
   # Eg: trust: "tofu"
-  trust: 
+  trust: tofu
 
 proxy:
   #This will be the proxy/ingress provider. Can have values "ambassador" or "haproxy"
@@ -149,7 +149,7 @@ proxy:
 storage:
   #Provide the kubernetes storageclass for node
   #Eg. storageclassname: awsstorageclass
-  storageclassname: 
+  storageclassname: awsstorageclass 
   #Provide the memory for node
   #Eg. storagesize: 1Gi
-  storagesize: 
+  storagesize: 1Gi

--- a/platforms/quorum/charts/node_quorum/README.md
+++ b/platforms/quorum/charts/node_quorum/README.md
@@ -1,0 +1,255 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "quorum-node-deployment"></a>
+# Quorum Node Deployment
+
+- [Quorum Node Deployment Helm Chart](#quorum-node-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+<a name = "quorum-node-deployment-helm-chart"></a>
+## Quorum Node Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum) helps to deploy Quorum nodes with tessera transaction manager.
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+node_quorum/
+    |- templates/
+            |- _helpers.yaml
+            |- configmap.yaml
+            |- deployment.yaml
+            |- ingress.yaml
+            |- service.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `configmap.yaml`: The file defines a ConfigMap that stores the base64-encoded content of the "genesis.json" file under the key "genesis.json.base64" in the specified namespace.
+- `deployment.yaml`: This file is a configuration file for deploying a StatefulSet in Kubernetes. It creates a StatefulSet with a specified number of replicas and defines various settings for the deployment. It includes initialization containers for fetching secrets from a Vault server, an init container for initializing the Quorum blockchain network, and a main container for running the Quorum node. It also specifies volume mounts for storing certificates and data. The StatefulSet ensures stable network identities for each replica.
+- `ingress.yaml`: This file is a Kubernetes configuration file for setting up an Ingress resource with HAProxy as the provider. It includes annotations for SSL passthrough and specifies rules for routing traffic based on the host and path.
+- `service.yaml`: This file defines a Kubernetes Service with multiple ports for different protocols and targets, and supports Ambassador proxy annotations for specific configurations when using the "ambassador" proxy provider.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes configuration for the metadata, image, node, Vault, etc.
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### replicaCount
+
+| Name                     | Description                          | Default Value |
+| ------------------------ | ------------------------------------ | ------------- |
+| replicaCount             | Number of replicas                   | 1             |
+
+### metadata
+
+| Name            | Description                                                                  | Default Value |
+| ----------------| ---------------------------------------------------------------------------- | ------------- |
+| namespace       | Provide the namespace for the Quorum node                                    | default       |
+| labels          | Provide any additional labels                                                | ""            |
+
+### image
+
+| Name           | Description                                                                          | Default Value                         |
+| ---------------| ------------------------------------------------------------------------------------ | ------------------------------------- |
+| node           | Provide the valid image name and version for quorum node                             | quorumengineering/quorum:2.1.1        |
+| alpineutils    | Provide the valid image name and version to read certificates from vault server      | hyperledgerlabs/alpine-utils:1.0      |
+| tessera        | Provide the valid image name and version for quorum tessera                          | quorumengineering/tessera:0.9.2       |
+| busybox        | Provide the valid image name and version for busybox                                 | busybox                               |
+| mysql          | Provide the valid image name and version for MySQL. This is used as the DB for TM    | mysql/mysql-server:5.7                |
+
+### node
+
+| Name                     | Description                                                                    | Default Value     |
+| ------------------------ | ------------------------------------------------------------------------------ | -------------     |
+| name                     | Provide the name for Quorum node                                               | node-1            |
+| status                   | Provide the status of the node as default,additional                           | default           |
+| peer_id                  | Provide the id which is obtained when the new peer is added for raft consensus | 5                 |
+| consensus                | Provide the consesus for the Quorum network, values can be 'raft' or 'ibft'    | ibft              |
+| mountPath                | Provide the mountpath for Quorum pod                                           | /etc/quorum/qdata |
+| imagePullSecret          | Provide the docker secret name in the namespace                                | regcred           |
+| keystore                 | Provide the keystore file name                                                 | keystore_1        |
+| servicetype              | Provide the k8s service type                                                   | ClusterIP         |
+| ports.rpc                | Provide the rpc service ports                                                  | 8546              |
+| ports.raft               | Provide the raft service ports                                                 | 50401             |
+| ports.tm                 | Provide the Tessera Transaction Manager service ports                          | 15013             |
+| ports.quorum             | Provide the Quorum port                                                        | 21000             |
+| ports.db                 | Provide the DataBase port                                                      | 3306              |
+| dbname                   | Provide the mysql DB name                                                      | demodb            |
+| mysqluser                | Provide the mysql username                                                     | demouser          |
+| mysqlpassword            | Provide the mysql user password                                                | password          |
+
+### vault
+
+| Name               | Description                                                              | Default Value             |
+| ----------------   | -------------------------------------------------------------------------| -------------             |
+| address            | Address/URL of the Vault server.                                         | ""                        |
+| secretprefix       | Provide the Vault secret path from where secrets will be read            | secret/org1/crypto/node_1 |
+| serviceaccountname | Provide the service account name verified with Vault                     | vault-auth                |
+| keyname            | Provide the key name from where Quorum secrets will be read              | quorum                    |
+| tm_keyname         | Provide the key name from where transaction manager secrets will be read | tm                        |
+| role               | Provide the service role verified with Vault                             | vault-role                |
+| authpath           | Provide the Vault auth path created for the namespace                    | quorumorg1                |
+
+### tessera
+
+| Name          | Description                                                                                                       | Default Value                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------- | -------------                     |
+| dburl         | Provide the Database URL                                                                                          | jdbc:mysql://localhost:3306/demodb|
+| dbusername    | Provide the Database username                                                                                     | demouser                          |
+| dbpassword    | Provide the Database password                                                                                     | password                          |
+| url           | Provide the tessera node's own url. This should be local. Use http if tls is OFF                                  | ""                                |
+| othernodes    | Provide the list of tessera nodes to connect in `url: <value>` format. This should be reachable from this node    | ""                                |
+| tls           | Provide if tessera will use tls                                                                                   | STRICT                            |
+| trust         | Provide the server/client  trust configuration for quorum nodes                                            | TOFU                              |
+
+
+### genesis
+
+| Name    | Description                                    | Default Value |
+| --------| ---------------------------------------------- | ------------- |
+| genesis | Provide the genesis.json file in base64 format | ""            |
+
+
+### staticnodes
+
+| Name            | Description                           | Default Value |
+| ----------------| --------------------------------------| ------------- |
+| staticnodes     | Provide the static nodes as an array  | ""            |
+
+### proxy
+
+| Name                  | Description                                                           | Default Value |
+| --------------------- | --------------------------------------------------------------------- | ------------- |
+| provider              | The proxy/ingress provider (ambassador, haproxy)                      | ambassador    |
+| external_url          | This field contains the external URL of the node                      | ""            |
+| portTM                | The TM port exposed externally via the proxy                          | 15013         |
+| rpcport               | The RPC port exposed externally via the proxy                         | 15030         |
+| quorumport            | The Quorum port exposed externally via the proxy                      | 15031         |
+| portRaft              | The Raft port exposed externally via the proxy                        | 15032         |
+
+### storage
+
+| Name                  | Description                               | Default Value     |
+| --------------------- | ------------------------------------------| -------------     |
+| storageclassname      | The Kubernetes storage class for the node | awsstorageclass   |
+| storagesize           | The memory for the node                   | 1Gi               |
+| dbstorage             | Provide the memory for database           | 1Gi               |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the node_quorum Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./node_quorum
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the quorum node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_constellation/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./node_quorum
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the quorum node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the  [Quorum Node Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/node_quorum/values.yaml
+++ b/platforms/quorum/charts/node_quorum/values.yaml
@@ -14,7 +14,7 @@ replicaCount: 1
 metadata:
   #Provide the namespace for the Quorum node
   #Eg. namespace: example-quo
-  namespace: 
+  namespace: default
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -41,27 +41,27 @@ images:
 node:
   #Provide the name for Quorum node
   #Eg. name: node-1
-  name: 
+  name: node-1
   #Provide the status of the node as default,additional
   #Eg. status: default
-  status:
+  status: default
   #Provide the id which is obtained when the new peer is added for raft consensus
   #This field is only for RAFT consensus and only when a new node is added to existing network
   #Eg. peer_id: 5
-  peer_id: 
+  peer_id: 5
   #Provide the consesus for the Quorum network
   # values can be 'raft' or 'ibft'
   #Eg. consensus: raft 
-  consensus: 
+  consensus: ibft
   #Provide the mountpath for Quorum pod
   #Eg. mountPath: /etc/quorum/qdata
-  mountPath: 
+  mountPath: /etc/quorum/qdata
   #Provide the docker secret name in the namespace
   #Eg. imagePullSecret: regcred
   imagePullSecret: regcred
   #Provide the keystore file name
   #Eg. keystore: keystore_1
-  keystore: 
+  keystore: keystore_1
   #Provide the k8s service type
   servicetype: ClusterIP
   #Provide the container and service ports
@@ -73,10 +73,10 @@ node:
     db: 3306
   #Provide the mysql DB name
   #Eg. dbname: demodb
-  dbname: 
+  dbname: demodb
   #Provide the mysql username
   #Eg. mysqluser: demouser
-  mysqluser: 
+  mysqluser: demouser
   #Provide the mysql user password
   #Eg. mysqlpassword: pass
   mysqlpassword: 
@@ -87,33 +87,33 @@ vault:
   address: 
   #Provide the Vault secret path from where secrets will be read
   #Eg. secretprefix: secret/org1/crypto/node_1
-  secretprefix: 
+  secretprefix: "secret/org1/crypto/node_1"
   #Provide the serviceaccount which is verified with Vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname: 
+  serviceaccountname: "vault-auth"
   #Provide the key name from where quorum secrets will be read
   #Eg. keyname: quorum
-  keyname: 
+  keyname: "quorum"
   #Provide the key name from where transaction-manager secrets will be read
   #Eg. tm_keyname: tm
-  tm_keyname: 
+  tm_keyname: "tm"
   #Provide the service role which is verified with Vault
   #Eg. role: vault-role
-  role: 
+  role: "vault-role"
   #Provide the Vault auth-path which is created for the namespace
   #Eg. authpath: quorumorg1
-  authpath:
+  authpath: "quorumorg1"
 
 tessera:
   #Provide the Database URL
   #Eg. dburl: jdbc:mysql://localhost:3306/demodb
-  dburl: 
+  dburl: jdbc:mysql://localhost:3306/demodb 
   #Provide the Database username
   #Eg. dbusername: $username
-  dbusername:
+  dbusername: "demouser"
   #Provide the Database password
   #Eg. dbpassword: $password
-  dbpassword:   
+  dbpassword: password
   #Provide the tessera node's own url. This should be local. Use http if tls is OFF
   #Eg. url: "https://node1.quo.demo.aws.blockchaincloudpoc.com"
   url: 
@@ -131,11 +131,11 @@ tessera:
   ##     still possible. This should only be used if another transport security
   ##     mechanism like WireGuard is in place.
   #Eg. tls: 'STRICT'
-  tls: 
-  #Provide the server/client  trust configuration for constellation nodes. 
+  tls: "STRICT"
+  #Provide the server/client  trust configuration for quorum nodes. 
   # options are: "WHITELIST", "CA_OR_TOFU", "CA", "TOFU"
   # Eg: trust: "TOFU"
-  trust: 
+  trust: "TOFU"
 
 #Provide the genesis.json file in base64 format
 #Eg. genesis: ewogICAgImFsbG9jIjogewogICAgICAgICIwOTg2Nzk2ZjM0ZDhmMWNkMmI0N2M3MzQ2YTUwYmY2
@@ -168,10 +168,10 @@ proxy:
 storage:
   #Provide the kubernetes storageclass for node
   #Eg. storageclassname: awsstorageclass
-  storageclassname: 
+  storageclassname: "awsstorageclass"
   #Provide the memory for node
   #Eg. storagesize: 1Gi
-  storagesize: 
+  storagesize: 1Gi
   #Provide the memory for database
   #Eg. dbstorage: 1Gi
-  dbstorage: 
+  dbstorage: 1Gi

--- a/platforms/quorum/charts/node_quorum_member/README.md
+++ b/platforms/quorum/charts/node_quorum_member/README.md
@@ -1,0 +1,257 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "quorum-member-node-deployment"></a>
+# Quorum Member Node Deployment
+
+- [Quorum Member Node Deployment Helm Chart](#quorum-member-node-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+<a name = "quorum-member-node-deployment-helm-chart"></a>
+## Quorum Member Node Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_member) helps to deploy Quorum Member (non-validator) nodes with tessera transaction manager.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+node_quorum_member/
+    |- templates/
+            |- _helpers.yaml
+            |- configmap.yaml
+            |- deployment.yaml
+            |- ingress.yaml
+            |- service.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `configmap.yaml`: The file defines a ConfigMap that stores the base64-encoded content of the "genesis.json" file under the key "genesis.json.base64" in the specified namespace.
+- `deployment.yaml`: This file is a configuration file for deploying a StatefulSet in Kubernetes. It creates a StatefulSet with a specified number of replicas and defines various settings for the deployment. It includes initialization containers for fetching secrets from a Vault server, an init container for initializing the Quorum blockchain network, and a main container for running the Quorum member node. It also specifies volume mounts for storing certificates and data. The StatefulSet ensures stable network identities for each replica.
+- `ingress.yaml`: This file is a Kubernetes configuration file for setting up an Ingress resource with HAProxy as the provider. It includes annotations for SSL passthrough and specifies rules for routing traffic based on the host and path.
+- `service.yaml`: This file defines a Kubernetes Service with multiple ports for different protocols and targets, and supports Ambassador proxy annotations for specific configurations when using the "ambassador" proxy provider.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes configuration for the metadata, image, node, Vault, etc.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_member/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### replicaCount
+
+| Name                     | Description                          | Default Value |
+| ------------------------ | ------------------------------------ | ------------- |
+| replicaCount             | Number of replicas                   | 1             |
+
+### metadata
+
+| Name            | Description                                                                  | Default Value |
+| ----------------| ---------------------------------------------------------------------------- | ------------- |
+| namespace       | Provide the namespace for the Quorum node                                    | default       |
+| labels          | Provide any additional labels                                                | ""            |
+
+### image
+
+| Name           | Description                                                                          | Default Value                         |
+| ---------------| ------------------------------------------------------------------------------------ | ------------------------------------- |
+| node           | Provide the valid image name and version for quorum node                             | quorumengineering/quorum:2.1.1        |
+| alpineutils    | Provide the valid image name and version to read certificates from vault server      | hyperledgerlabs/alpine-utils:1.0      |
+| tessera        | Provide the valid image name and version for quorum tessera                          | quorumengineering/tessera:0.9.2       |
+| busybox        | Provide the valid image name and version for busybox                                 | busybox                               |
+| mysql          | Provide the valid image name and version for MySQL. This is used as the DB for TM    | mysql/mysql-server:5.7                |
+
+### node
+
+| Name                     | Description                                                                    | Default Value     |
+| ------------------------ | ------------------------------------------------------------------------------ | -------------     |
+| name                     | Provide the name for Quorum node                                               | node-1            |
+| status                   | Provide the status of the node as default,additional                           | default           |
+| peer_id                  | Provide the id which is obtained when the new peer is added for raft consensus | 5                 |
+| consensus                | Provide the consesus for the Quorum network, values can be 'raft' or 'ibft'    | ibft              |
+| mountPath                | Provide the mountpath for Quorum pod                                           | /etc/quorum/qdata |
+| imagePullSecret          | Provide the docker secret name in the namespace                                | regcred           |
+| keystore                 | Provide the keystore file name                                                 | keystore_1        |
+| servicetype              | Provide the k8s service type                                                   | ClusterIP         |
+| ports.rpc                | Provide the rpc service ports                                                  | 8546              |
+| ports.raft               | Provide the raft service ports                                                 | 50401             |
+| ports.tm                 | Provide the Tessera Transaction Manager service ports                          | 15013             |
+| ports.quorum             | Provide the Quorum port                                                        | 21000             |
+| ports.db                 | Provide the DataBase port                                                      | 3306              |
+| dbname                   | Provide the mysql DB name                                                      | demodb            |
+| mysqluser                | Provide the mysql username                                                     | demouser          |
+| mysqlpassword            | Provide the mysql user password                                                | password          |
+
+### vault
+
+| Name               | Description                                                              | Default Value             |
+| ----------------   | -------------------------------------------------------------------------| -------------             |
+| address            | Address/URL of the Vault server.                                         | ""                        |
+| secretprefix       | Provide the Vault secret path from where secrets will be read            | secret/org1/crypto/node_1 |
+| serviceaccountname | Provide the service account name verified with Vault                     | vault-auth                |
+| keyname            | Provide the key name from where Quorum secrets will be read              | quorum                    |
+| tm_keyname         | Provide the key name from where transaction manager secrets will be read | tm                        |
+| role               | Provide the service role verified with Vault                             | vault-role                |
+| authpath           | Provide the Vault auth path created for the namespace                    | quorumorg1                |
+
+### tessera
+
+| Name          | Description                                                                                                       | Default Value                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------- | -------------                     |
+| dburl         | Provide the Database URL                                                                                          | jdbc:mysql://localhost:3306/demodb|
+| dbusername    | Provide the Database username                                                                                     | demouser                          |
+| dbpassword    | Provide the Database password                                                                                     | ""                                |
+| url           | Provide the tessera node's own url. This should be local. Use http if tls is OFF                                  | ""                                |
+| othernodes    | Provide the list of tessera nodes to connect in `url: <value>` format. This should be reachable from this node    | ""                                |
+| tls           | Provide if tessera will use tls                                                                                   | STRICT                            |
+| trust         | Provide the server/client  trust configuration for constellation nodes                                            | TOFU                              |
+
+
+### genesis
+
+| Name    | Description                                    | Default Value |
+| --------| ---------------------------------------------- | ------------- |
+| genesis | Provide the genesis.json file in base64 format | ""            |
+
+
+### staticnodes
+
+| Name            | Description                           | Default Value |
+| ----------------| --------------------------------------| ------------- |
+| staticnodes     | Provide the static nodes as an array  | ""            |
+
+### proxy
+
+| Name                  | Description                                                           | Default Value |
+| --------------------- | --------------------------------------------------------------------- | ------------- |
+| provider              | The proxy/ingress provider (ambassador, haproxy)                      | ambassador    |
+| external_url          | This field contains the external URL of the node                      | ""            |
+| portTM                | The TM port exposed externally via the proxy                          | 15013         |
+| rpcport               | The RPC port exposed externally via the proxy                         | 15030         |
+| quorumport            | The Quorum port exposed externally via the proxy                      | 15031         |
+| portRaft              | The Raft port exposed externally via the proxy                        | 15032         |
+
+### storage
+
+| Name                  | Description                               | Default Value   |
+| --------------------- | ------------------------------------------| -------------   |
+| storageclassname      | The Kubernetes storage class for the node | awsstorageclass |
+| storagesize           | The memory for the node                   | 1Gi             |
+| dbstorage             | Provide the memory for database           | 1Gi             |
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the node_quorum_member Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_member/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./node_quorum_member
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the quorum member node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_member/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./node_quorum_member
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the quorum member node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Quorum Member Node Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_member), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/node_quorum_member/values.yaml
+++ b/platforms/quorum/charts/node_quorum_member/values.yaml
@@ -41,27 +41,27 @@ images:
 node:
   #Provide the name for Quorum node
   #Eg. name: node-1
-  name: 
+  name: node-1
   #Provide the status of the node as default,additional
   #Eg. status: default
-  status:
+  status: default
   #Provide the id which is obtained when the new peer is added for raft consensus
   #This field is only for RAFT consensus and only when a new node is added to existing network
   #Eg. peer_id: 5
-  peer_id: 
+  peer_id: 5
   #Provide the consesus for the Quorum network
   # values can be 'raft' or 'ibft'
   #Eg. consensus: raft 
-  consensus: 
+  consensus: ibft
   #Provide the mountpath for Quorum pod
   #Eg. mountPath: /etc/quorum/qdata
-  mountPath: 
+  mountPath: /etc/quorum/qdata
   #Provide the docker secret name in the namespace
   #Eg. imagePullSecret: regcred
   imagePullSecret: regcred
   #Provide the keystore file name
   #Eg. keystore: keystore_1
-  keystore: 
+  keystore: keystore_1
   #Provide the k8s service type
   servicetype: ClusterIP
   #Provide the container and service ports
@@ -73,10 +73,10 @@ node:
     db: 3306
   #Provide the mysql DB name
   #Eg. dbname: demodb
-  dbname: 
+  dbname: demodb
   #Provide the mysql username
   #Eg. mysqluser: demouser
-  mysqluser: 
+  mysqluser: demouser
   #Provide the mysql user password
   #Eg. mysqlpassword: pass
   mysqlpassword: 
@@ -87,33 +87,33 @@ vault:
   address: 
   #Provide the Vault secret path from where secrets will be read
   #Eg. secretprefix: secret/org1/crypto/node_1
-  secretprefix: 
+  secretprefix: secret/org1/crypto/node_1
   #Provide the serviceaccount which is verified with Vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname: 
+  serviceaccountname: vault-auth
   #Provide the key name from where quorum secrets will be read
   #Eg. keyname: quorum
-  keyname: 
+  keyname: quorum
   #Provide the key name from where transaction-manager secrets will be read
   #Eg. tm_keyname: tm
-  tm_keyname: 
+  tm_keyname: tm
   #Provide the service role which is verified with Vault
   #Eg. role: vault-role
-  role: 
+  role: vault-role
   #Provide the Vault auth-path which is created for the namespace
   #Eg. authpath: quorumorg1
-  authpath:
+  authpath: quorumorg1
 
 tessera:
   #Provide the Database URL
   #Eg. dburl: jdbc:mysql://localhost:3306/demodb
-  dburl: 
+  dburl: jdbc:mysql://localhost:3306/demodb
   #Provide the Database username
   #Eg. dbusername: $username
-  dbusername:
+  dbusername: demouser
   #Provide the Database password
   #Eg. dbpassword: $password
-  dbpassword:   
+  dbpassword: password  
   #Provide the tessera node's own url. This should be local. Use http if tls is OFF
   #Eg. url: "https://node1.quo.demo.aws.blockchaincloudpoc.com"
   url: 
@@ -131,11 +131,11 @@ tessera:
   ##     still possible. This should only be used if another transport security
   ##     mechanism like WireGuard is in place.
   #Eg. tls: 'STRICT'
-  tls: 
+  tls: STRICT
   #Provide the server/client  trust configuration for constellation nodes. 
   # options are: "WHITELIST", "CA_OR_TOFU", "CA", "TOFU"
   # Eg: trust: "TOFU"
-  trust: 
+  trust: TOFU
 
 #Provide the genesis.json file in base64 format
 #Eg. genesis: ewogICAgImFsbG9jIjogewogICAgICAgICIwOTg2Nzk2ZjM0ZDhmMWNkMmI0N2M3MzQ2YTUwYmY2
@@ -168,10 +168,10 @@ proxy:
 storage:
   #Provide the kubernetes storageclass for node
   #Eg. storageclassname: awsstorageclass
-  storageclassname: 
+  storageclassname: awsstorageclass
   #Provide the memory for node
   #Eg. storagesize: 1Gi
-  storagesize: 
+  storagesize: 1Gi
   #Provide the memory for database
   #Eg. dbstorage: 1Gi
-  dbstorage: 
+  dbstorage: 1Gi

--- a/platforms/quorum/charts/node_quorum_validator/README.md
+++ b/platforms/quorum/charts/node_quorum_validator/README.md
@@ -1,0 +1,244 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "quorum-member-node-deployment"></a>
+# Quorum Validator Node Deployment
+
+- [Quorum Validator Node Deployment Helm Chart](#quorum-validator-node-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "quorum-validator-node-deployment-helm-chart"></a>
+## Quorum Validator Node Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_validator) helps to deploy Quorum validator nodes.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+node_quorum_validator/
+    |- templates/
+            |- _helpers.yaml
+            |- configmap.yaml
+            |- deployment.yaml
+            |- ingress.yaml
+            |- service.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `configmap.yaml`: The file defines a ConfigMap that stores the base64-encoded content of the "genesis.json" file under the key "genesis.json.base64" in the specified namespace.
+- `deployment.yaml`: This file is a configuration file for deploying a StatefulSet in Kubernetes. It creates a StatefulSet with a specified number of replicas and defines various settings for the deployment. It includes initialization containers for fetching secrets from a Vault server, an init container for initializing the Quorum blockchain network, and a main container for running the Quorum validator node. It also specifies volume mounts for storing certificates and data. The StatefulSet ensures stable network identities for each replica.
+- `ingress.yaml`: This file is a Kubernetes configuration file for setting up an Ingress resource with HAProxy as the provider. It includes annotations for SSL passthrough and specifies rules for routing traffic based on the host and path.
+- `service.yaml`: This file defines a Kubernetes Service with multiple ports for different protocols and targets, and supports Ambassador proxy annotations for specific configurations when using the "ambassador" proxy provider.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes configuration for the metadata, image, node, Vault, etc.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_validator/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### replicaCount
+
+| Name                     | Description                          | Default Value |
+| ------------------------ | ------------------------------------ | ------------- |
+| replicaCount             | Number of replicas                   | 1             |
+
+### metadata
+
+| Name            | Description                                                                  | Default Value |
+| ----------------| ---------------------------------------------------------------------------- | ------------- |
+| namespace       | Provide the namespace for the Quorum node                                    | default       |
+| labels          | Provide any additional labels                                                | ""            |
+
+### image
+
+| Name           | Description                                                                          | Default Value                         |
+| ---------------| ------------------------------------------------------------------------------------ | ------------------------------------- |
+| node           | Provide the valid image name and version for quorum node                             | quorumengineering/quorum:2.1.1        |
+| alpineutils    | Provide the valid image name and version to read certificates from vault server      | hyperledgerlabs/alpine-utils:1.0      |
+| busybox        | Provide the valid image name and version for busybox                                 | busybox                               |
+| mysql          | Provide the valid image name and version for MySQL. This is used as the DB for TM    | mysql/mysql-server:5.7                |
+
+### node
+
+| Name                     | Description                                                                    | Default Value     |
+| ------------------------ | ------------------------------------------------------------------------------ | -------------     |
+| name                     | Provide the name for Quorum node                                               | node-1            |
+| status                   | Provide the status of the node as default,additional                           | default           |
+| peer_id                  | Provide the id which is obtained when the new peer is added for raft consensus | 5                 |
+| consensus                | Provide the consesus for the Quorum network, values can be 'raft' or 'ibft'    | ibft              |
+| mountPath                | Provide the mountpath for Quorum pod                                           | /etc/quorum/qdata |
+| imagePullSecret          | Provide the docker secret name in the namespace                                | regcred           |
+| keystore                 | Provide the keystore file name                                                 | keystore_1        |
+| servicetype              | Provide the k8s service type                                                   | ClusterIP         |
+| ports.rpc                | Provide the rpc service ports                                                  | 8546              |
+| ports.raft               | Provide the raft service ports                                                 | 50401             |
+| ports.tm                 | Provide the Tessera Transaction Manager service ports                          | 15013             |
+| ports.quorum             | Provide the Quorum port                                                        | 21000             |
+| ports.db                 | Provide the DataBase port                                                      | 3306              |
+| dbname                   | Provide the mysql DB name                                                      | demodb            |
+| mysqluser                | Provide the mysql username                                                     | demouser          |
+| mysqlpassword            | Provide the mysql user password                                                | password          |
+
+### vault
+
+| Name               | Description                                                              | Default Value             |
+| ----------------   | -------------------------------------------------------------------------| -------------             |
+| address            | Address/URL of the Vault server.                                         | ""                        |
+| secretprefix       | Provide the Vault secret path from where secrets will be read            | secret/org1/crypto/node_1 |
+| serviceaccountname | Provide the service account name verified with Vault                     | vault-auth                |
+| keyname            | Provide the key name from where Quorum secrets will be read              | quorum                    |
+| role               | Provide the service role verified with Vault                             | vault-role                |
+| authpath           | Provide the Vault auth path created for the namespace                    | quorumorg1                |
+
+### genesis
+
+| Name    | Description                                    | Default Value |
+| --------| ---------------------------------------------- | ------------- |
+| genesis | Provide the genesis.json file in base64 format | ""            |
+
+
+### staticnodes
+
+| Name            | Description                           | Default Value |
+| ----------------| --------------------------------------| ------------- |
+| staticnodes     | Provide the static nodes as an array  | ""            |
+
+### proxy
+
+| Name                  | Description                                                           | Default Value |
+| --------------------- | --------------------------------------------------------------------- | ------------- |
+| provider              | The proxy/ingress provider (ambassador, haproxy)                      | ambassador    |
+| external_url          | This field contains the external URL of the node                      | ""            |
+| portTM                | The TM port exposed externally via the proxy                          | 15013         |
+| rpcport               | The RPC port exposed externally via the proxy                         | 15030         |
+| quorumport            | The Quorum port exposed externally via the proxy                      | 15031         |
+| portRaft              | The Raft port exposed externally via the proxy                        | 15032         |
+
+### storage
+
+| Name                  | Description                               | Default Value     |
+| --------------------- | ------------------------------------------| ----------------- |
+| storageclassname      | The Kubernetes storage class for the node | awsstorageclass   |
+| storagesize           | The memory for the node                   | 1Gi               |
+| dbstorage             | Provide the memory for database           | 1Gi               |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the node_quorum_member Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_validator/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./node_quorum_validator
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the quorum validator node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_validator/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./node_quorum_validator
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the quorum validator node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Quorum Validator Node Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_quorum_validator), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/node_quorum_validator/values.yaml
+++ b/platforms/quorum/charts/node_quorum_validator/values.yaml
@@ -14,7 +14,7 @@ replicaCount: 1
 metadata:
   #Provide the namespace for the Quorum node
   #Eg. namespace: example-quo
-  namespace: 
+  namespace: default
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -38,27 +38,27 @@ images:
 node:
   #Provide the name for Quorum node
   #Eg. name: node-1
-  name: 
+  name: node-1
   #Provide the status of the node as default,additional
   #Eg. status: default
-  status:
+  status: default
   #Provide the id which is obtained when the new peer is added for raft consensus
   #This field is only for RAFT consensus and only when a new node is added to existing network
   #Eg. peer_id: 5
-  peer_id: 
+  peer_id: 5
   #Provide the consesus for the Quorum network
   # values can be 'raft' or 'ibft'
   #Eg. consensus: raft 
-  consensus: 
+  consensus: ibft
   #Provide the mountpath for Quorum pod
   #Eg. mountPath: /etc/quorum/qdata
-  mountPath: 
+  mountPath: /etc/quorum/qdata
   #Provide the docker secret name in the namespace
   #Eg. imagePullSecret: regcred
   imagePullSecret: regcred
   #Provide the keystore file name
   #Eg. keystore: keystore_1
-  keystore: 
+  keystore: keystore_1
   #Provide the k8s service type
   servicetype: ClusterIP
   #Provide the container and service ports
@@ -70,10 +70,10 @@ node:
     db: 3306
   #Provide the mysql DB name
   #Eg. dbname: demodb
-  dbname: 
+  dbname: demodb
   #Provide the mysql username
   #Eg. mysqluser: demouser
-  mysqluser: 
+  mysqluser: demouser
   #Provide the mysql user password
   #Eg. mysqlpassword: pass
   mysqlpassword: 
@@ -84,19 +84,19 @@ vault:
   address: 
   #Provide the Vault secret path from where secrets will be read
   #Eg. secretprefix: secret/org1/crypto/node_1
-  secretprefix: 
+  secretprefix: secret/org1/crypto/node_1
   #Provide the serviceaccount which is verified with Vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname: 
+  serviceaccountname: vault-auth
   #Provide the key name from where quorum secrets will be read
   #Eg. keyname: quorum
-  keyname: 
+  keyname: quorum
   #Provide the service role which is verified with Vault
   #Eg. role: vault-role
-  role: 
+  role: vault-role
   #Provide the Vault auth-path which is created for the namespace
   #Eg. authpath: quorumorg1
-  authpath:
+  authpath: quorumorg1
 
 #Provide the genesis.json file in base64 format
 #Eg. genesis: ewogICAgImFsbG9jIjogewogICAgICAgICIwOTg2Nzk2ZjM0ZDhmMWNkMmI0N2M3MzQ2YTUwYmY2
@@ -129,10 +129,10 @@ proxy:
 storage:
   #Provide the kubernetes storageclass for node
   #Eg. storageclassname: awsstorageclass
-  storageclassname: 
+  storageclassname: awsstorageclass
   #Provide the memory for node
   #Eg. storagesize: 1Gi
-  storagesize: 
+  storagesize: 1Gi
   #Provide the memory for database
   #Eg. dbstorage: 1Gi
-  dbstorage: 
+  dbstorage: 1Gi

--- a/platforms/quorum/charts/node_tessera/README.md
+++ b/platforms/quorum/charts/node_tessera/README.md
@@ -1,0 +1,260 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "quorum-tessera-node-deployment"></a>
+# Quorum Tessera Node Deployment
+
+- [Quorum Tessera Node Deployment Helm Chart](#quorum-tessera-node-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "quorum-tessera-node-deployment-helm-chart"></a>
+## Quorum Tessera Node Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_tessera) helps to deploy tessera nodes.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+node_tessera/
+    |- templates/
+            |- _helpers.yaml
+            |- configmap.yaml
+            |- deployment.yaml
+            |- ingress.yaml
+            |- service.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `configmap.yaml`: The file defines a ConfigMap that stores the base64-encoded content of the "genesis.json" file under the key "genesis.json.base64" in the specified namespace.
+- `deployment.yaml`: This file is a configuration file for deploying a StatefulSet in Kubernetes. It creates a StatefulSet with a specified number of replicas and defines various settings for the deployment. It includes initialization containers for fetching secrets from a Vault server, an init container for initializing the Quorum blockchain network, and a main container for running the Quorum tessera node. It also specifies volume mounts for storing certificates and data. The StatefulSet ensures stable network identities for each replica.
+- `ingress.yaml`: This file is a Kubernetes configuration file for setting up an Ingress resource with HAProxy as the provider. It includes annotations for SSL passthrough and specifies rules for routing traffic based on the host and path.
+- `service.yaml`: This file defines a Kubernetes Service with multiple ports for different protocols and targets, and supports Ambassador proxy annotations for specific configurations when using the "ambassador" proxy provider.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes configuration for the metadata, image, node, Vault, etc.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_tessera/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+## Parameters
+---
+
+### replicaCount
+
+| Name                     | Description                          | Default Value |
+| ------------------------ | ------------------------------------ | ------------- |
+| replicaCount             | Number of replicas                   | 1             |
+
+### metadata
+
+| Name            | Description                                                                  | Default Value |
+| ----------------| ---------------------------------------------------------------------------- | ------------- |
+| namespace       | Provide the namespace for the Quorum node                                    | default       |
+| labels          | Provide any additional labels                                                | ""            |
+
+### image
+
+| Name           | Description                                                                          | Default Value                         |
+| ---------------| ------------------------------------------------------------------------------------ | ------------------------------------- |
+| node           | Provide the valid image name and version for quorum node                             | quorumengineering/quorum:2.1.1        |
+| alpineutils    | Provide the valid image name and version to read certificates from vault server      | hyperledgerlabs/alpine-utils:1.0      |
+| tessera        | Provide the valid image name and version for quorum tessera                          | quorumengineering/tessera:0.9.2       |
+| busybox        | Provide the valid image name and version for busybox                                 | busybox                               |
+| mysql          | Provide the valid image name and version for MySQL. This is used as the DB for TM    | mysql/mysql-server:5.7                |
+
+### node
+
+| Name                     | Description                                                                    | Default Value     |
+| ------------------------ | ------------------------------------------------------------------------------ | -------------     |
+| name                     | Provide the name for Quorum node                                               | node-1            |
+| status                   | Provide the status of the node as default,additional                           | default           |
+| peer_id                  | Provide the id which is obtained when the new peer is added for raft consensus | 5                 |
+| consensus                | Provide the consesus for the Quorum network, values can be 'raft' or 'ibft'    | ibft              |
+| mountPath                | Provide the mountpath for Quorum pod                                           | /etc/quorum/qdata |
+| imagePullSecret          | Provide the docker secret name in the namespace                                | regcred           |
+| keystore                 | Provide the keystore file name                                                 | keystore_1        |
+| servicetype              | Provide the k8s service type                                                   | ClusterIP         |
+| ports.rpc                | Provide the rpc service ports                                                  | 8546              |
+| ports.raft               | Provide the raft service ports                                                 | 50401             |
+| ports.tm                 | Provide the Tessera Transaction Manager service ports                          | 15013             |
+| ports.quorum             | Provide the Quorum port                                                        | 21000             |
+| ports.db                 | Provide the DataBase port                                                      | 3306              |
+| dbname                   | Provide the mysql DB name                                                      | demodb            |
+| mysqluser                | Provide the mysql username                                                     | demouser          |
+| mysqlpassword            | Provide the mysql user password                                                | password          |
+
+### vault
+
+| Name               | Description                                                              | Default Value             |
+| ----------------   | -------------------------------------------------------------------------| -------------             |
+| address            | Address/URL of the Vault server.                                         | ""                        |
+| secretprefix       | Provide the Vault secret path from where secrets will be read            | secret/org1/crypto/node_1 |
+| serviceaccountname | Provide the service account name verified with Vault                     | vault-auth                |
+| keyname            | Provide the key name from where Quorum secrets will be read              | quorum                    |
+| role               | Provide the service role verified with Vault                             | vault-role                |
+| authpath           | Provide the Vault auth path created for the namespace                    | quorumorg1                |
+
+### tessera
+
+| Name          | Description                                                                                                       | Default Value                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| dburl         | Provide the Database URL                                                                                          | jdbc:mysql://localhost:3306/demodb|
+| dbusername    | Provide the Database username                                                                                     | demouser                          |
+| dbpassword    | Provide the Database password                                                                                     | password                          |
+| url           | Provide the tessera node's own url. This should be local. Use http if tls is OFF                                  | ""                                |
+| othernodes    | Provide the list of tessera nodes to connect in `url: <value>` format. This should be reachable from this node    | ""                                |
+| tls           | Provide if tessera will use tls                                                                                   | STRICT                            |
+| trust         | Provide the server/client  trust configuration for constellation nodes                                            | TOFU                              |
+
+### genesis
+
+| Name    | Description                                    | Default Value |
+| --------| ---------------------------------------------- | ------------- |
+| genesis | Provide the genesis.json file in base64 format | ""            |
+
+
+### staticnodes
+
+| Name            | Description                           | Default Value |
+| ----------------| --------------------------------------| ------------- |
+| staticnodes     | Provide the static nodes as an array  | ""            |
+
+### proxy
+
+| Name                  | Description                                                           | Default Value |
+| --------------------- | --------------------------------------------------------------------- | ------------- |
+| provider              | The proxy/ingress provider (ambassador, haproxy)                      | ambassador    |
+| external_url          | This field contains the external URL of the node                      | ""            |
+| portTM                | The TM port exposed externally via the proxy                          | 15013         |
+| rpcport               | The RPC port exposed externally via the proxy                         | 15030         |
+| quorumport            | The Quorum port exposed externally via the proxy                      | 15031         |
+| portRaft              | The Raft port exposed externally via the proxy                        | 15032         |
+
+### storage
+
+| Name                  | Description                               | Default Value     |
+| --------------------- | ------------------------------------------| ----------------- |
+| storageclassname      | The Kubernetes storage class for the node | awsstorageclass   |
+| storagesize           | The memory for the node                   | 1Gi               |
+| dbstorage             | Provide the memory for database           | 1Gi               |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the node_tessera Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_tessera/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./node_tessera
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the quorum tessera node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_tessera/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./node_tessera
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the quorum tessera node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Quorum Tessera Node Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/node_tessera), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/node_tessera/values.yaml
+++ b/platforms/quorum/charts/node_tessera/values.yaml
@@ -14,7 +14,7 @@ replicaCount: 1
 metadata:
   #Provide the namespace for the Quorum node
   #Eg. namespace: example-quo
-  namespace: 
+  namespace: default
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -41,27 +41,27 @@ images:
 node:
   #Provide the name for Quorum node
   #Eg. name: node-1
-  name: 
+  name: node-1
   #Provide the status of the node as default,additional
   #Eg. status: default
-  status:
+  status: default
   #Provide the id which is obtained when the new peer is added for raft consensus
   #This field is only for RAFT consensus and only when a new node is added to existing network
   #Eg. peer_id: 5
-  peer_id: 
+  peer_id: 5
   #Provide the consesus for the Quorum network
   # values can be 'raft' or 'ibft'
   #Eg. consensus: raft 
-  consensus: 
+  consensus: ibft
   #Provide the mountpath for Quorum pod
   #Eg. mountPath: /etc/quorum/qdata
-  mountPath: 
+  mountPath: /etc/quorum/qdata
   #Provide the docker secret name in the namespace
   #Eg. imagePullSecret: regcred
   imagePullSecret: regcred
   #Provide the keystore file name
   #Eg. keystore: keystore_1
-  keystore: 
+  keystore: keystore_1
   #Provide the k8s service type
   servicetype: ClusterIP
   #Provide the container and service ports
@@ -73,10 +73,10 @@ node:
     db: 3306
   #Provide the mysql DB name
   #Eg. dbname: demodb
-  dbname: 
+  dbname: demodb
   #Provide the mysql username
   #Eg. mysqluser: demouser
-  mysqluser: 
+  mysqluser: demouser
   #Provide the mysql user password
   #Eg. mysqlpassword: pass
   mysqlpassword: 
@@ -87,30 +87,30 @@ vault:
   address: 
   #Provide the Vault secret path from where secrets will be read
   #Eg. secretprefix: secret/org1/crypto/node_1
-  secretprefix: 
+  secretprefix: secret/org1/crypto/node_1
   #Provide the serviceaccount which is verified with Vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname: 
+  serviceaccountname: vault-auth
   #Provide the key name from where quorum secrets will be read
   #Eg. keyname: quorum
-  keyname: 
+  keyname: quorum
   #Provide the service role which is verified with Vault
   #Eg. role: vault-role
-  role: 
+  role: vault-role
   #Provide the Vault auth-path which is created for the namespace
   #Eg. authpath: quorumorg1
-  authpath:
+  authpath: quorumorg1
 
 tessera:
   #Provide the Database URL
   #Eg. dburl: jdbc:mysql://localhost:3306/demodb
-  dburl: 
+  dburl: jdbc:mysql://localhost:3306/demodb
   #Provide the Database username
   #Eg. dbusername: $username
-  dbusername:
+  dbusername: demouser
   #Provide the Database password
   #Eg. dbpassword: $password
-  dbpassword:   
+  dbpassword: password
   #Provide the tessera node's own url. This should be local. Use http if tls is OFF
   #Eg. url: "https://node1.quo.demo.aws.blockchaincloudpoc.com"
   url: 
@@ -128,11 +128,11 @@ tessera:
   ##     still possible. This should only be used if another transport security
   ##     mechanism like WireGuard is in place.
   #Eg. tls: 'STRICT'
-  tls: 
+  tls: STRICT
   #Provide the server/client  trust configuration for constellation nodes. 
   # options are: "WHITELIST", "CA_OR_TOFU", "CA", "TOFU"
   # Eg: trust: "TOFU"
-  trust: 
+  trust: TOFU
 
 #Provide the genesis.json file in base64 format
 #Eg. genesis: ewogICAgImFsbG9jIjogewogICAgICAgICIwOTg2Nzk2ZjM0ZDhmMWNkMmI0N2M3MzQ2YTUwYmY2
@@ -165,10 +165,10 @@ proxy:
 storage:
   #Provide the kubernetes storageclass for node
   #Eg. storageclassname: awsstorageclass
-  storageclassname: 
+  storageclassname: awsstorageclass
   #Provide the memory for node
   #Eg. storagesize: 1Gi
-  storagesize: 
+  storagesize: 1Gi
   #Provide the memory for database
   #Eg. dbstorage: 1Gi
-  dbstorage: 
+  dbstorage: 1Gi

--- a/platforms/quorum/charts/tessera_key_mgmt/README.md
+++ b/platforms/quorum/charts/tessera_key_mgmt/README.md
@@ -1,0 +1,182 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "ibft-crypto-goquorum-deployment"></a>
+# RAFT Crypto GoQuorum Deployment
+
+- [Tessera Key Management Deployment Helm Chart](#tessera-key-management-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "tessera-key-management-deployment-helm-chart"></a>
+## Tessera Key Management Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/tessera_key_mgmt) helps in generating Tessera crypto.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- The GoQuorum network is set up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+tessera_key_mgmt/
+    |- templates/
+            |- helpers.tpl
+            |- job.yaml
+    |- Chart.yaml
+    |- README.md
+    |- values.yaml
+```
+
+- `templates/`: This directory contains the template files for generating Kubernetes resources.
+- `helpers.tpl`: A template file used for defining custom labels in the Helm chart.
+- `job.yaml`: The job.yaml file defines a Kubernetes Job that runs the "tessera-crypto" container. This container interacts with a Vault server to retrieve secrets and generate tessera keys.
+- `Chart.yaml`: Provides metadata about the chart, such as its name, version, and description.
+- `README.md`: This file provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the chart. It includes settings for the peer, metadata, image, and Vault configurations.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/crypto_ibft/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Peer
+
+| Name            | Description                                                                             | Default Value |
+| ----------------| --------------------------------------------------------------------------------------- | ------------- |
+| name            | Provide the name of the peer                                                            | node_1        |
+
+### Metadata
+
+| Name            | Description                                                                             | Default Value         |
+| -------------   | --------------------------------------------------------------------------------------- | --------------------- |
+| namespace       | Provide the namespace for organization's peer                                           | default               |
+| name            | Provide the name for indy-key-mgmt release                                              | indy-key-mgmt         |
+
+### Image
+
+| Name               | Description                                                   | Default Value                              |
+| ----------------   | ------------------------------------------------------------- | ------------------------------------------ |
+| pullSecret         | Pull policy to be used for the Docker image                   | regcred                                    |
+| repository         | Provide the image repository for the indy-key-mgmt container  | quorumengineering/tessera:hashicorp-21.7.3 |
+
+### Vault
+
+| Name                | Description                                                             | Default Value                       |
+| ------------------- | ------------------------------------------------------------------------| ----------------------------------- |
+| address             | Provide the vault address/URL                                           | ""                                  |
+| authpath            | Provide the authpath configured to be used                              | ""                                  |
+| role                | Provide the vault role used                                             | vault-role                          |
+| serviceAccountName  | Provide the already created service account name autheticated to vault  | vault-auth                          |
+| tmprefix            | Provide the vault path where the tm secrets are stored                  | secret/node_1-quo/crypto/node_1/tm  |
+| keyprefix           | Provide the vault path where the keys are stored                        | secret/node_1-quo/crypto/node_1/key |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the crypto_ibft Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/tessera_key_mgmt/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./tessera_key_mgmt
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the tessera-key-management node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of 
+replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/tessera_key_mgmt/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./tessera_key_mgmt
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the tessera-key-management node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Tessera Key Management Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/develop/platforms/quorum/charts/tessera_key_mgmt), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/quorum/charts/tessera_key_mgmt/templates/_helpers.tpl
+++ b/platforms/quorum/charts/tessera_key_mgmt/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/quorum/charts/tessera_key_mgmt/values.yaml
+++ b/platforms/quorum/charts/tessera_key_mgmt/values.yaml
@@ -10,25 +10,25 @@
 peer:
   #Provide the name for organization's peer
   #Eg. namespace: supplychain-quo1
-  name:
+  name: node_1
 
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: supplychain-quo
-  namespace:
+  namespace: default
 
   #Provide the name for indy-key-mgmt release
   #Eg. name: indy-key-mgmt
-  name:
+  name: indy-key-mgmt
 
 image:
   #Provide the image repository for the indy-key-mgmt container
   #Eg. repository: indy-key-mgmt:latest
-  repository:
+  repository: quorumengineering/tessera:hashicorp-21.7.3
 
   #Provide the image pull secret of image
   #Eg. pullSecret: regcred
-  pullSecret:
+  pullSecret: regcred
 
 
 vault:
@@ -42,15 +42,17 @@ vault:
 
   #Provide the identity for vault
   #Eg. role: my-identity
-  role:
+  role: vault-role
 
   # Provide the service account name autheticated to vault.
   # NOTE: Make sure that the service account is already created and autheticated to use the vault.
   # Eg. serviceAccountName: vault-auth
-  serviceaccountname: 
+  serviceaccountname: vault-auth
 
   # Provide the vault path where the tm secrets are stored
   # Eg. tmprefix: secret/warehouse-quo/crypto/warehouse/tm
-  tmprefix: 
+  tmprefix: secret/node_1-quo/crypto/node_1/tm
 
-  keyprefix:
+  # Provide the vault path where the keys are stored
+  # Eg. tmprefix: secret/warehouse-quo/crypto/warehouse/key
+  keyprefix: secret/node_1-quo/crypto/node_1/key


### PR DESCRIPTION
### **Commit to be reviewed**
---

**docs(quorum): add README.md file for each GoQuorum Helm chart**

```
This commit adds the README.md file for each GoQuorum Helm chart. The README.md files provide essential information and instructions about the respective Helm charts, enabling users and developers to deploy each chart individually.

Additionally, the following changes have been made:

- Updated values.yaml of each Helm chart with default values to provide a clear configuration reference.
- Added helpers.tpl template file only to Helm charts where it was missing, ensuring consistency across the charts.
- Updated the description field of certain required charts.yaml files to provide accurate and informative descriptions.

These changes enhance the usability and documentation of the GoQuorum Helm charts, making it easier for users and developers to understand and work with the charts.
```

fixes #2286
