### PR TITLE
[besu] use default securityContext

### DIFF
--- a/platforms/hyperledger-besu/configuration/roles/create/helm_component/templates/node_besu.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/helm_component/templates/node_besu.tpl
@@ -128,3 +128,8 @@ spec:
     metrics:
       enabled: {{ peer.metrics.enabled | default(false)}}
       port: {{ peer.metrics.port | default(9545) }}
+
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 3000

--- a/platforms/hyperledger-besu/configuration/roles/create/helm_component/templates/validator.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/create/helm_component/templates/validator.tpl
@@ -114,3 +114,8 @@ spec:
     metrics:
       enabled: {{ peer.metrics.enabled | default(false)}}
       port: {{ peer.metrics.port | default(9545) }}    
+
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 3000


### PR DESCRIPTION
```
This commit implements the following changes:
- use the securityContext in the besu and validator nodes.

These changes enable besu and validator nodes to run with default securityContext.
```