### PR TITLE
[ci-skip] make docker credentials section optional in network.yaml

### DIFF
--- a/platforms/hyperledger-fabric/charts/anchorpeer/templates/anchorpeer.yaml
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/templates/anchorpeer.yaml
@@ -27,8 +27,10 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
@@ -28,8 +28,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/ca/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/ca/templates/deployment.yaml
@@ -42,8 +42,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }} 
     spec:
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       - name: ca-server-db
         persistentVolumeClaim:

--- a/platforms/hyperledger-fabric/charts/catools/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/templates/deployment.yaml
@@ -35,8 +35,10 @@ spec:
         name: {{ .Values.metadata.name }}
     spec:
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       - name: ca-tools-pv
         persistentVolumeClaim:

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
@@ -28,8 +28,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/create_channel/templates/create_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/templates/create_channel.yaml
@@ -32,8 +32,10 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca
@@ -147,8 +149,8 @@ spec:
           mountPath: /secret
       containers:
       - name: createchannel
-        image: {{ $.Values.metadata.images.fabrictools }}
-        imagePullPolicy: IfNotPresent
+        image: {{ $.Values.metadata.images.fabrictools }}  
+        imagePullPolicy: IfNotPresent 
         stdin: true
         tty: true
         command: ["sh", "-c"]

--- a/platforms/hyperledger-fabric/charts/external_chaincode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/external_chaincode/templates/deployment.yaml
@@ -34,8 +34,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:   
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
     {{ if .Values.chaincode.tls }}
       volumes:
       {{ if .Values.vault.tls  }}

--- a/platforms/hyperledger-fabric/charts/fabric_cli/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/templates/deployment.yaml
@@ -20,8 +20,10 @@ spec:
         app: cli
     spec:
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       - name: {{ .Values.peer.name }}-cli-pv
         persistentVolumeClaim:

--- a/platforms/hyperledger-fabric/charts/generate_cacerts/templates/job.yaml
+++ b/platforms/hyperledger-fabric/charts/generate_cacerts/templates/job.yaml
@@ -28,8 +28,10 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       - name: certcheck
         emptyDir:

--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/install_external_chaincode/templates/install_external_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_external_chaincode/templates/install_external_chaincode.yaml
@@ -23,8 +23,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/operations_console/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/operations_console/templates/deployment.yaml
@@ -46,8 +46,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:   
       serviceAccountName: {{ $.Values.service.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.service.imagesecretname }}
+      {{- end }}
       containers:
       - name: couchdb
         image: {{ $.Values.metadata.images.couchdb }} 

--- a/platforms/hyperledger-fabric/charts/orderernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/templates/deployment.yaml
@@ -45,8 +45,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }} 
     spec:    
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       - name: certificates
         emptyDir:

--- a/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
@@ -46,8 +46,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:   
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       initContainers:
       - name: certificates-init
         image: {{ $.Values.metadata.images.alpineutils}}

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/job.yaml
+++ b/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/job.yaml
@@ -28,8 +28,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }} 
     spec:
       restartPolicy: OnFailure
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       serviceAccountName: {{ $.Values.vault.reviewer_service }}
       volumes:
       {{ if .Values.vault.tls  }}

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/templates/verify_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/templates/verify_chaincode.yaml
@@ -29,8 +29,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      {{- if .Values.vault.imagesecretname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
+      {{- end }}
       volumes:
       {{ if .Values.vault.tls  }}
       - name: vaultca

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/anchorpeer_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/anchorpeer_job.tpl
@@ -41,7 +41,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/users/admin
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}      
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}      
 
     channel:
       name: {{channel_name}}      

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/approve_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/approve_chaincode_job.tpl
@@ -35,7 +35,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/users/admin 
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     orderer:
       address: {{ participant.ordererAddress }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-orderer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-orderer.tpl
@@ -62,7 +62,11 @@ spec:
       secretkey: {{ vault.secret_path | default('secretsv2') }}/data/crypto/ordererOrganizations/{{ component_name | e }}/ca?{{ component_name | e }}-CA.key
       secretadminpass: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ component_name | e }}/ca/{{ component }}?user
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
     service:
       servicetype: ClusterIP
       ports:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-peer.tpl
@@ -62,7 +62,11 @@ spec:
       secretkey: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_name | e }}/ca?{{ component_name | e }}-CA.key
       secretadminpass: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ component_name | e }}/ca/{{ component }}?user
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
     service:
       servicetype: ClusterIP
       ports:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-tools.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-tools.tpl
@@ -70,7 +70,11 @@ spec:
       secretcouchdb: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ component_name }}/couchdb/{{ org_name }}
       secretconfigfile: {{ vault.secret_path | default('secretsv2') }}/data/crypto/{{ component_type }}Organizations/{{ component_name | e }}/msp/config
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
     
     healthcheck: 
       retries: 10

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cacerts_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cacerts_job.tpl
@@ -32,7 +32,11 @@ spec:
       secretcryptoprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/{{ component_type }}Organizations/{{ component }}-net/ca
       secretcredentialsprefix: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ component }}-net/ca/{{ component }}
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       
     ca:
       subject: {{ subject }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cli.tpl
@@ -32,7 +32,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/users/admin
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     peer:
       name: {{ peer.name }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/commit_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/commit_chaincode_job.tpl
@@ -36,7 +36,11 @@ spec:
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       secretpath: {{ vault.secret_path | default('secretsv2') }}
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     orderer:
       address: {{ participant.ordererAddress }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
@@ -37,9 +37,13 @@ spec:
       authpath: {{ network.env.type }}{{ component_ns }}-auth
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/users/admin
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/orderer 
-      serviceaccountname: vault-auth
+      serviceaccountname: vault-auth 
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
-
+{% else %}
+      imagesecretname: ""
+{% endif %}
+    
     channel:
       name: {{ component_name }}
     orderer:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
@@ -38,7 +38,11 @@ spec:
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       secretgitprivatekey: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ namespace }}/git
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     orderer:
       address: {{ orderer_address }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_external_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_external_chaincode_job.tpl
@@ -38,7 +38,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/users/admin 
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       secretgitprivatekey: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ namespace }}/git?git_password
       tls: false
       chaincodepackageprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/chaincodes/{{ component_chaincode.name | lower | e }}/package/v{{ component_chaincode.version }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/instantiate_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/instantiate_chaincode_job.tpl
@@ -35,7 +35,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/users/admin 
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     orderer:
       address: {{ participant.ordererAddress }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
@@ -39,7 +39,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/users/admin 
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     orderer:
       address: {{ participant.ordererAddress }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
@@ -41,7 +41,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/users/admin
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ component_ns }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
 
     channel:
       name: {{channel_name}}      

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/operations_console.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/operations_console.tpl
@@ -31,7 +31,11 @@ spec:
       name: {{ name }}console
       default_consortium: {{ default_consortium }}
       serviceaccountname: default
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       servicetype: ClusterIP
       ports:
         console:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
@@ -75,7 +75,11 @@ spec:
       role: vault-role
       authpath: {{ network.env.type }}{{ namespace }}-auth
       secretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/ordererOrganizations/{{ namespace }}/orderers/{{ orderer.name }}.{{ namespace }}
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       serviceaccountname: vault-auth
 {% if orderer.consensus == 'kafka' %}
     kafka:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/upgrade_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/upgrade_chaincode_job.tpl
@@ -35,7 +35,11 @@ spec:
       adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/users/admin 
       orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       tls: false
     orderer:
       address: {{ participant.ordererAddress }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
@@ -82,7 +82,11 @@ spec:
       secretprefix: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/peers/{{ peer_name }}.{{ namespace }}
       secretambassador: {{ vault.secret_path | default('secretsv2') }}/data/crypto/peerOrganizations/{{ namespace }}/ambassador
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
       secretcouchdbpass: {{ vault.secret_path | default('secretsv2') }}/data/credentials/{{ namespace }}/couchdb/{{ name }}?user
 
     service:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/vault_kubernetes_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/vault_kubernetes_job.tpl
@@ -32,7 +32,11 @@ spec:
       policy: vault-crypto-{{ component_type }}-{{ name }}-net-ro
       secret_path: {{ vault.secret_path }}
       serviceaccountname: vault-auth
+{% if network.docker.username is defined and network.docker.password is defined %}
       imagesecretname: regcred
+{% else %}
+      imagesecretname: ""
+{% endif %}
     
     k8s:
       kubernetes_url: {{ kubernetes_url }}

--- a/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -27,6 +27,7 @@
     namespace: "{{ item.name | lower}}-net"
     kubernetes: "{{ item.k8s }}"
     check: "docker_credentials"
+  when: network.docker.username is defined and network.docker.password is defined
 
 #############################################################################################
 # This task creates secrets for the root token


### PR DESCRIPTION
This pull request aims to make the Docker credentials section optional in the network.yaml file of Hyperledger Fabric. By doing so, will have the flexibility to include or exclude the Docker credentials based on the deployment requirements.

Changes Made:
1. Made the docker username and passsword section optional by allowing us to exclude it or leave it empty if not required.
2. Updated the relevant charts and tpl files to reflect the optional docker credentials section.
3. In the file Hyperledger-fabric/configuration/roles/setup/vault Kubernetes/tasks/main.yaml, docker pull credentials are only created when a specific condition is met.

Fixes: #613