### PR TITLE
[ci-skip] fix hardcoded port 8443 and introduce the ordererAddress field

### DIFF
--- a/platforms/hyperledger-fabric/charts/orderernode/templates/service.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/templates/service.yaml
@@ -35,7 +35,7 @@ metadata:
       grpc: True
       name: orderer_mapping_{{ $.Values.orderer.name }}_{{ $.Values.metadata.namespace }}
       headers:
-        :authority: {{ $.Values.orderer.name }}.{{ $.Values.proxy.external_url_suffix }}:8443
+        :authority: {{ $.Values.orderer.ordererAddress }}
       prefix: /
       rewrite: /
       service: https://{{ $.Values.orderer.name }}.{{ $.Values.metadata.namespace }}:7050

--- a/platforms/hyperledger-fabric/configuration/roles/create/console_assets/templates/orderer_console.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/console_assets/templates/orderer_console.tpl
@@ -1,7 +1,7 @@
 {
     "display_name": "ordering node - {{ item.name | lower }}",
     "grpcwp_url": "https://{{ orderer.name }}-proxy.{{ item.external_url_suffix }}",
-    "api_url": "grpcs://{{ orderer.name }}.{{ item.external_url_suffix }}:8443",
+    "api_url": "grpcs://{{ orderer.ordererAddress }}",
     "operations_url": "https://{{ orderer.name }}-ops.{{ item.external_url_suffix }}",
     "type": "fabric-orderer",
     "msp_id": "{{ item.name | lower }}MSP",

--- a/platforms/hyperledger-fabric/configuration/roles/create/console_assets/templates/peer_console.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/console_assets/templates/peer_console.tpl
@@ -1,7 +1,7 @@
 {
     "display_name": "{{ component_name }} - local",
     "grpcwp_url": "https://{{ peer.name }}-proxy.{{ component_ns }}.{{ item.external_url_suffix }}",
-    "api_url": "grpcs://{{ peer.name }}.{{ component_ns }}.{{ item.external_url_suffix }}:8443",
+    "api_url": "grpcs://{{ peer.peerAddress }},
     "operations_url": "https://{{ peer.name }}-ops.{{ component_ns }}.{{ item.external_url_suffix }}",
     "msp_id": "{{ item.name | lower }}MSP",
     "name": "{{ component_name }} - local",

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_appchannel_block.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_appchannel_block.yaml
@@ -55,7 +55,7 @@
     then
       echo -n '"{{ orderer.name }}.{{ component_ns }}:{{ orderer.grpc.port }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
     else
-      echo -n '"{{ orderer.name }}.{{ org.external_url_suffix }}:8443"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
+      echo -n '"{{ orderer.ordererAddress }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
     fi
 
 # Create the values for orderer files

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_cli.yaml
@@ -28,7 +28,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
 
 
 # Create the value first orderer in orderer organization
@@ -68,7 +68,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
 - name: fetch and update the configuration block from the blockchain for proxy none
   shell: |
@@ -99,7 +99,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
 - name: fetch the latest block from the blockchain for proxy none
   shell: |

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_syschannel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_syschannel_block/tasks/nested_create_cli.yaml
@@ -27,7 +27,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
 
 
 # Start the cli using the value file created in the previous step
@@ -66,7 +66,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
 - name: fetch, modify, update and copy the configuration block from the blockchain for proxy none
   shell: |
@@ -97,7 +97,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
 - name: fetch the latest block from the blockchain
   shell: |

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_syschannel_block/tasks/nested_main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_syschannel_block/tasks/nested_main.yaml
@@ -56,7 +56,7 @@
     then
       echo -n '"{{ orderer.name }}.{{ component_ns }}:{{ orderer.grpc.port }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
     else
-      echo -n '"{{ orderer.name }}.{{ org.external_url_suffix }}:8443"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer 
+      echo -n '"{{ orderer.ordererAddress }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
     fi    
   when: update_type == "address"
 

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/tasks/nested_main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/tasks/nested_main.yaml
@@ -55,7 +55,7 @@
     then
       echo -n '"{{ orderer.name }}.{{ component_ns }}:{{ orderer.grpc.port }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-orderer
     else
-      echo -n '"{{ orderer.name }}.{{ neworg.external_url_suffix }}:8443"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-orderer
+      echo -n '"{{ orderer.ordererAddress }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-orderer
     fi
 
 ############################################################################################

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/tasks/sign_block_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/tasks/sign_block_orderer.yaml
@@ -37,7 +37,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/create_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/create_orderer.yaml
@@ -36,7 +36,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step
@@ -77,7 +77,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"    
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
 - name: fetch, modify, sign and copy the configuration block from the blockchain for proxy none
   shell: |

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/nested_main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/nested_main.yaml
@@ -56,7 +56,7 @@
     then
       echo -n '"{{ orderer.name }}.{{ component_ns }}:{{ orderer.grpc.port }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-consenter
     else
-      echo -n '"{{ orderer.name }}.{{ neworg.external_url_suffix }}:8443"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-consenter 
+      echo -n '"{{ orderer.ordererAddress }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-consenter 
     fi    
   when: update_type == "address"
 

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/sign_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/sign_orderer.yaml
@@ -37,7 +37,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/update_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/update_orderer.yaml
@@ -37,7 +37,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step
@@ -73,7 +73,7 @@
     cat {{ build_path }}/{{ channel_name }}_config_block.pb | base64 > {{ build_path }}/channel-artifacts/genesis.block.base64
   environment:
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
-    ORDERER_URL: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ORDERER_URL: "{{ orderer.ordererAddress }}"
   vars: 
     kubernetes: "{{ org.k8s }}"
   when: network.env.proxy != 'none'

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/nested_create_cli.yaml
@@ -28,7 +28,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "./build"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
 
 
 # Start the cli using the value file created in the previous step
@@ -70,7 +70,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
 - name: fetch, modify, update and copy the configuration block from the blockchain for proxy none
   shell: |

--- a/platforms/hyperledger-fabric/configuration/roles/create/refresh_certs/create_channel_block/tasks/get_update_block.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/refresh_certs/create_channel_block/tasks/get_update_block.yaml
@@ -12,7 +12,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: 
     - check == "fetch_block"
     - network.env.proxy != 'none'
@@ -54,7 +54,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: 
     - check == "update_block"
     - network.env.proxy != 'none'
@@ -86,7 +86,7 @@
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
-    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    ordererAddress: "{{ orderer.ordererAddress }}"
   when: 
     - check == "latest_block"
     - network.env.proxy != 'none'

--- a/platforms/hyperledger-fabric/configuration/roles/create/refresh_certs/create_channel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/refresh_certs/create_channel_block/tasks/nested_create_cli.yaml
@@ -26,7 +26,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
 
 # Start the cli using the value file created in the previous step
 - name: "Start cli"

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
@@ -49,7 +49,8 @@ spec:
       localmspid: {{ org_name }}MSP
       tlsstatus: true
       keepaliveserverinterval: 10s
-    
+      ordererAddress: {{ orderer.ordererAddress }}
+      
     consensus:
       name: {{ orderer.consensus }}
 

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
@@ -53,7 +53,7 @@ spec:
 {% if provider == 'none' %}
       gossipexternalendpoint: {{ peer_name }}.{{ peer_ns }}:7051
 {% else %}
-      gossipexternalendpoint: {{ peer_name }}.{{ peer_ns }}.{{item.external_url_suffix}}:8443
+      gossipexternalendpoint: {{ peer.peerAddress }}
 {% endif %}
       localmspid: {{ name }}MSP
       loglevel: info

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/channel-group/sign_block_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/channel-group/sign_block_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/orderer-group/orderer_group_capability.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/orderer-group/orderer_group_capability.yaml
@@ -37,7 +37,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/orderer-group/sign_block_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/orderer-group/sign_block_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/orderer-group/update_block_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/application-capabilities/tasks/orderer-group/update_block_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/enable-endorsement-consortium/tasks/orderer/add_orderer_enable_endorsement.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/enable-endorsement-consortium/tasks/orderer/add_orderer_enable_endorsement.yaml
@@ -36,7 +36,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/enable-endorsement-consortium/tasks/orderer/sign_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/enable-endorsement-consortium/tasks/orderer/sign_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/enable-endorsement-consortium/tasks/orderer/update_block_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/enable-endorsement-consortium/tasks/orderer/update_block_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-addresses/tasks/add-orderer_addresses.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-addresses/tasks/add-orderer_addresses.yaml
@@ -37,7 +37,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/channel_group_capability.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/channel_group_capability.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/orderer_group_capability.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/orderer_group_capability.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/sign_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/sign_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/update_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/upgrade/orderer-capabilities/tasks/update_orderer.yaml
@@ -38,7 +38,7 @@
     storage_class: "{{ org.name }}sc"
     release_dir: "{{ build_path }}"
     orderer_component: "{{ orderer.name | lower }}.{{ component_ns }}"
-    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+    orderer_address: "{{ orderer.ordererAddress }}"
   when: existing_cli.resources|length == 0
 
 # Start the cli using the value file created in the previous step

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
@@ -272,18 +272,21 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443
 
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
     - organization:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-ordererorg.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-ordererorg.yaml
@@ -217,18 +217,21 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443
       
     # New Orderer Organization
     - organization:
@@ -298,12 +301,14 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer10.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer11
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer11.org1ambassador.blockchaincloudpoc.com:8443
 
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
     - organization:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
@@ -217,18 +217,21 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443
 
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
     - organization:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml
@@ -293,15 +293,18 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
@@ -191,18 +191,21 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443
 
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
     - organization:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-kafka.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-kafka.yaml
@@ -197,12 +197,14 @@ network:
           consensus: kafka
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: kafka
           grpc:
             port: 7050      
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         
 
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
@@ -199,6 +199,7 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           status: existing
@@ -206,13 +207,15 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           status: existing
           type: orderer
           consensus: raft
           grpc:
-            port: 7050  
+            port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer4
           status: new
@@ -220,3 +223,4 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer4.org1ambassador.blockchaincloudpoc.com:8443

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -226,18 +226,22 @@ network:
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer1.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer2
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer2.org1ambassador.blockchaincloudpoc.com:8443
         - orderer:
           name: orderer3
           type: orderer
           consensus: raft
           grpc:
             port: 7050
+          ordererAddress: orderer3.org1ambassador.blockchaincloudpoc.com:8443
+
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
     - organization:
       name: manufacturer

--- a/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
@@ -175,6 +175,7 @@ network:
           metrics:
             enabled: false
             port: 9443
+          ordererAddress: orderer1.develop.local.com:8443
 
     # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
     - organization:

--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -613,7 +613,8 @@
             "name": { "type": "string","pattern": "^[a-z0-9-]{1,30}$","description":"Name of the Orderer service"},
             "consensus": {"type":"string","enum": ["kafka","raft"]},
             "grpc":{ "$ref":"#/definitions/shared_port"},
-            "metrics": { "$ref": "#/definitions/shared_metrics"}
+            "metrics": { "$ref": "#/definitions/shared_metrics"},
+            "ordererAddress": { "type": "string","pattern": "^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?::[0-9]{2,5})?$"}
             },
           "required": [ "type","name","consensus","grpc"],
           "additionalProperties": false


### PR DESCRIPTION
### **Commit to be reviewed**
---
**feat(fabric): fix hardcoded port 8443 and introduce the ordererAddress field**

```
This commit removes all occurrences of the hardcoded port and introduces a new field called ordererAddress. This new field will be used to refer to the orderer address, similar to how peerAddress is used for the peer address.

Changes Made:
- Removed all occurrences of port 8443 in the Fabric codebase.
- Introduced the new ordererAddress field for referring to the orderer address.

By making this change, it is no longer necessary to rely on a proxy check when determining the orderer or peer address. This improves flexibility and makes the codebase more maintainable.
```

fixes: #2273