### PR TITLE
[ci-skip] add README.md files for each Helm chart

### DIFF
--- a/platforms/hyperledger-fabric/charts/anchorpeer/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for updating the anchorpeer details
+description: "Hyperledger Fabric: Updates the anchorpeer details."
 name: anchorpeer
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/anchorpeer/README.md
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/README.md
@@ -1,0 +1,198 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "anchor-peer-hyperledger-fabric-deployment"></a>
+# Anchor Peer Hyperledger Fabric Deployment
+
+- [Anchor Peer Hyperledger Fabric Deployment Helm Chart](#anchor-peer-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "anchor-peer-hyperledger-fabric-deployment-helm-chart"></a>
+## Anchor Peer Hyperledger Fabric Deployment Helm Chart
+---
+This [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/anchorpeer) updates the anchor peers for the Hyperledger Fabric channel.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+anchorpeer/
+  |- templates/
+      |- _helpers.yaml
+      |- anchorpeer.yaml
+      |- configmap.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `anchorpeer.yaml`: Uses two initContainers to fetch the orderer TLS certificates and the MSP certificates from Vault. The main container then uses the fetched certificates to update the anchor peer for the channel.
+- `configmap.yaml`: Stores configuration data for an anchor peer. The file contains two ConfigMaps, one for the configuration data and one for the artifacts. The configuration ConfigMap contains the key-value pairs that are used to configure the peer, and the artifacts ConfigMap contains the base64-encoded transaction that anchors the peer to the channel.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/anchorpeer/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Metadata
+
+| Name                  | Description                                                                       | Default Value                                     |
+| ----------------------| ----------------------------------------------------------------------------------| --------------------------------------------------|
+| namespace             | Provide the namespace for organization's peer                                     | org1-example-com                                  |
+| images.fabrictools    | Provide the valid image name and version                                          | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils    | Provide the valid image name and version to read certificates from vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Provide the custom labels                                                         | anchorpeer                                        |
+
+### Peer
+
+| Name          | Description                                                                                             | Default Value                 |
+| --------------| --------------------------------------------------------------------------------------------------------| ------------------------------|
+| name          | Provide the name of the peer as per deployment yaml                                                     | peer0                         |
+| address       | Provide the address of the peer which will update the channel about the anchor peer of the organization | peer0.org1-example-com:7051   |
+| localmspid    | Provide the localmspid for organization                                                                 | org1MSP                       |
+| loglevel      | Provide the loglevel for organization's peer                                                            | debug                         |
+| tlsstatus     | Provide the value for tlsstatus to be true or false for organization's peer                             | true                          |
+
+### Vault
+
+| Name                 | Description                                                                 | Default Value                |
+| ---------------------| ----------------------------------------------------------------------------| -----------------------------|
+| role                 | Provide the vaultrole for an organization                                   | vault-role                   |
+| address              | Provide the vault server address                                            | ""                           |
+| authpath             | Provide the kubernetes auth backed configured in vault for an organization  | fra-demo-hlkube-cluster-org1 |
+| adminsecretprefix    | PProvide the value for vault secretprefix                                   | secret/                      |
+| orderersecretprefix  | Provide the value for vault secretprefix                                    | secret/                      |
+| serviceaccountname   | Provide the serviceaccount name for vault                                   | vault-auth                   |
+| imagesecretname      | Provide the imagesecretname for vault                                       | ""                           |
+| tls                  | Enable or disable TLS for vault communication                               | vaultca                      |
+
+### Channel
+
+| Name      | Description                          | Default Value |
+| ----------| -------------------------------------|---------------|
+| name      | Provide the name of the channel      | mychannel     |
+
+### orderer
+
+| Name       | Description                        | Default Value              |
+| -----------| -----------------------------------|----------------------------|
+| address    | Provide the address for orderer    | orderer.fratest-com:7050   |
+
+### anchorstx
+
+| Name           | Description                                              | Default Value |
+| ---------------| ---------------------------------------------------------| ------------- |
+| anchorstx      | Provide the base64 encoded file contents for anchorstx   | ""            |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the anchorpeer Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/anchorpeer/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./anchorpeer
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the anchorpeer job to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/anchorpeer/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./anchorpeer
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the anchorpeer node is up to date.
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Anchor Peer Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/anchorpeer), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/anchorpeer/values.yaml
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/values.yaml
@@ -7,74 +7,74 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabric-tools: hyperledger/fabrictools:1.4.0
-    fabrictools:
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils:
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
   #      role: anchorpeer
-  labels:
+  labels: anchorpeer
 
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer which will update the channel about the anchor peer of the organization
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: debug
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
-  #Provide the serviceaccountname for vault
+  orderersecretprefix: secret/orderersecretprefix/
+  #Provide the serviceaccount name for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel
 
 orderer:
   #Provide the address for orderer
   #Eg. address: orderer.fratest-com:7050
-  address:
+  address: orderer.fratest-com:7050
 
 #Provide the base64 encoded file contents for anchorstx
 anchorstx: 

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode instantiation on a peer
+description: "Hyperledger Fabric: Approves the chaincode."
 name: approve_chaincode
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/README.md
@@ -1,0 +1,212 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "approve-chaincode-hyperledger-fabric-deployment"></a>
+# Approve Chaincode Hyperledger Fabric Deployment
+
+- [Approve Chaincode Hyperledger Fabric Deployment Helm Chart](#approve-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "approve-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Approve Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/approve_chaincode) to approve the chaincode.
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+approve_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- approve_chaincode.yaml
+      |- configmap.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `approve_chaincode.yaml`: Retrieves necessary certificates from Vault, checks if the chaincode is already approved. If it is, the job exits. If the chaincode is not approved, the job extracts the package ID of the chaincode and creates a command to approve the chaincode for the organization. The job then evaluates the endorsement policy, if any, and adds it to the command. Finally, the job runs the command to approve the chaincode.
+- `configmap.yaml`: stores the private data collection configuration for a chaincode. The ConfigMap is optional, and it is only used if the chaincode.pdc.enabled value is set. Otherwise, the default configuration for the Fabric CA server will be used.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/approve_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Metadata
+
+| Name                  | Description                                                                       | Default Value                                    |
+| ----------------------| ----------------------------------------------------------------------------------| -------------------------------------------------|
+| namespace             | Provide the namespace for organization's peer                                     | org1-example-com                                 |
+| images.fabrictools    | Provide the valid image name and version                                          | hyperledger/fabric-tools:2.2.2                   |
+| images.alpineutils    | Provide the valid image name and version to read certificates from vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0 |
+| labels                | Provide the custom labels                                                         | create_channel                                   |
+
+### Peer
+
+| Name          | Description                                                                                             | Default Value                |
+| --------------| --------------------------------------------------------------------------------------------------------| -----------------------------|
+| name          | Provide the name of the peer as per deployment yaml                                                     | peer0                        |
+| address       | Provide the address of the peer which will update the channel about the anchor peer of the organization | peer0.org1-example-com:7051  |
+| localmspid    | Provide the localmspid for organization                                                                 | Org1MSP                      |
+| loglevel      | Provide the loglevel for organization's peer                                                            | debug                        |
+| tlsstatus     | Provide the value for tlsstatus to be true or false for organization's peer                             | true                         |
+
+### Vault
+
+| Name                 | Description                                                                 | Default Value                |
+| ---------------------| ----------------------------------------------------------------------------| -----------------------------|
+| role                 | Provide the vaultrole for an organization                                   | vault-role                   |
+| address              | Provide the vault server address                                            | ""                           |
+| authpath             | Provide the kubernetes auth backed configured in vault for an organization  | fra-demo-hlkube-cluster-org1 |
+| adminsecretprefix    | Provide the value for vault secretprefix                                    | secret/adminsecretprefix/    |
+| orderersecretprefix  | Provide the value for vault secretprefix                                    | secret/orderersecretprefix/  |
+| serviceaccountname   | Provide the serviceaccount name for vault                                   | vault-auth                   |
+| imagesecretname      | Provide the imagesecretname for vault                                       | ""                           |
+| tls                  | Enable or disable TLS for vault communication                               | vaultca                      |
+
+### Orderer
+
+| Name         | Description                        | Default Value                 |
+| -------------| -----------------------------------| ------------------------------|
+| address      | Provide the address for orderer    | orderer-ext.example-com:443   |
+
+### Chaincode
+
+| Name                          | Description                                               | Default Value                             |
+| ------------------------------| ----------------------------------------------------------| ------------------------------------------|
+| builder                       | Chaincode builder image for Fabric                        | hyperledger/fabric-ccenv:1.4.8            |
+| name                          | Name of the chaincode to be committed                     | example                                   |
+| version                       | Version of the chaincode to be committed                  | 1                                         |
+| sequence                      | Chaincode sequence (applies to Fabric 2.2.x)              | 1                                         |
+| lang                          | Language of the chaincode                                 | golang                                    |
+| commitarguments               | Commit arguments for the chaincode                        | ""                                        |
+| endorsementpolicies           | Endorsement policies for the chaincode                    | ""                                        |
+| repository.hostname           | Hostname of the chaincode repository                      | github.com                                |
+| repository.git_username       | Git username for the chaincode repository                 | user                                      |
+| repository.url                | URL of the chaincode repository                           | github.com/hyperledger/bevel-samples.git  |
+| repository.branch             | Branch of the chaincode repository                        | main                                      |
+| repository.path               | Path to the chaincode within the repository               | .                                         |
+| repository.collectionsconfig  | Collections configuration for the chaincode               | ""                                        |
+| pdc.enabled                   | Enable private data collections for the chaincode         | false                                     |
+| pdc.collectionsconfig         | Collections configuration for private data collections    | ""                                        |
+
+### Channel
+
+| Name    | Description            | Default Value |
+| --------| -----------------------| ------------- |
+| name    | Name of the channel    | mychannel     |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the approve_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/approve_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./approve_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the approve_chaincode job to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/approve_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./approve_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the approve_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Approve Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/approve_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/values.yaml
@@ -7,19 +7,19 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
     fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg. alpineutils: gcr.io/acn-stp-on-blockchain/alpine-utils
-    alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
   #      role: create_channel
-  labels:
+  labels: create_channel
 
 
 peer:
@@ -28,10 +28,10 @@ peer:
   name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
   loglevel: debug
@@ -49,28 +49,28 @@ vault:
   address: ""
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath: ""
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix: ""
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix: ""
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
   serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Eg. address: orderer-ext.example-com:443
+  address: orderer-ext.example-com:443
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
@@ -94,17 +94,25 @@ chaincode:
   #Eg.endorsementpolicies: "OR('Org1MSP.peer', 'Org2MSP.peer')"
   endorsementpolicies: ""
   repository:
+    # Hostname of the chaincode repository
     hostname: "github.com"
+    # Git username for the chaincode repository
     git_username: "user"
+    # URL of the chaincode repository
     url: "github.com/hyperledger/bevel-samples.git"
+    # Branch of the chaincode repository
     branch: "main"
+    # Path to the chaincode within the repository
     path: "."
+    # Collections configuration for the chaincode
     collectionsconfig: ""
   pdc:
+    # Enable private data collections for the chaincode
     enabled: false
+    # Collections configuration for private data collections
     collectionsconfig: ""
 
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel

--- a/platforms/hyperledger-fabric/charts/ca/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/ca/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for CA server
+description: "Hyperledger Fabric: Deploys a CA server."
 name: ca
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/ca/README.md
+++ b/platforms/hyperledger-fabric/charts/ca/README.md
@@ -1,0 +1,219 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "ca-server-hyperledger-fabric-deployment"></a>
+# CA Server Hyperledger Fabric Deploymen
+
+- [CA Server Hyperledger Fabric Deployment Helm Chart](#ca-server-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "ca-server-hyperledger-fabric-deployment-helm-chart"></a>
+## CA Server Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/ca) to deploy a CA server.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+ca/
+  |- conf/
+      |- fabric-ca-server-config-default.yaml
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- deployment.yaml
+      |- service.yaml
+      |- volume.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `fabric-ca-server-config-default.yaml`: Configuration file for the fabric-ca-server command.
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Store the configuration for the Fabric CA server. The configuration file is stored in the fabric-ca-server-config.yaml file, and it is mounted into the Fabric CA server container. The ConfigMap is optional, and it is only used if the server.configpath value is set. Otherwise, the default configuration for the Fabric CA server will be used.
+- `deployment.yaml`: Deploys CA server Pod, allowing it to handle certificate-related operations within the Hyperledger Fabric blockchain network. To ensure the security and proper configuration of the CA server, the included init-container retrieves essential secrets from a Vault server.
+- `service.yaml`: Expose a Fabric CA server to the outside world either using Ambassador or HaProxy as a reverse proxy engine.
+- `volume.yaml`: Defines a persistent volume that can be used to store the Fabric CA server's database.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/ca/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+## Parameters
+---
+
+### Metadata
+
+| Name                  | Description                                                      | Default Value                                     |
+| ----------------------| -----------------------------------------------------------------| --------------------------------------------------|
+| namespace             | Namespace for CA server                                          | default                                           |
+| images.ca             | image name and version for fabric ca                             | hyperledger/fabric-ca:1.4.8                       |
+| images.alpineutils    | image name and version to read certificates from vault server    | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Provide the custom labels                                        | ca                                                |
+
+### Server
+
+| Name                  | Description                                                      | Default Value                              |
+| ----------------------| -----------------------------------------------------------------| -------------------------------------------|
+| name                  | Name for CA server deployment                                    | ca                                         |
+| tlsstatus             | Specify if TLS is enabled or disabled for the deployment         | true                                       |
+| admin                 | Admin name for CA server                                         | admin                                      |
+| configpath            | Path for Fabric CA Server Config                                 | conf/fabric-ca-server-config-default.yaml  |
+
+### Storage
+
+| Name                  | Description                           | Default Value |
+| ----------------------| --------------------------------------| ------------- |
+| storageclassname      | Storage class name for CA server      | aws-storage   |
+| storagesize           | Size of storage for CA server         | 512Mi         |
+
+### Vault
+
+| Name                  | Description                                                         | Default Value                     |
+| ----------------------| --------------------------------------------------------------------| --------------------------------- |
+| address               | Vault server address                                                | ""                                |
+| role                  | Vault role for deployment                                           | vault-role                        |
+| authpath              | Kubernetes auth backend configured in Vault for CA server           | fra-demo-hlkube-cluster-cluster   |
+| secretcert            | Path of secret certificate configured in Vault for CA server        | secret/secretcert/                |
+| secretkey             | Path of secret key configured in Vault for CA server                | secret/secretkey/                 |
+| secretadminpass       | Secret path for admin password configured in Vault for CA server    | secret/secretadminpass/           |
+| serviceaccountname    | Service account name for Vault                                      | vault-auth                        |
+| imagesecretname       | Image secret name for Vault                                         | ""                                |
+| tls                   | Enable or disable TLS for Vault communication                       | true                              |
+| tlssecret             | Kubernetes secret for Vault CA certificate                          | vaultca                           |
+
+### Service
+
+| Name                      | Description                                        | Default Value  |
+| --------------------------| ---------------------------------------------------| ---------------|
+| servicetype               | Service type for the pod                           | ClusterIP      |
+| ports.tcp.nodeport        | TCP node port to be exposed for CA server          | 30007          |
+| ports.tcp.clusteripport   | TCP cluster IP port to be exposed for CA server    | 7054           |
+
+### Annotations
+
+| Name        | Description                            | Default Value |
+| ------------| ---------------------------------------| ------------- |
+| service     | Extra annotations for the service      | ""            |
+| pvc         | Extra annotations for the PVC          | ""            |
+
+### Proxy
+
+| Name                  | Description                                                              | Default Value                  |
+| ----------------------| -------------------------------------------------------------------------|--------------------------------|
+| provider              | Proxy/ingress provider. Possible values: "ambassador" or "haproxy"       | haproxy                        |
+| type                  | Type of the deployment. Possible values: "orderer", "peer", or "test"    | test                           |
+| external_url_suffix   | External URL suffix for the organization                                 | org1.blockchaincloudpoc.com    |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the ca Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/ca/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./ca
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the ca server node to the Kubernetes cluster based on the provided configurations.
+
+
+a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/ca/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./ca
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the ca server node is up to date.
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [CA Server Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/ca), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/ca/values.yaml
+++ b/platforms/hyperledger-fabric/charts/ca/values.yaml
@@ -11,15 +11,15 @@ metadata:
   images:
     #Provide the valid image name and version for fabric ca
     #Eg. ca: hyperledger/fabric-ca:1.4.0
-    ca:
+    ca: hyperledger/fabric-ca:1.4.8
     #Provide the valid image name and version to read certificates from vault server
     #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , run.
   #Eg. labels:
   #      role: ca
-  labels:
+  labels: ca
 
 deployment:
   annotations:
@@ -27,13 +27,13 @@ deployment:
 server:
   #Provide name for ca server deployment
   #Eg. name: ca
-  name:
+  name: ca
   #Provide the value for tlsstatus to be true or false for  deployment
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
   #Provide the admin name for CA server
-  #Eg. admin:
-  admin:
+  #Eg. admin: admin
+  admin: admin
   # Provide the path for Fabric CA Server Config
   # Eg. configpath: conf/fabric-ca-server-config-default.yaml
   configpath: conf/fabric-ca-server-config-default.yaml
@@ -41,42 +41,42 @@ server:
 storage:
   #Provide the storageclassname for CA
   #Eg. storageclassname: aws-storage
-  storageclassname:
+  storageclassname: aws-storage
   #Provide the storagesize for CA
   #Eg. storagesize: 512Mi
-  storagesize:
+  storagesize: 512Mi
 
 vault:
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the vaultrole for  deployment
-  #Eg. vaultrole: -vault-role
-  role: 
+  #Eg. vaultrole: vault-role
+  role: vault-role
   #Provide the kubernetes auth backend configured in vault for CA server
   #Eg. authpath: fra-demo-hlkube-cluster-cluster
-  authpath:
+  authpath: fra-demo-hlkube-cluster-cluster
   #Provide the secretcert path configured in vault for CA server
   #Eg. secretcert: secret/crypto/Organizations/.../...-cert.pem
-  secretcert:
+  secretcert: secret/secretcert/
   #Provide the secretkey path configured in vault for CA server
   #Eg. secretkey: secret/crypto/Organizations/.../...-CA.key
-  secretkey:
+  secretkey: secret/secretkey/
   # Provide the secret path for admin password configured in vault for CA server
   # Eg. secretadminpass: secret/credentials/example-com/ca/orderer?user
-  secretadminpass:
+  secretadminpass: secret/secretadminpass/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Enable or disable TLS for vault communication
   #Eg. tls: true
-  tls:
+  tls: true
   #kuberenetes secret for vault ca.cert
   #Eg. tlssecret: vaultca
-  tlssecret:
+  tlssecret: vaultca
 
 
 service:
@@ -87,23 +87,24 @@ service:
     tcp:
       #Provide tcp node port to be exposed for ca server
       #Eg. nodeport: 30007
-      nodeport:
+      nodeport: 30007
       #Provide tcp cluster IP port to be exposed for ca server
       #Eg. clusteripport: 7054
       clusteripport: 7054
 
 annotations:
-  #Extra annotations wanted
-  service: {}
-  pvc: {}
+  # Extra annotations for the service
+  service: []
+  # Extra annotations for the PVC
+  pvc: []
   
 proxy:
   #This will be the proxy/ingress provider. Can have values "ambassador" or "haproxy"
   #Eg. provider: "haproxy"
-  provider: 
+  provider: haproxy
   #Type can be "orderer" or "peer"; "test" is defaulted
   #Eg. type: orderer
   type: test
   #This field specifies the external url for the organization
   #Eg. external_url_suffix: org1.blockchaincloudpoc.com
-  external_url_suffix:
+  external_url_suffix: org1.blockchaincloudpoc.com

--- a/platforms/hyperledger-fabric/charts/catools/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for Fabric CA tools
+description: "Hyperledger Fabric: Deploys a Fabric CA tools."
 name: catools
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/catools/README.md
+++ b/platforms/hyperledger-fabric/charts/catools/README.md
@@ -1,0 +1,251 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "ca-tools-hyperledger-fabric-deployment"></a>
+# CA Tools Hyperledger Fabric Deployment
+
+- [CA Tools Hyperledger Fabric Deployment Helm Chart](#ca-tools-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "ca-tools-hyperledger-fabric-deployment-helm-chart"></a>
+## CA Tools Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/catools) to deploy Fabric CA tools.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+catools/
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- deployment.yaml
+      |- volume.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Contains definitions for six different configmaps. These configmaps will be used by the main and store-vault containers through volume mounting to support their respective tasks.
+- `deployment.yaml`: The init-container generates the cryptographic material for the Fabric CA server and checks if the cryptographic material already exists in Vault. If it does, the init-container will skip the generation process. The main container runs the Fabric CA server, issues certificates to clients in the organization, and has a liveness probe that checks if the Fabric CA server is running. The store-vault container stores the cryptographic material in Vault, Checks if any certificates have not been stored correctly.
+- `volume.yaml`: Defines 2 persistent volume to store the data. 
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/catools/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                       | Default Value       |
+| ----------------------| --------------------------------------------------| ------------------- |
+| namespace             | Namespace for CA deployment                       | example-com         |
+| name                  | Name for CA server deployment                     | ca-tools            |
+| component_type        | Organization's type (orderer or peer)             | orderer             |
+| org_name              | Organization's name in lowercase                  | org1                |
+| proxy                 | Proxy/ingress provider (ambassador or haproxy)    | haproxy             |
+
+### Replica
+
+| Name                  | Description                 | Default Value  |
+| ----------------------| --------------------------- | ---------------|
+| replicaCount          | Number of replica pods      | 1              |
+
+### Image
+
+| Name          | Description                                                             | Default Value                                       |
+| --------------| ------------------------------------------------------------------------| ----------------------------------------------------|
+| repository    | Image name for the server container                                     | hyperledger/fabric-ca-tools                         |
+| tag           | Image tag for the server container                                      | 1.3.0                                               |
+| pullPolicy    | Image pull policy                                                       | IfNotPresent                                        |
+| alpineutils   | Valid image name and version to read certificates from the vault server | index.docker.io/hyperledgerlabs/alpine-utils:1.0    |
+
+### Annotations
+
+| Name           | Description                           | Default Value   |
+| ---------------| --------------------------------------|-----------------|
+| pvc            | Extra annotations for PVC             | ""              |
+| deployment     | Extra annotations for Deployment      | ""              |
+
+### Storage
+
+| Name                  | Description                 | Default Value       |
+| ----------------------| --------------------------- | ------------------- |
+| storageclassname      | Storage class name          | aws-storage         |
+| storagesize           | Storage size for CA         | 512Mi               |
+
+### Vault
+
+| Name                  | Description                                                       | Default Value                     |
+| ----------------------| ------------------------------------------------------------------|-----------------------------------|
+| role                  | Vault role for an organization                                    | org1-vault-role                   |
+| address               | Vault server address                                              | ""                                |
+| authpath              | Kubernetes auth backend configured in vault for an organization   | fra-demo-hlkube-cluster-org1      |
+| secretmsp             | Path configured in vault for admin MSP                            | secret/secretmsp/                 |
+| secrettls             | Path configured in vault for admin TLS                            | secret/secrettls/                 |
+| secretorderer         | Path configured in vault for orderers                             | secret/secretorderer/             |
+| secretpeerorderertls  | Path configured in vault for peer orderer TLS                     | secret/secretpeerorderertls/      |
+| secretambassador      | Path configured in vault for ambassador credentials               | secret/secretambassador/          |
+| secretcert            | Path configured in vault for CA server certificate                | secret/secretcert/                |
+| secretkey             | Path configured in vault for CA server private key                | secret/secretkey/                 |
+| secretconfigfile      | Path configured in vault for MSP config.yaml file                 | secret/secretconfigfile/          |
+| secretcouchdb         | Path configured in vault for CouchDB credentials                  | secret/secretcouchdb/             |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                        |
+| imagesecretname       | Image secret name for Vault                                       | ""                                |
+
+### HealthCheck
+
+| Name                  | Description                                                               | Default Value  |
+| ----------------------| --------------------------------------------------------------------------| ---------------|
+| retries               | Number of times to retry fetching from/writing to Vault before giving up  | 10             |
+| sleepTimeAfterError   | Time in seconds to wait after an error occurs when interacting with Vault | 15             |
+
+### Org_data
+
+| Name                  | Description                       | Default Value   |
+| ----------------------| ----------------------------------| ----------------|
+| external_url_suffix   | External URL of the organization  | ""              |
+| component_subject     | Organization's subject            | ""              |
+| cert_subject          | Organization's subject            | ""              |
+| component_country     | Organization's country            | UK              |
+| component_state       | Organization's state              | London          |
+| component_location    | Organization's location           | London          |
+| ca_url                | Organization's CA URL             | ""              |
+
+### Orderers
+
+| Name           | Description                           | Default Value  |
+| ---------------| --------------------------------------| ---------------|
+| name           | Orderer's name                        | orderer1       |
+| orderers_info  | Orderer's names and CA certificates   | ""             |
+
+### Peers
+
+| Name          | Description                 | Default Value    |
+| --------------| --------------------------- | -----------------|
+| name          | Peer's name                 | peer1            |
+| peer_count    | Total number of peers       | 4                |
+
+### Users
+
+| Name                  | Description                   | Default Value   |
+| ----------------------| ---------------------------   | ----------------|
+| users_list            | Base64 encoded list of users  | ""              |
+| users_identities      | List of user identities       | ""              |
+
+### Checks
+
+| Name                  | Description                 | Default Value       |
+| ----------------------| --------------------------- | ------------------- |
+| refresh_cert_value    | Refresh user certificates   | ""                  |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the catools Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/catools/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./catools
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the catools node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/catools/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./catools
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the catools node is up to date.
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [CA Tools Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/catools), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/catools/templates/_helpers.tpl
+++ b/platforms/hyperledger-fabric/charts/catools/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/hyperledger-fabric/charts/catools/values.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/values.yaml
@@ -7,34 +7,34 @@
 metadata:
   #Provide the namespace for CA deployment
   #Eg. namespace: example-com
-  namespace: 
+  namespace: example-com
   #Provide name for ca server deployment
   #Eg. name: ca-tools
-  name:
+  name: ca-tools
   #Provide organization's type (orderer or peer)
-  #Eg. namespace: orderer
-  component_type:
+  #Eg. component_type: orderer
+  component_type: orderer
   #Provide organization's name in lowercases
-  #Eg. namespace: org1 
-  org_name:
+  #Eg. org_name: org1 
+  org_name: org1
   #This will be the proxy/ingress provider. Can have values "ambassador" or "haproxy"
   #Eg. provider: "haproxy"
-  proxy:
+  proxy: haproxy
 # Provide the number of replica pods
 replicaCount: 1
 
 image:
   #Provide the image name for the server container
   #Eg. image: hyperledger/fabric-ca-tools
-  repository: 
+  repository: hyperledger/fabric-ca-tools
   #Provide the image tag for the server container
   #Eg. imagetag: 1.3.0
-  tag: 
+  tag: 1.3.0
   # Provide image pull policy
   pullPolicy: IfNotPresent
   #Provide the valid image name and version to read certificates from vault server
   #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-  alpineutils:
+  alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
 
 annotations:
   #Extra annotations
@@ -44,63 +44,63 @@ annotations:
 storage:
   #Provide the storageclassname for 
   #Eg. storageclassname: aws-storage
-  storageclassname: 
+  storageclassname: aws-storage
   #Provide the storagesize for CA
   #Eg. storagesize: 512Mi
-  storagesize: 
+  storagesize: 512Mi
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: org1-vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the path configured in vault for admin msp
   #Eg. secretmsp: secret/crypto/Organizations/.../.../admin/msp
-  secretmsp:
+  secretmsp: secret/secretmsp/
   #Provide the path configured in vault for admin msp
   #Eg. secretcert: secret/crypto/Organizations/.../.../admin/tls
-  secrettls:
+  secrettls: secret/secrettls/
   #Provide the path configured in vault for orderers
   #Eg. secrettls: secret/crypto/Organizations/.../.../orderers
-  secretorderer:
+  secretorderer: secret/secretorderer/
   #Provide the path configured in vault for orderers
   #Eg. secretpeerorderertls: secret/crypto/Organizations/.../.../orderers
-  secretpeerorderertls:
+  secretpeerorderertls: secret/secretpeerorderertls/
   #Provide the path configured in vault for ambassador creds
   #Eg. secretambassador: secret/crypto/Organizations/.../.../ambassador
-  secretambassador:
+  secretambassador: secret/secretambassador/
   #Provide the secretcert path configured in vault for CA server
   #Eg. secretcert: secret/crypto/Organizations/.../...-cert.pem
-  secretcert:
+  secretcert: secret/secretcert/
   #Provide the secretkey path configured in vault for CA server
   #Eg. secretkey: secret/crypto/Organizations/.../...-CA.key
-  secretkey:
+  secretkey: secret/secretkey/
   #Provide the path configured in vault for MSP config.yaml file
   #Eg. secretconfigfile: secret/crypto/Organizations/.../config
-  secretconfigfile:
+  secretconfigfile: secret/secretconfigfile/
   #Provide the path configured in vault for couchdb credentials
   #Eg. secretconfigfile: secret/credentials/.../couchdb/org1
-  secretcouchdb:
+  secretcouchdb: secret/secretcouchdb/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
 
 healthcheck: 
   # The amount of times to retry fetching from/writing to Vault before giving up.
   # Eg. retries: 10
-  retries:
+  retries: 10
   # The amount of time in seconds to wait after an error occurs when fetching from/writing to Vault.
   # Eg. sleepTimeAfterError: 15  
-  sleepTimeAfterError:
+  sleepTimeAfterError: 15
 
 org_data:
   #External URL of the organization
@@ -112,29 +112,29 @@ org_data:
   #Provide organization's subject
   #Eg. "O=Orderer,L=51.50/-0.13/London,C=GB"
   cert_subject:
-  #Provide organization's subject
+  #Provide organization's country
   #Eg. UK
-  component_country:
+  component_country: UK
   #Provide organization's state
   #Eg. London
-  component_state:
+  component_state: London
   #Provide organization's location
   #Eg. Lodon
-  component_location:
+  component_location: Lodon
   #Provide organization's ca_url
-  #Eg. "ca.supplychain-net.org1.blockchaincloudpoc.com:8443"
+  #Eg. "ca.supplychain-net.org1.blockchaincloudpoc.com"
   ca_url:
   
 #Provide orderer's names
 orderers:
-      name:     
+      name: orderer1    
 #Provide orderer's names and ca certificates
 orderers_info: {}
 #Provide peer's names
 peers:
-  name:
+  name: peer1
 #Provide the total number of peers
-peer_count:
+peer_count: 4
 
 users: 
     #Base64 encoded list of users

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode instantiation on a peer
+description: "Hyperledger Fabric: Commits a chaincode to a channel."
 name: commit_chaincode
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/README.md
@@ -1,0 +1,222 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "commit-chaincode-hyperledger-fabric-deployment"></a>
+# Commit Chaincode Hyperledger Fabric Deployment
+
+- [Commit Chaincode Hyperledger Fabric Deployment Helm Chart](#commit-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "commit-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Commit Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/commit_chaincode) commits a chaincode to a channel.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+commit_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- commit_chaincode.yaml
+      |- configmap.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `commit_chaincode.yaml`: The certificates-init fetches certificates from Vault and stores them in local directories, formats the CA certificates for each Endorsing organization, and writes the CA certificates back to Vault. The commitchaincode commits a chaincode to a channel, first checking if it has already been committed, then checking if it is ready to be committed, and finally checking if a private data collection or endorsement policy is used.
+- `configmap.yaml`: Includes the collection configuration file. The commitchaincode container uses this data to commit the chaincode to the channel.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/commit_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                       | Default Value                                     |
+| ----------------------| --------------------------------------------------| --------------------------------                  |
+| namespace             | Namespace for organization's peer                 | peer0-net                                           |
+| images.fabrictools    | Image name and version for fabric tools           | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils    | Image name and version to read certificates       | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Custom labels (if applicable)                     | ""                                                |
+
+### Peer
+
+| Name             | Description                           | Default Value                  |
+| -----------------| --------------------------------------| -------------------------------|
+| name             | Name of the peer                      | peer0                          |
+| address          | Address of the peer                   | peer0.peer0-net:7051           |
+| localmspid       | Local MSP ID for organization         | Org1MSP                        |
+| loglevel         | Log level for organization's peer     | info                           |
+| tlsstatus        | TLS status for organization's peer    | true                           |
+
+### Vault
+
+| Name                  | Description                                    | Default Value                    |
+| ----------------------| -----------------------------------------------| -------------------------------- |
+| role                  | Vault role for the organization                | vault-role                       |
+| address               | Vault server address                           | ""                               |
+| authpath              | Kubernetes auth backend configured in Vault    | fra-demo-hlkube-cluster-org1     |
+| adminsecretprefix     | Vault secret prefix for admin credentials      | secret/adminsecretprefix/        |
+| orderersecretprefix   | Vault secret prefix for orderer credentials    | secret/orderersecretprefix/      |
+| secretpath            | Vault secret path                              | secret/secretpath/               |
+| serviceaccountname    | Service account name for Vault                 | vault-auth                       |
+| imagesecretname       | Image secret name for Vault                    | ""                               |
+| tls                   | TLS configuration for Vault communication      | vaultca                          |
+
+### Orderer
+
+| Name          | Description                          | Default Value   |
+| --------------| -------------------------------------| ----------------|
+| address       | Address for orderer including port   | ""              |
+
+### Chaincode
+
+| Name                          | Description                                               | Default Value                             |
+| ------------------------------| ----------------------------------------------------------| ------------------------------------------|
+| builder                       | Chaincode builder image for Fabric                        | hyperledger/fabric-ccenv:2.2.2            |
+| name                          | Name of the chaincode to be committed                     | example                                   |
+| version                       | Version of the chaincode to be committed                  | 1                                         |
+| sequence                      | Sequence of the chaincode (for Fabric 2.2.x)              | 1                                         |
+| lang                          | Language of the chaincode                                 | golang                                    |
+| commitarguments               | Commit arguments for the chaincode                        | ""                                        |
+| endorsementpolicies           | Endorsement policies for the chaincode                    | ""                                        |
+| repository.hostname           | Git repository hostname                                   | github.com                                |
+| repository.git_username       | Git repository username                                   | user                                      |
+| repository.url                | Git repository URL                                        | github.com/hyperledger/bevel-samples.git  |
+| repository.branch             | Git repository branch                                     | main                                      |
+| repository.path               | Path to the chaincode in the repository                   | .                                         |
+| repository.collectionsconfig  | Collections configuration for the chaincode               | ""                                        |
+| pdc.enabled                   | Enable private data collections for the chaincode         | false                                     |
+| pdc.collectionsconfig         | Collections configuration for private data collections    | ""                                        |
+
+### Channel
+
+| Name       | Description           | Default Value   |
+| -----------|-----------------------| ----------------|
+| name       | Name of the channel   | mychannel       |
+
+### Endorsers
+
+| Name              | Description                                                   | Default Value    |
+| ------------------| --------------------------------------------------------------| -----------------|
+| creator           | Namespace of the creator organization                         | creator_org      |
+| name              | Names of organizations approving the chaincode                | ""               |
+| corepeeraddress   | Core peer addresses of organizations approving the chaincode  | ""               |
+| nameslist         | List of organization names approving the chaincode            | {}               |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the commit_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/commit_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./commit_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the commit_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/commit_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./commit_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the commit_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Commit Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/commit_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-net
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
     fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg. alpineutils: gcr.io/acn-stp-on-blockchain/alpine-utils
-    alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -28,10 +28,10 @@ peer:
   name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-net:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
   loglevel: info
@@ -49,36 +49,36 @@ vault:
   address: ""
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath: ""
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix: ""
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix: ""
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the value secret path
   #Eg. orderersecretprefix: secret/...
-  secretpath: ""
+  secretpath: secret/secretpath/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
   serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 orderer:
-  #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Provide the address for orderer including port
+  #Eg. address: orderer-ext.example-com:443
+  address: ""
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
   #Eg. builder: hyperledger/fabric-ccenv:1.4.8
-  builder: hyperledger/fabric-ccenv:1.4.8
+  builder: hyperledger/fabric-ccenv:2.2.2
   #Provide the name of the chaincode to be commmitted
   #Eg. name: cc
   name: example
@@ -110,13 +110,13 @@ chaincode:
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel
 
 endorsers:
   #Namespace of creator organization
-  creator: 
+  creator: creator_org
   # Name all the orgs which are approving the chaincode
-  name: 
+  name:
   # CorepeerAddresses all the orgs which are approving the chaincode
   corepeeraddress:
   # Name all the orgs which are approving the chaincode in list format

--- a/platforms/hyperledger-fabric/charts/create_channel/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for create channel
+description: "Hyperledger Fabric: Creates channel."
 name: create_channel
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/create_channel/README.md
+++ b/platforms/hyperledger-fabric/charts/create_channel/README.md
@@ -1,0 +1,204 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "create-channel-hyperledger-fabric-deployment"></a>
+# Create Channel Hyperledger Fabric Deployment
+
+- [Create Channel Hyperledger Fabric Deployment Helm Chart](#create-channel-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "create-channel-hyperledger-fabric-deployment-helm-chart"></a>
+## Create Channel Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/commit_chaincode) to create a channel.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+create_channel/
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- create_channel.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Store configuration data that can be consumed by containers. The first ConfigMap stores various configuration data as key-value pairs and the second ConfigMap stores the base64-encoded content of the channel configuration file (channel.tx.base64). 
+- `create_channel.yaml`: The certificates-init fetches TLS certificates from a Vault server and stores them in a local directory. The createchannel fetches the channel configuration file from a local directory and checks to see if the channel already exists. If the channel does not exist, the createchannel creates the channel.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/create_channel/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                                           | Default Value                                     |
+| ----------------------| ----------------------------------------------------------------------|---------------------------------------------------|
+| namespace             | Provide the namespace for organization's peer                         | org1-example-com                                  |
+| images.fabrictools    | Valid image name and version for fabric tools                         | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils    | Valid image name and version to read certificates from vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Custom labels (other than specified)                                  | ""                                                |
+
+### Deployment
+
+| Name         | Description                                 | Default Value  |
+| ------------ | ------------------------------------------- | -------------- |
+| annotations  | Deployment annotations                      | ""             |
+
+### Peer
+
+| Name          | Description                                   | Default Value                 |
+| --------------| ----------------------------------------------| ------------------------------|
+| name          | Name of the peer as per deployment yaml       | peer0                         |
+| address       | Address of the peer and grpc cluster IP port  | peer0.org1-example-com:7051   |
+| localmspid    | Local MSP ID for organization                 | Org1MSP                       |
+| loglevel      | Log level for organization's peer             | debug                         |
+| tlsstatus     | True or False for organization's peer         | true                          |
+
+### Vault
+
+| Name                | Description                                                         | Default Value                 |
+| ------------------- | --------------------------------------------------------------------| ------------------------------|
+| role                | Vault role for the organization                                     | vault-role                    |
+| address             | Vault server address                                                | ""                            |
+| authpath            | Kubernetes auth backend configured in vault for the organization    | fra-demo-hlkube-cluster-org1  |
+| adminsecretprefix   | Vault secret prefix for admin                                       | secret/adminsecretprefix/     |
+| orderersecretprefix | Vault secret prefix for orderer                                     | secret/orderersecretprefix/   |
+| serviceaccountname  | Service account name for vault                                      | vault-auth                    |
+| imagesecretname     | Image secret name for vault                                         | ""                            |
+| tls                 | Vault ca.cert Kubernetes secret                                     | vaultca                       |
+
+### Channel
+
+| Name   | Description                       | Default Value  |
+| ------ | --------------------------------- | -------------- |
+| name   | Name of the channel               | mychannel      |
+
+### Orderer
+
+| Name    | Description                 | Default Value             |
+| ------- | ----------------------------| --------------------------|
+| address | Address for the orderer     | orderer.fratest-com:7050  |
+
+### Other
+
+| Name       | Description                                  | Default Value   |
+| ---------- | ---------------------------------------------| --------------- |
+| channeltx  | Base64 encoded file contents for channeltx   | ""              |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the create_channel Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/create_channel/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./create_channel
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the create_channel node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/create_channel/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./create_channel
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the create_channel node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Create Channel Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/create_channel), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/create_channel/values.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -28,57 +28,57 @@ deployment:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: debug
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel
 
 orderer:
   #Provide the address for orderer
   #Eg. address: orderer.fratest-com:7050
-  address:
+  address: orderer.fratest-com:7050
 
 #Provide the base64 encoded file contents for channeltx
 channeltx: 

--- a/platforms/hyperledger-fabric/charts/external_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/external_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for external chaincode server deployment
+description: "Hyperledger Fabric: Deploys external chaincode server."
 name: external_chaincode
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/external_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/external_chaincode/README.md
@@ -1,0 +1,193 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "external-chaincode-hyperledger-fabric-deployment"></a>
+# External Chaincode Hyperledger Fabric Deployment
+
+- [External Chaincode Tools Hyperledger Fabric Deployment Helm Chart](#external-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "external-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## External Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/external_chaincode) for external chaincode server deployment.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+external_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- deployment.yaml
+      |- service.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `deployment.yaml`: The certificates-init gets the chaincode certificates from Vault and mounts them into the Pod. The chaincode runs the chaincode and exposes port 9999.
+- `service.yaml`: Exposing the chaincode to the network. The service creates a clusterIP that can be used to access the chaincode from other Pods in the cluster.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/external_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                      | Description                                           | Default Value                                     |
+| --------------------------| ------------------------------------------------------| --------------------------------------------------|
+| namespace                 | Provide the namespace for organization's peer         | default                                           |
+| network.version           | Version of the network                                | 2.2.2                                             |
+| images.external_chaincode | Valid image name and version for chaincode server     | ghcr.io/hyperledger/bevel-samples-example:1.0     |
+| images.alpineutils        | Valid image name and version for Alpine utilities     | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                    | Custom labels                                         | ""                                                |
+
+
+### Chaincode
+
+| Name              | Description                                                                   | Default Value    |
+| ------------------| ------------------------------------------------------------------------------| -----------------|
+| org               | Organisation name                                                             | manufacturer     |
+| name              | Chaincode name                                                                | example          |
+| version           | Chaincode version eg. 1                                                       | 1                |
+| ccid              | Chaincode ID generated after chaincode is installed                           | ""               |
+| crypto_mount_path | Path in the chaincode server container where the crypto needs to be mounted   | ""               |
+| tls               | If TLS is disabled or not                                                     | false            |
+
+
+### Vault
+
+| Name                  | Description                                                                   | Default Value                 |
+| ----------------------| ------------------------------------------------------------------------------|-------------------------------|
+| role                  | Provide the vaultrole for an organization                                     | vault-role                    |
+| address               | Provide the vault server address                                              | ""                            |
+| authpath              | Provide the kubernetes auth backend configured in vault for an organization   | ""                            |
+| chaincodesecretprefix | Provide the value for vault secretprefix                                      | secret/chaincodesecretprefix/ |
+| serviceaccountname    | Provide the serviceaccountname for vault                                      | vault-auth                    |
+| imagesecretname       | Provide the imagesecretname for vault                                         | ""                            |
+| tls                   | Kubernetes secret for vault ca.cert                                           | vaultca                       |
+
+
+### Service
+
+| Name                      | Description                                                       | Default Value   |
+| --------------------------|-------------------------------------------------------------------|-----------------|
+| servicetype               | Provide the servicetype for a peer                                | ClusterIP       |
+| loadBalancerType          | Load balancer type                                                | ""              |
+| ports.grpc.nodeport       | Nodeport for grpc service in the range of 30000-32767 (optional)  | 30001           |
+| ports.grpc.clusteripport  | Cluster IP port for grpc service to be exposed                    | 7052            |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the external_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/external_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./external_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the external_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/external_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./external_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the external_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [External Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/external_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/external_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/external_chaincode/values.yaml
@@ -14,7 +14,7 @@ metadata:
     #Provide the valid image name and version for chaincode server
     #Eg. <DOCKER_USERNAME>/marbles:latest
     external_chaincode: ghcr.io/hyperledger/bevel-samples-example:1.0
-    alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -48,13 +48,13 @@ vault:
   authpath: ""
   #Provide the value for vault secretprefix
   #Eg. chaincodesecretprefix: secret/...
-  chaincodesecretprefix:
+  chaincodesecretprefix: secret/chaincodesecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
   serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
@@ -69,7 +69,7 @@ service:
     grpc:
       #Provide a nodeport for grpc service in the range of 30000-32767 (optional)
       #Eg. nodeport: 30001
-      nodeport:
+      nodeport: 30001
       #Provide a cluster IP port for grpc service to be exposed
       #Eg. clusteripport: 7051
       clusteripport: 7052

--- a/platforms/hyperledger-fabric/charts/fabric-connector/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/Chart.yaml
@@ -5,8 +5,8 @@
 ##############################################################################################
 apiVersion: v2
 name: fabric-connector
-description: A Helm chart for Cactus Fabric Connector
+description: "Hyperledger Fabric: Deploys Cactus Fabric Connector."
 type: application
-version: '0.14.0'
+version: '0.14.1'
 # For Cactus release 1.1.3
 appVersion: "1.1.3"

--- a/platforms/hyperledger-fabric/charts/fabric-connector/README.md
+++ b/platforms/hyperledger-fabric/charts/fabric-connector/README.md
@@ -1,0 +1,236 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "fabric-connector-hyperledger-fabric-deployment"></a>
+# Fabric Connector Hyperledger Fabric Deployment
+
+- [Fabric Connector Hyperledger Fabric Deployment Helm Chart](#fabric-connector-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "fabric-connector-hyperledger-fabric-deployment-helm-chart"></a>
+## Fabric Connector Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/fabric_connector) for Cactus Fabric Connector.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+fabric_connector/
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- deployment.yaml
+      |- service.yaml
+  |- .helmignore
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Contains the configuration for the Hyperledger Cactus plugins. The plugins are used to interact with Hyperledger Fabric networks.
+- `deployment.yaml`: The certificates-init retrieves TLS certificates from Vault and stores them in the filesystem. The cactus-connector runs the Hyperledger Cacti connector, which allows applications to interact with Fabric networks.
+- `service.yaml`: Responsible for routing incoming traffic to Pods labeled "{{ .Release.Name }}-cactus-connector." The Service is equipped to handle two different proxy providers, Ambassador and HAProxy. For Ambassador, additional annotations enable traffic mapping, while TLSContext handles secure communication. Meanwhile, for HAProxy, an Ingress resource is set up to manage traffic with SSL passthrough, ensuring end-to-end TLS encryption.
+- `.helmignore.yaml`: 
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/fabric_connector/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name              | Description                                           | Default Value       |
+| ------------------| ------------------------------------------------------| ------------------- |
+| namespace         | Namespace where this deployment will be created       | manufacturer-net    |
+| replicaCount      | Number of replicas                                    | 1                   |
+
+### Image
+
+| Name              | Description                           | Default Value                                       |
+| ------------------| ------------------------------------- | ----------------------------------------------------|
+| repository        | Docker image of the API server        | ghcr.io/hyperledger/cactus-cmd-api-server:1.1.3     |
+| alpineutils       | Docker image of the alpine utils      | ghcr.io/hyperledger/bevel-alpine:latest             |
+| pullPolicy        | Pull policy of the docker image       | IfNotPresent                                        |
+
+### Service
+
+| Name              | Description                           | Default Value       |
+|-------------------|-------------------------------------- |-------------------- |
+| type              | Service type for the Cactus API server| ClusterIP           |
+| port              | Port for the above service            | 4000                |
+
+### Plugins
+
+| Name                      | Description                                   | Default Value                                                                         |
+| --------------------------| ----------------------------------------------| ------------------------------------------------------------------------------------- |
+| packageName               | Package name for the connector plugin         | "@hyperledger/cactus-plugin-ledger-connector-fabric"                                  |
+| type                      | Type for the connector plugin                 | org.hyperledger.cactus.plugin_import_type.LOCAL                                       |
+| action                    | Action for the connector plugin               | org.hyperledger.cactus.plugin_import_action.INSTALL                                   |
+| instanceId                | Unique instance id for multiple connectors    | "12345678"                                                                            |
+| dockerBinary              | Docker binary path                            | "usr/local/bin/docker"                                                                |
+| caName                    | CA name for the Fabric network                | ca.manufacturer-net                                                                   |
+| caAddress                 | CA address for the Fabric network             | ca.manufacturer-net:7054                                                              |
+| corePeerMSPconfigpath     | MSP config path for the core peer             | "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp"                      |
+| corePeerAdmincertFile     | Admin cert file for the core peer             | "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt"       |
+| corePeerTlsRootcertFile   | TLS root cert file for the core peer          | "/opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt" |
+| ordererTlsRootcertFile    | TLS root cert file for the orderer            | "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"             |
+| discoveryEnabled          | Enable/disable discovery service              | "true"                                                                                |
+| asLocalhost               | Enable/disable localhost for connections      | "true"                                                                                |
+
+### Env 
+
+| Name                       | Description                                      | Default Value  |
+| ---------------------------| -------------------------------------------------| ---------------|
+| authorizationProtocol      | Authorization protocol for Cactus connector      | "NONE"         |
+| authorizationConfigJson    | Authorization config JSON for Cactus connector   | "{}"           |
+| grpcTlsEnabled             | Enable/disable gRPC TLS for Cactus connector     | "false"        |
+
+### Proxy
+
+| Name              | Description                                       | Default Value                                         |
+| ------------------| --------------------------------------------------|-------------------------------------------------------|
+| provider          | Proxy provider (Only haproxy supported)           | "haproxy"                                             |
+| external_url      | Complete external URL for Connector service       | manufacturer-net.hf.demo.aws.blockchaincloudpoc.com   |
+
+### Vault
+
+| Name                | Description                                     | Default Value                                                         |
+| --------------------| ------------------------------------------------|---------------------------------------------------------------------- |
+| role                | Vault role for the organization                 | vault-role                                                            |
+| address             | Vault server address                            | http://vault.internal.demo.aws.blockchaincloudpoc.com:9001            |
+| authpath            | Kubernetes auth backend configured in Vault     | demo-fabricmanufacturer-net-auth                                      |
+| adminsecretprefix   | Vault secret prefix for admin user              | secretsv2/data/crypto/peerOrganizations/manufacturer-net/users/admin  |
+| orderersecretprefix | Vault secret prefix for orderer                 | secretsv2/data/crypto/peerOrganizations/manufacturer-net/orderer      |
+| serviceaccountname  | Service account name for Vault                  | vault-auth                                                            |
+| tls                 | Enable/disable TLS for Vault communication      | false                                                                 |
+
+### Peer
+
+| Name              | Description                                   | Default Value               |
+| ------------------| ----------------------------------------------| ----------------------------|
+| name              | Name of the peer as per deployment yaml       | peer0                       |
+| peerID            | Peer ID for the organization's peer           | peer0.manufacturer-net      |
+| localmspid        | Local MSP ID for the organization             | manufacturerMSP             |
+| tlsstatus         | Enable/disable TLS for organization's peer    | true                        |
+| address           | Address for the peer                          | peer0.manufacturer-net:7051 |
+
+### Orderer
+
+| Name         | Description                 | Default Value                    |
+| -------------| ----------------------------| ---------------------------------|
+| address      | Address for the orderer     | orderer1.supplychain-net:7050    |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the fabric_connector Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric_connector/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./fabric_connector
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the fabric_connector node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric_connector/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./fabric_connector
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the fabric_connector node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Fabric Connector Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric_connector), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/fabric_cli/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for Fabric Cli
+description: "Hyperledger Fabric: Deploys Fabric Cli."
 name: fabric_cli
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/fabric_cli/README.md
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/README.md
@@ -1,0 +1,191 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "fabric-cli-hyperledger-fabric-deployment"></a>
+# Fabric Cli Hyperledger Fabric Deployment
+
+- [Fabric Cli Hyperledger Fabric Deployment Helm Chart](#fabric-cli-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "fabric-cli-hyperledger-fabric-deployment-helm-chart"></a>
+## Fabric Cli Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/fabric_cli) for Fabric Cli.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+fabric_cli/
+  |- templates/
+      |- _helpers.yaml
+      |- deployment.yaml
+      |- volume.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `deployment.yaml`: The certificates-init retrieves TLS certificates and cryptographic materials from HashiCorp Vault, ensuring secure communication. The cli runs Hyperledger Fabric CLI tools, using the fetched certificates for secure interaction with the network.
+- `volume.yaml`: Requests storage resources for the cli container
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/fabric_cli/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                                           | Default Value                                     |
+| ----------------------| ----------------------------------------------------------------------| --------------------------------------------------|
+| namespace             | Namespace for organization's peer deployment                          | org1-example-com                                  |
+| images.fabrictools    | Valid image name and version for fabric tools                         | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils    | Valid image name and version to read certificates from vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+
+### Storage
+
+| Name        | Description           | Default Value  |
+| ------------| ----------------------| ---------------|
+| class       | Storage class name    | standard       |
+| size        | Storage size          | 512Mi          |
+
+### Vault 
+
+| Name                  | Description                                                       | Default Value                  |
+| ----------------------| ------------------------------------------------------------------| -------------------------------|
+| role                  | Vault role for the organization                                   | org1-vault-role                |
+| address               | Vault server address                                              | ""                             |
+| authpath              | Kubernetes auth backend configured in Vault for the organization  | fra-demo-hlkube-cluster-org1   |
+| adminsecretprefix     | Vault secret prefix for admin                                     | secret/adminsecretprefix/      |
+| orderersecretprefix   | Vault secret prefix for orderer                                   | secret/orderersecretprefix/    |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                     |
+| imagesecretname       | Image secret name for Vault                                       | ""                             |
+| tls                   | TLS status for Vault communication                                | vaultca                        |
+
+### Peer Configuration
+
+| Name          | Description                                 | Default Value               |
+| --------------| --------------------------------------------| ----------------------------|
+| name          | Name of the peer as per deployment YAML     | peer0                       |
+| localmspid    | Local MSP ID for the organization's peer    | Org1MSP                     |
+| tlsstatus     | TLS status for the organization's peer      | true                        |
+| address       | Address for the peer                        | peer0.org1-example-com:7051 |
+
+### Orderer Configuration
+
+| Name        | Description              | Default Value                |
+| ------------| -------------------------| -----------------------------|
+| address     | Address for the orderer  | orderer-ext.example-com:443  |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the fabric_cli Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric_cli/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./fabric_cli
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the fabric_cli node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get deployments -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the deployment was created. The command will display information about the deployment, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric_cli/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./fabric_cli
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the fabric_cli node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Fabric Cli Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric_cli), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/fabric_cli/templates/_helpers.tpl
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/hyperledger-fabric/charts/fabric_cli/values.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/values.yaml
@@ -10,15 +10,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-net
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
    #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
-
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
 
 storage:
   #Provide the storageclassname
@@ -29,46 +28,46 @@ storage:
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: org1-vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
   #Provide the address for the peer
-  #Eg: address: peer0-ext.org1-fratest-com:8443
-  address: 
+  #Eg: address: peer0.org1-example-com:7051
+  address: peer0.peer0-net:7051
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Eg. address: orderer-ext.example-com:443
+  address: orderer-ext.example-com:443

--- a/platforms/hyperledger-fabric/charts/generate_cacerts/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/generate_cacerts/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for ca server configuration
+description: "Hyperledger Fabric: Generates CA Server certs."
 name: generate_cacerts
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/generate_cacerts/README.md
+++ b/platforms/hyperledger-fabric/charts/generate_cacerts/README.md
@@ -1,0 +1,174 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "generate-cacerts-hyperledger-fabric-deployment"></a>
+# Generate Cacerts Hyperledger Fabric Deployment
+
+- [Generate Cacerts Hyperledger Fabric Deployment Helm Chart](#generate-cacerts-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "generate-cacerts-hyperledger-fabric-deployment-helm-chart"></a>
+## Generate Cacerts Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/generate_cacerts) to generate CA Server certs.
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+generate_cacerts/
+  |- templates/
+      |- _helpers.yaml
+      |- job.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `job.yaml`: The init-check-certificates checks if the certificates are present in the Vault server. If the certificates are not present, the cacerts generates and uploads CA certificates and admin credentials to Vault.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/generate_cacerts/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+
+### Metadata
+
+| Name                 | Description                                                                | Default Value                     |
+| ---------------------| -------------------------------------------------------------------------- | ----------------------------------|
+| namespace            | Namespace for the organization's peer                                      | org1-net                          |
+| name                 | Organization's name                                                        | org1                              |
+| component_name       | Organization's component name                                              | org1-net                          |
+| images.fabrictools   | Valid image name and version for fabric tools                              | hyperledger/fabrictools:1.4.0     |
+| images.alpineutils   | Valid image name and version to read certificates from the vault server    | hyperledgerlabs/alpine-utils:1.0  |
+| labels               | Custom labels for the organization                                         | anchorpeer                        |
+
+### Vault
+
+| Name                      | Description                                      | Default Value                      |
+| --------------------------| ------------------------------------------------ | -----------------------------------|
+| role                      | Vault role for the organization                  | vault-role                         |
+| address                   | Vault server address                             | ""                                 |
+| authpath                  | Kubernetes auth backend configured in vault      | fra-demo-hlkube-cluster-org1       |
+| secretcryptoprefix        | Vault secret prefix for crypto                   | secrets/secretcryptoprefix/        |
+| secretcredentialsprefix   | Vault secret prefix for credentials              | secrets/secretcredentialsprefix/   |
+| serviceaccountname        | Service account name for vault                   | vault-auth                         |
+| imagesecretname           | Image secret name for vault                      | ""                                 |
+
+### CA
+
+| Name     | Description                                      | Default Value                                           |
+| ---------| ------------------------------------------------ | --------------------------------------------------------|
+| subject  | Subject of the services CA organization's        | /C=GB/ST=London/L=London/O=Orderer/CN=ca.org1-org1-net  |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the generate_cacerts Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/generate_cacerts/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./generate_cacerts
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the generate_cacerts node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/generate_cacerts/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./generate_cacerts
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the generate_cacerts node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Generate Cacerts Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/generate_cacerts), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/generate_cacerts/templates/_helpers.tpl
+++ b/platforms/hyperledger-fabric/charts/generate_cacerts/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "labels.custom" }}
+  {{ range $key, $val := $.Values.metadata.labels }}
+  {{ $key }}: {{ $val }}
+  {{ end }}
+{{- end }}

--- a/platforms/hyperledger-fabric/charts/generate_cacerts/values.yaml
+++ b/platforms/hyperledger-fabric/charts/generate_cacerts/values.yaml
@@ -7,48 +7,50 @@
 metadata:
   #Provide organization's name
   #Eg. namespace: org1
-  name:
+  name: org1
   #Provide organization's component_name
-  #Eg. namespace: org1-net
-  component_name:
+  #Eg. component_name: org1-net
+  component_name: org1-net
   #Provide the namespace for organization's peer
-  #Eg. namespace: org1-example-com
-  namespace: default
+  #Eg. namespace: org1-net
+  namespace: org1-net
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabric-tools: hyperledger/fabrictools:1.4.0
-    fabrictools:
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils:
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
   #      role: anchorpeer
-  labels:
+  labels: anchorpeer
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
-  secretcryptoprefix: 
-  secretcredentialsprefix:
+  authpath: fra-demo-hlkube-cluster-org1
+  # Vault secret prefix for crypto  
+  secretcryptoprefix: secrets/secretcryptoprefix/
+  # Vault secret prefix for credentials
+  secretcredentialsprefix: secrets/secretcredentialsprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
 
 ca:
   #Provide the subject of the services ca organization's
   #Eg. subject: "/C=GB/ST=London/L=London/O=Carrier/CN=org1-net"
-  subject: 
+  subject: /C=GB/ST=London/L=London/O=Orderer/CN=ca.org1-org1-net

--- a/platforms/hyperledger-fabric/charts/install_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode installation on a peer
+description: "Hyperledger Fabric: Installs chaincode on a peer."
 name: install_chaincode
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/install_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/README.md
@@ -1,0 +1,201 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "install-chaincode-hyperledger-fabric-deployment"></a>
+# Install Chaincode Hyperledger Fabric Deployment
+
+- [Install Chaincode Hyperledger Fabric Deployment Helm Chart](#install-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "install-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Install Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/install_chaincode) for chaincode installation on a peer.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+install_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- install_chaincode.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `install_chaincode.yaml`: The certificates-init retrieves certificates and credentials from Vault and stores them in a local directory. The installchaincode installs the chaincode on the peer. Both containers are used to prepare the peer for running chaincode.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/install_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                   | Description                                                              | Default Value                                     |
+| ----------------       | -------------------------------------------------------------------------| --------------------------------------------------|
+| network.version        | HyperLedger Fabric network version                                       | 2.2.2                                             |
+| namespace              | Namespace for organization's peer                                        | org1-example-com                                  |
+| images.fabrictools     | Valid image name and version for Fabric tools                            | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils     | Valid image name and version to read certificates from the Vault server  | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                 | Custom labels for the organization                                       | ""                                                |
+
+### Peer
+
+| Name        | Description                                      | Default Value               |
+| ------------| -------------------------------------------------| ----------------------------|
+| name        | Name of the peer as per deployment YAML          | peer0                       |
+| address     | Address of the peer and its grpc cluster IP port | peer0.org1-example-com:7051 |
+| localmspid  | Local MSPID for the organization                 | Org1MSP                     |
+| loglevel    | Log level for the organization's peer            | info                        |
+| tlsstatus   | TLS status for the organization's peer           | true                        |
+
+### Vault
+
+| Name                  | Description                                                       | Default Value                             |
+| ----------------------| ------------------------------------------------------------------| ------------------------------------------|
+| role                  | Vault role for the organization                                   | org1-vault-role                           |
+| address               | Vault server address                                              | ""                                        |
+| authpath              | Kubernetes auth backend configured in Vault for the organization  | fra-demo-hlkube-cluster-org1              |
+| adminsecretprefix     | Vault secretprefix for admin                                      | secret/adminsecretprefix/                 |
+| orderersecretprefix   | Vault secretprefix for orderer                                    | secret/orderersecretprefix/               |
+| secretgitprivatekey   | Secret for Git private key                                        | secret/credentials/org1-example-com/git   |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                                |
+| imagesecretname       | Imagesecret name for Vault                                        | ""                                        |
+| tls                   | Kubernetes secret for Vault ca.cert                               | vaultca                                   |
+
+### Orderer
+
+| Name      | Description               | Default Value                |
+| ----------| --------------------------| -----------------------------|
+| address   | Address for the orderer   | orderer-ext.example-com:443  |
+
+### Chaincode
+
+| Name                        | Description                                                       | Default Value                                               |
+| ----------------------------| ------------------------------------------------------------------| ------------------------------------------------------------|
+| builder                     | Valid chaincode builder image for Fabric                          | hyperledger/fabric-ccenv:1.4.8                              |
+| name                        | Name of the chaincode to be installed                             | cc                                                          |
+| version                     | Chaincode version to be installed                                 | "1.0"                                                       |
+| language                    | Language of the chaincode                                         | golang                                                      |
+| maindirectory               | Path to the main.go package if different from chaincode directory | cmd                                                         |
+| repository.hostname         | Chaincode remote Git repository hostname                          | innersource.accenture.com                                   |
+| repository.URL              | Chaincode remote Git repository URL                               | ssh://git@innersource.accenture.com/dlta/dlt-ansible.git    |
+| repository.branch           | Chaincode remote Git repository branch to be cloned for chaincode | develop                                                     |
+| repository.path             | Git repository path containing chaincodes                         | dlt-chaincodes/go/chaincode_example02/                      |
+| repository.git_username     | Username for the Git repository                                   | user                                                        |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the install_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/install_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./install_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the install_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/install_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./install_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the install_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Install Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/install_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/install_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/values.yaml
@@ -7,17 +7,17 @@
 metadata:
   # HLF network version
   network:
-    version:
+    version: 2.2.2
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -28,85 +28,85 @@ metadata:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: org1-vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the secretgitprivatekey
   #Eg. secretgitprivatekey: secret/credentials/org1-example-com/git
-  secretgitprivatekey:
+  secretgitprivatekey: secret/credentials/org1-example-com/git
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Eg. address: orderer-ext.example-com:443
+  address: orderer-ext.example-com:443
 
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
   #Eg. builder: hyperledger/fabric-ccenv:1.4.8
-  builder:
+  builder: hyperledger/fabric-ccenv:1.4.8
   #Provide the name of the chaincode to be installed
   #Eg. name: cc
-  name:
+  name: cc
   #Provide the chaincode version to be installed
   #Eg. version: "1.0"
-  version:
+  version: "1.0"
   # language of the chaincode
-  lang:
+  lang: golang
   #Provide the path to the main.go package if it is different from chaincode directory
   #Eg. maindirectory: cmd
-  maindirectory: 
+  maindirectory: cmd
   repository:
     #Provide the chaincode remote git repository hostname
     #Eg. hostname: innersource.accenture.com
-    hostname:
+    hostname: innersource.accenture.com
     #Provide the chaincode remote git repository URL
     #Eg. url: ssh://git@innersource.accenture.com/dlta/dlt-ansible.git
-    url:
+    url: ssh://git@innersource.accenture.com/dlta/dlt-ansible.git
     #Provide the chaincode remote git repo branch to be cloned for chaincode
     #Eg. branch: develop
-    branch:
+    branch: develop
     #Provide the git repository path containing chaincodes.
     #Eg. path: dlt-chaincodes/go/chaincode_example02/
-    path:
+    path: dlt-chaincodes/go/chaincode_example02/
     # Username for the git repo. password is taken from Vault using secretgitprivatekey
-    git_username:
+    git_username: user1

--- a/platforms/hyperledger-fabric/charts/install_external_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/install_external_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for external chaincode installation
+description: "Hyperledger Fabric: Installs external chaincode."
 name: install_external_chaincode
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/install_external_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/install_external_chaincode/README.md
@@ -1,0 +1,192 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "install-external-chaincode-hyperledger-fabric-deployment"></a>
+# Install External Chaincode Hyperledger Fabric Deployment
+
+- [Install External Chaincode Hyperledger Fabric Deployment Helm Chart](#install-external-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "install-external-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Install External Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/install_external_chaincode) for external chaincode installation.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+install_external_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- install_external_chaincode.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `install_external_chaincode.yaml`: The certificates-init retrieves TLS certificates and MSP certificates from Vault and stores them in a local directory. The package-init retrieves the chaincode package from Vault and stores it in a local directory. The "instextcc" installs the chaincode on the peer.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/install_external_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                   | Description                                                              | Default Value                                     |
+| -----------------------| -------------------------------------------------------------------------| --------------------------------------------------|
+| network.version        | HyperLedger Fabric network version                                       | 2.2.2                                             |
+| namespace              | Namespace for organization's peer                                        | org1-example-com                                  |
+| images.fabrictools     | Valid image name and version for Fabric tools                            | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils     | Valid image name and version to read certificates from the Vault server  | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |  
+| labels                 | Custom labels for the organization                                       | ""                                                |
+
+### Peer
+
+| Name        | Description                                      | Default Value               |
+| ------------|--------------------------------------------------|-----------------------------|
+| name        | Name of the peer as per deployment YAML          | peer0                       |
+| address     | Address of the peer and its grpc cluster IP port | peer0.org1-example-com:7051 |
+| localmspid  | Local MSPID for the organization                 | Org1MSP                     |
+| loglevel    | Log level for the organization's peer            | info                        |
+| tlsstatus   | TLS status for the organization's peer           | true                        |
+
+
+### Vault
+
+| Name                  | Description                                                       | Default Value                                       |
+| ----------------------| ------------------------------------------------------------------| ----------------------------------------------------|
+| role                  | Vault role for the organization                                   | org1-vault-role                                     |
+| address               | Vault server address                                              | ""                                                  |
+| authpath              | Kubernetes auth backend configured in Vault for the organization  | fra-demo-hlkube-cluster-org1                        |
+| chaincodesecretprefix | Vault secretprefix for chaincode                                  | secret/chaincodesecretprefix/                       |
+| adminsecretprefix     | Vault secretprefix for admin                                      | secret/adminsecretprefix/                           |
+| orderersecretprefix   | Vault secretprefix for orderer                                    | secret/orderersecretprefix/                         |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                                          |
+| imagesecretname       | Imagesecret name for Vault                                        | ""                                                  |
+| secretgitprivatekey   | Secret for Git private key                                        | secret/credentials/org1-example-com/git             |
+| tls                   | Kubernetes secret for Vault ca.cert                               | vaultca                                             |
+
+### Chaincode
+
+| Name             | Description                                      | Default Value     |
+|------------------|--------------------------------------------------|-------------------|
+| name             | Name of the chaincode to be installed            | cc                |
+| version          | Chaincode version to be installed                | "1.0"             |
+| sequence         | chaincode sequence to be committed               | ""                |
+| tls_disabled     | tls is disabled or not                           | true              |
+| address          | Chaincode server address                         | ""                |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the install_external_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/install_external_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./install_external_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the install_external_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/install_external_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./install_external_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the install_external_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Install External Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/install_external_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/install_external_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/install_external_chaincode/values.yaml
@@ -7,17 +7,17 @@
 metadata:
   # HLF network version
   network:
-    version:
+    version: 2.2.2
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -28,63 +28,64 @@ metadata:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: org1-vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
+  # Vault secretprefix for chaincode
   chaincodesecretprefix:
-  #Provide the value for vault secretprefix
+  # Vault secretprefix for admin
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
-  #Provide the value for vault secretprefix
+  adminsecretprefix: secret/adminsecretprefix/
+  # Vault secretprefix for orderer
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Provide the secretgitprivatekey
   #Eg. secretgitprivatekey: secret/credentials/org1-example-com/git?ssh-key
-  secretgitprivatekey:
+  secretgitprivatekey: secret/credentials/org1-example-com/git
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 chaincode:
   #Provide the name of the chaincode to be installed
   #Eg. name: cc
-  name:
+  name: cc
   #Provide the chaincode version to be installed
   #Eg. version: "1.0"
-  version:
+  version: "1.0"
   #Provide the chaincode sequence to be committed
   #Eg. name: "1.0"
   sequence:
   # if tls is disabled or not | BOOLEAN | eg. true
-  tls_disabled:
+  tls_disabled: true
   # Chaincode server address eg. chaincode-marbles-1-carrier.carrier-net.svc.cluster.local:7052
   address:

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode instantiation on a peer
+description: "Hyperledger Fabric: Instantiates chaincode on a peer."
 name: instantiate_chaincode
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/README.md
@@ -1,0 +1,202 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "instantiate-chaincode-hyperledger-fabric-deployment"></a>
+# Instantiate Chaincode Hyperledger Fabric Deployment
+
+- [Instantiate Chaincode Hyperledger Fabric Deployment Helm Chart](#instantiate-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "instantiate-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Instantiate Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/instantiate_chaincode) for chaincode instantiation on a peer.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+instantiate_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- instantiate_chaincode.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `instantiate_chaincode.yaml`: The certificates-init prepares the environment for the instantiatechaincode by retrieving the necessary secrets from Vault. The instantiatechaincode container then uses these secrets to instantiate the chaincode on the channel.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/instantiate_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                   | Description                                                              | Default Value                                     |
+|------------------------|--------------------------------------------------------------------------| --------------------------------------------------|
+| namespace              | Namespace for organization's peer                                        | org1-example-com                                  |
+| images.fabrictools     | Valid image name and version for Fabric tools                            | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils     | Valid image name and version to read certificates from the Vault server  | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                 | Custom labels for the organization                                       | ""                                                |
+
+### Peer
+
+| Name        | Description                                      | Default Value               |
+| ------------| -------------------------------------------------| ----------------------------|
+| name        | Name of the peer as per deployment YAML          | peer0                       |
+| address     | Address of the peer and its grpc cluster IP port | peer0.org1-example-com:7051 |
+| localmspid  | Local MSPID for the organization                 | Org1MSP                     |
+| loglevel    | Log level for the organization's peer            | info                        |
+| tlsstatus   | TLS status for the organization's peer           | true                        |
+
+
+### Vault
+
+| Name                  | Description                                                       | Default Value                |
+| ----------------------| ------------------------------------------------------------------| -----------------------------|
+| role                  | Vault role for the organization                                   | vault-role                   |
+| address               | Vault server address                                              | ""                           |
+| authpath              | Kubernetes auth backend configured in Vault for the organization  | fra-demo-hlkube-cluster-org1 |
+| adminsecretprefix     | Vault secretprefix for admin                                      | secret/adminsecretprefix/    |
+| orderersecretprefix   | Vault secretprefix for orderer                                    | secret/orderersecretprefix/  |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                   |
+| imagesecretname       | Imagesecret name for Vault                                        | ""                           |
+| tls                   | Kubernetes secret for Vault ca.cert                               | vaultca                      |
+
+### Orderer
+
+| Name      | Description               | Default Value                |
+| ----------| --------------------------| -----------------------------|
+| address   | Address for the orderer   | orderer-ext.example-com:443  |
+
+### Chaincode
+
+| Name                      | Description                                      | Default Value                      |
+| --------------------------| -------------------------------------------------| -----------------------------------|
+| builder                   | Valid chaincode builder image for Fabric         | hyperledger/fabric-ccenv:1.4.8     |
+| name                      | Name of the chaincode to be installed            | cc                                 |
+| version                   | Chaincode version to be instantiated             | "1.0"                              |
+| instantiationarguments    | Instantiation arguments                          | ""                                 |
+| endorsementpolicies       | Endorsement policies for the chaincode           | true                               |
+| address                   | Chaincode server address                         | ""                                 |
+
+### channel
+
+| Name      | Description           | Default Value    |
+| ----------|-----------------------| -----------------|
+| address   | Name of the channel   | mychannel        |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the instantiate_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/instantiate_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./instantiate_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the instantiate_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/instantiate_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./instantiate_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the instantiate_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Instantiate Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/instantiate_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg. alpineutils: gcr.io/acn-stp-on-blockchain/alpine-utils
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -25,66 +25,66 @@ metadata:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/ 
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Eg. address: orderer-ext.example-com:443
+  address:  orderer-ext.example-com:443
 
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
   #Eg. builder: hyperledger/fabric-ccenv:1.4.8
-  builder:
+  builder: hyperledger/fabric-ccenv:1.4.8
   #Provide the name of the chaincode to be instantiated
   #Eg. name: cc
-  name:
+  name: cc
   #Provide the chaincode version to be instantiated
   #Eg. name: "1.0"
-  version:
+  version: "1.0"
   #Provide the instantiation arguments
   #Eg. instantiationarguments: '"init","a","200","b","400"'
   instantiationarguments:
@@ -96,4 +96,4 @@ chaincode:
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode invocation on a peer
+description: "Hyperledger Fabric: Invokes chaincode on a peer."
 name: invoke_chaincode
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/README.md
@@ -1,0 +1,205 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "invoke-chaincode-hyperledger-fabric-deployment"></a>
+# Invoke Chaincode Hyperledger Fabric Deployment
+
+- [Invoke Chaincode Hyperledger Fabric Deployment Helm Chart](#invoke-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "invoke-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Invoke Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/invoke_chaincode) for chaincode invocation on a peer.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+invoke_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- invoke_chaincode.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `invoke_chaincode.yaml`: The certificates-init fetches TLS and MSP certificates from Vault and stores them for secure communication. The invokechaincode then uses these certificates to invoke the chaincode.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                   | Description                                                                      | Default Value                                     |
+| -----------------------| ---------------------------------------------------------------------------------| --------------------------------------------------|
+| namespace              | Namespace for organization's peer                                                | org1-example-com                                  |
+| network.version        | HyperLedger Fabric network version                                               | 2.2.2                                             |
+| images.fabrictools     | Valid image name and version for Fabric tools                                    | hyperledger/fabric-tools:1.4.0                    |
+| images.alpineutils     | Valid image name and version to read certificates from the Vault server          | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| add_organization       | Flag for ivoking the chaincode for addition of an org or for the first network   | false                                             |
+| labels                 | Custom labels for the organization                                               | ""                                                |
+
+### Peer
+
+| Name        | Description                                      | Default Value               |
+| ------------| -------------------------------------------------| ----------------------------|
+| name        | Name of the peer as per deployment YAML          | peer0                       |
+| address     | Address of the peer and its grpc cluster IP port | peer0.org1-example-com:7051 |
+| localmspid  | Local MSPID for the organization                 | Org1MSP                     |
+| loglevel    | Log level for the organization's peer            | info                        |
+| tlsstatus   | TLS status for the organization's peer           | true                        |
+
+
+### Vault
+
+| Name                  | Description                                                       | Default Value                |
+| ----------------------| ------------------------------------------------------------------| -----------------------------|
+| role                  | Vault role for the organization                                   | org1-vault-role              |
+| address               | Vault server address                                              | ""                           |
+| authpath              | Kubernetes auth backend configured in Vault for the organization  | fra-demo-hlkube-cluster-org1 |
+| secretpath            | value for vault secret path                                       | secret/                      |
+| adminsecretprefix     | Vault secretprefix for admin                                      | secret/adminsecretprefix/    |
+| orderersecretprefix   | Vault secretprefix for orderer                                    | secret/orderersecretprefix/  |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                   |
+| imagesecretname       | Imagesecret name for Vault                                        | ""                           |
+| tls                   | Kubernetes secret for Vault ca.cert                               | vaultca                      |
+
+### Orderer
+
+| Name      | Description               | Default Value                |
+| ----------| --------------------------| -----------------------------|
+| address   | Address for the orderer   | orderer-ext.example-com:443  |
+
+### Chaincode
+
+| Name                      | Description                                      | Default Value                      |
+| ------------------------- | -------------------------------------------------| -----------------------------------|
+| builder                   | Valid chaincode builder image for Fabric         | hyperledger/fabric-ccenv:2.2.2     |
+| name                      | Name of the chaincode to be installed            | cc                                 |
+| version                   | Chaincode version to be instantiated             | 1                                  |
+| lang                      | Language of the chaincode                        | golang                             |
+| instantiationarguments    | Instantiation arguments                          | ""                                 |
+| endorsementpolicies       | Endorsement policies for the chaincode           | true                               |
+
+### channel
+
+| Name      | Description           | Default Value    |
+| ----------| ----------------------| -----------------|
+| address   | Name of the channel   | mychannel        |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the invoke_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./invoke_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the invoke_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./invoke_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the invoke_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Invoke Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/invoke_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml
@@ -7,7 +7,7 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   # HLF Network Version
   network:
     version: 2.2.2
@@ -17,7 +17,7 @@ metadata:
     fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg. alpineutils: gcr.io/acn-stp-on-blockchain/alpine-utils
-    alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Flag for ivoking the chaincode for addition of an org or for the first network
   add_organization: false
   #Provide the custom labels
@@ -33,10 +33,10 @@ peer:
   name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
   loglevel: info
@@ -54,31 +54,31 @@ vault:
   address: ""
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath: ""
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secret path
   #Eg. secretpath: secret
-  secretpath: ""
+  secretpath: secret/
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix: ""
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix: ""
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
   serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Eg. address: orderer-ext.example-com:443
+  address: orderer-ext.example-com:443
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
@@ -86,7 +86,7 @@ chaincode:
   builder: hyperledger/fabric-ccenv:2.2.2
   #Provide the name of the chaincode to be invoked
   #Eg. name: cc
-  name: example
+  name: cc
   #Provide the chaincode version to be instantiated
   #Eg. name: "1.0"
   version: 1
@@ -102,4 +102,4 @@ chaincode:
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel

--- a/platforms/hyperledger-fabric/charts/join_channel/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for joining the channel
+description: "Hyperledger Fabric: Joins the peer to the channel."
 name: join_channel
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/join_channel/README.md
+++ b/platforms/hyperledger-fabric/charts/join_channel/README.md
@@ -1,0 +1,192 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "join-channel-hyperledger-fabric-deployment"></a>
+# Join Channel Hyperledger Fabric Deployment
+
+- [Join Channel Hyperledger Fabric Deployment Helm Chart](#join-channel-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "join-channel-hyperledger-fabric-deployment-helm-chart"></a>
+## Join Channel Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/join_channel) for joining the channel.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+join_channel/
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- join_channel.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Stores the configuration for the joinchannel container.
+- `join_channel.yaml`: The certificates-init retrieves TLS and MSP certificates from Vault and stores them in the local filesystem. The joinchannel joins the peer to the channel by fetching the channel configuration block from the orderer. Both containers are essential for the peer to join the channel and start participating in the network.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/join_channel/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                   | Description                                                                      | Default Value                                     |
+| -----------------------| ---------------------------------------------------------------------------------| --------------------------------------------------|
+| namespace              | Namespace for organization's peer                                                | org1-example-com                                  |
+| images.fabrictools     | Valid image name and version for Fabric tools                                    | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils     | Valid image name and version to read certificates from the Vault server          | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                 | Custom labels for the organization                                               | ""                                                |
+
+### Peer
+
+| Name        | Description                                      | Default Value               |
+|-------------| -------------------------------------------------| ----------------------------|
+| name        | Name of the peer as per deployment YAML          | peer0                       |
+| address     | Address of the peer and its grpc cluster IP port | peer0.org1-example-com:7051 |
+| localmspid  | Local MSPID for the organization                 | Org1MSP                     |
+| loglevel    | Log level for the organization's peer            | info                        |
+| tlsstatus   | TLS status for the organization's peer           | true                        |
+
+### Vault
+
+| Name                  | Description                                                       | Default Value                |
+| ----------------------| ------------------------------------------------------------------| -----------------------------|
+| role                  | Vault role for the organization                                   | vault-role                   |
+| address               | Vault server address                                              | ""                           |
+| authpath              | Kubernetes auth backend configured in Vault for the organization  | fra-demo-hlkube-cluster-org1 |
+| adminsecretprefix     | Vault secretprefix for admin                                      | secret/adminsecretprefix/    |
+| orderersecretprefix   | Vault secretprefix for orderer                                    | secret/orderersecretprefix/  |
+| serviceaccountname    | Service account name for Vault                                    | vault-auth                   |
+| imagesecretname       | Imagesecret name for Vault                                        | ""                           |
+| tls                   | Kubernetes secret for Vault ca.cert                               | vaultca                      |
+
+### channel
+
+| Name      | Description           | Default Value    |
+| ----------| ----------------------| -----------------|
+| address   | Name of the channel   | mychannel        |
+
+### Orderer
+
+| Name      | Description               | Default Value                |
+| ----------| --------------------------| -----------------------------|
+| address   | Address for the orderer   | orderer.fratest-com:7050     |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the join_channel Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/join_channel/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./join_channel
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the join_channel node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/join_channel/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./join_channel
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the join_channel node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Join Channel Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/join_channel), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/join_channel/values.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabric-tools: hyperledger/fabrictools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
     #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -24,55 +24,55 @@ metadata:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who wants to join channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel
 
 orderer:
   #Provide the address for orderer
   #Eg. address: orderer.fratest-com:7050
-  address:
+  address: orderer.fratest-com:7050
 

--- a/platforms/hyperledger-fabric/charts/operations_console/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/operations_console/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for Fabric Operations Console
+description: "Hyperledger Fabric: Deploys Fabric Operations Console."
 name: operations_console
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/operations_console/README.md
+++ b/platforms/hyperledger-fabric/charts/operations_console/README.md
@@ -1,0 +1,205 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "operation-console-hyperledger-fabric-deployment"></a>
+# Operation Console Hyperledger Fabric Deployment
+
+- [Operation Console Hyperledger Fabric Deployment Helm Chart](#operation-console-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "operation-console-hyperledger-fabric-deployment-helm-chart"></a>
+## Operation Console Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/operation_console) for Fabric Operations Console.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+operation_console/
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- deployment.yaml
+      |- pvc.yaml
+      |- service.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Store configuration for the fabric-console
+- `deployment.yaml`: Defines a StatefulSet with one replica that manages three containers: couchdb, fabric-console, and configtxlator. The couchdb container will be used to store the data for the Fabric network and it will be exposed on port 5984. The fabric-console container will be used to interact with the Fabric network and it will be exposed on port 3000. The configtxlator container will be used to generate and manage configuration transactions for the Fabric network and it will be exposed on port 7059.
+- `pvc.yaml`: Defines a persistent volume claim that will be used to store the data for the CouchDB database.
+- `service.yaml`: configures a Kubernetes Service and an Ingress. The service has three ports: console (port 3000) is exposed for the fabric-console, couchdb (port 5984) is exposed for the couchdb database, and configtxlator (port 7059) is exposed for the configtxlator container. The service can be exposed in two ways: ClusterIP and NodePort. Optionally, if haproxy is selected, ingress will route traffic to the Service using the host and path.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/operation_console/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                                           | Default Value                                         |
+| ----------------------| --------------------------------------------------------------------- | ------------------------------------------------------|
+| namespace             | Provide the namespace for organization's peer                         | org1-example-com                                      |
+| images.couchdb        | Valid image name and version for fabric couchdb                       | couchdb:3.1.1                                         |
+| images.console        | Valid image name and version for fabric peer                          | index.docker.io/hyperledgerlabs/fabric-console:latest |
+| images.configtxlator  | Valid image name and version to read certificates from vault server   | hyperledger/fabric-tools:2.2.2                        |
+| labels                | Custom labels (other than predefined ones)                            | ""                                                    |
+
+
+### Storage
+
+| Name          | Description                     | Default Value       |
+| --------------| --------------------------------| ------------------- |
+| couchdb       | Storage class name for couchdb  | gp2                 |
+| storagesize   | Storage size for couchdb        | 512Mi               |
+
+### Service
+
+| Name                          | Description                                     | Default Value       |
+| ------------------------------| ------------------------------------------------| ------------------- |
+| name                          | Name of the service as per deployment yaml      | fabconsole          |
+| serviceaccountname            | Service account name for vault                  | default             |
+| imagesecretname               | Image secret name for vault                     | ""                  |
+| servicetype                   | Service type for the peer                       | ClusterIP           |
+| default_consortium            | Default consortium value                        | SampleConsortium    |
+| loadBalancerType              | Load balancer type for the service              | ""                  |
+| ports.console.nodeport        | NodePort for grpc service (optional)            | 30001               |
+| ports.console.clusteripport   | Cluster IP port for grpc service                | 3000                |
+| ports.couchdb.nodeport        | NodePort for couchdb service (optional)         | 30003               |
+| ports.couchdb.clusteripport   | Cluster IP port for couchdb service             | 5984                |
+
+
+
+### Annotations
+
+| Name          | Description                                   | Default Value       |
+| --------------| ----------------------------------------------| ------------------- |
+| service       | Extra annotations for service                 | ""                  |
+| pvc           | Extra annotations for PersistentVolumeClaim   | ""                  |
+| deployment    | Extra annotations for deployment              | ""                  |
+
+
+
+### Proxy
+
+| Name                      | Description                                       | Default Value                         |
+| --------------------------| --------------------------------------------------| --------------------------------------|
+| proxy.provider            | Proxy/ingress provider (ambassador or haproxy)    | haproxy                               |
+| proxy.external_url_suffix | External URL suffix of the organization           | org1.blockchaincloudpoc.com           |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the operation_console Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/operation_console/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./operation_console
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the operation_console node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get statefulsets -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the StatefulSet was created. This command will display information about the StatefulSet, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/operation_console/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./operation_console
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the operation_console node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Operation Console Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/operation_console), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/operations_console/values.yaml
+++ b/platforms/hyperledger-fabric/charts/operations_console/values.yaml
@@ -7,17 +7,17 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric couchdb
     #Eg. couchdb: hyperledger/fabric-couchdb:0.4.14
     couchdb: couchdb:3.1.1
     #Provide the valid image name and version for fabric peer
     #Eg. hyperledger/fabric-peer:1.4.0
-    console: ghcr.io/hyperledger-labs/fabric-console:latest 
+    console: index.docker.io/hyperledgerlabs/fabric-console:latest
     #Provide the valid image name and version to read certificates from vault server 
     #Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
-    configtxlator: hyperledger/fabric-tools:2.2.3
+    configtxlator: hyperledger/fabric-tools:2.2.2
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -43,26 +43,26 @@ service:
   serviceaccountname: default
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname: regcred
+  imagesecretname: ""
   #Provide the servicetype for a peer
   #Eg. servicetype: NodePort
   servicetype: ClusterIP
   #Provide the default consortium value
   #Eg. default_consortium: SampleConsortium
-  default_consortium:
+  default_consortium: SampleConsortium
   loadBalancerType: ""
   ports:
     console:
       #Provide a nodeport for grpc service in the range of 30000-32767 (optional)
       #Eg. nodeport: 30001
-      nodeport:
+      nodeport: 30001
       #Provide a cluster IP port for grpc service to be exposed
       #Eg. clusteripport: 7051
       clusteripport: 3000    
     couchdb:
       #Provide a nodeport for couchdb service in the range of 30000-32767 (optional)
       #Eg. nodeport: 30003
-      nodeport:
+      nodeport: 30003
       #Provide a cluster IP port for couchdb service to be exposed
       #Eg. clusteripport: 5984
       clusteripport: 5984
@@ -79,4 +79,4 @@ proxy:
   provider: "haproxy"
   #This field contains the external URL of the organization
   #Eg. external_url_suffix: org1.blockchaincloudpoc.com
-  external_url_suffix: hf.demo.aws.blockchaincloudpoc.com
+  external_url_suffix: org1.blockchaincloudpoc.com

--- a/platforms/hyperledger-fabric/charts/orderernode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for orderer node
+description: "Hyperledger Fabric: Deploys orderer node."
 name: orderernode
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/orderernode/README.md
+++ b/platforms/hyperledger-fabric/charts/orderernode/README.md
@@ -1,0 +1,239 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "orderer-node-hyperledger-fabric-deployment"></a>
+# Orderer Node Hyperledger Fabric Deployment
+
+- [Orderer Node Hyperledger Fabric Deployment Helm Chart](#orderer-node-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "orderer-node-hyperledger-fabric-deployment-helm-chart"></a>
+## Orderer Node Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/orderernode) for orderer node.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+orderernode/
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- deployment.yaml
+      |- service.yaml
+      |- servicemonitor.yaml      
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Defines two ConfigMaps, one for the orderer configuration and one for the genesis block.
+- `deployment.yaml`: The kafka-healthcheck checks the health of the Kafka brokers before the main container is started. The certificates-init fetches the TLS and MSP certificates from Vault and stores them in a local directory. The {{ $.Values.orderer.name }} runs the Hyperledger Fabric orderer. The grpc-web exposes the orderer's gRPC API over HTTP/WebSockets. These containers are responsible for ensuring that the orderer is up and running, that it has the necessary certificates, and that it can be accessed by clients.
+- `service.yaml`: Ensures internal and external access with exposed ports for gRPC (7050), gRPC-Web (7443), and operations (9443), and optionally uses Ambassador or HAProxy for external exposure and secure communication.
+- `servicemonitor.yaml`: Define a ServiceMonitor resource that allows Prometheus to collect metrics from the orderer node's "operations" port. The configuration is conditionally applied based on the availability of the Prometheus Operator's API version and whether metrics are enabled for the orderer service.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/orderernode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                   | Description                                                           | Default Value                                    |
+| ---------------------- | ----------------------------------------------------------------------| -------------------------------------------------|
+| namespace              | Namespace for orderer                                                 | example-com                                      |
+| images.orderer         | Valid image name and version for fabric orderer                       | hyperledger/fabric-orderer:2.2.2                 |
+| images.alpineutils     | Valid image name and version to read certificates from vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0 |
+| images.healthcheck     | Valid image name and version for health check of Kafka                | busybox                                          |
+| labels                 | Custom labels                                                         | ""                                               |
+
+### Orderer
+
+| Name                        | Description                                                             | Default Value   |
+| --------------------------- | ----------------------------------------------------------------------- | ----------------|
+| name                        | Name for the orderer node                                               | orderer         |
+| loglevel                    | Log level for orderer deployment                                        | info            |
+| localmspid                  | Local MSP ID for orderer deployment                                     | OrdererMSP      |
+| tlsstatus                   | Enable/disable TLS for orderer deployment                               | true            |
+| keepaliveserverinterval     | Interval in which the orderer signals the connection has kept alive     | 10s             |
+
+### Consensus
+
+| Name     | Description                 | Default Value   |
+| ---------| ----------------------------| ----------------|
+| name     | Name of the consensus       | raft            |
+
+### Storage
+
+| Name                  | Description                        | Default Value   |
+| ----------------------| -----------------------------------| ----------------|
+| storageclassname      | Storage class name for orderer     | aws-storage     |
+| storagesize           | Storage size for storage class     | 512Mi           |
+
+### Service
+
+| Name                          | Description                               | Default Value   |
+|-------------------------------| ------------------------------------------| ----------------|
+| servicetype                   | Service type for orderer                  | ClusterIP       |
+| ports.grpc.nodeport           | Cluster IP port for grpc service          | ""              |
+| ports.grpc.clusteripport      | Cluster IP port for grpc service          | 7050            |
+| ports.metrics.enabled         | Enable/disable metrics service            | false           |
+| ports.metrics.clusteripport   | Cluster IP port for metrics service       | 9443            |
+
+### Annotations
+
+| Name           | Description                             | Default Value |
+| ---------------| ----------------------------------------| --------------|
+| service        | Extra annotations for service           | ""            |
+| deployment     | Extra annotations for deployment        | ""            |
+
+### Vault
+
+| Name                        | Description                                                         | Default Value                     |
+| --------------------------- | --------------------------------------------------------------------| --------------------------------- |
+| address                     | Vault server address                                                | ""                                |
+| role                        | Vault role for orderer deployment                                   | vault-role                        |
+| authpath                    | Kubernetes auth backend configured in vault for orderer deployment  | fra-demo-hlkube-cluster-orderer   |
+| secretprefix                | Vault secretprefix                                                  | secret/secretprefix/              |
+| imagesecretname             | Image secret name for vault                                         | ""                                |
+| serviceaccountname          | Service account name for vault                                      | vault-auth                        |
+| tls                         | Enable/disable TLS for vault communication                          | vaultca                           |
+
+### Kafka
+
+| Name                        | Description                                                             | Default Value   |
+| --------------------------- | ------------------------------------------------------------------------| ----------------|
+| readinesscheckinterval      | Interval in seconds to check readiness of Kafka services                | 5               |
+| readinessthreshold          | Threshold for checking if specified Kafka brokers are up and running    | 4               |
+| brokers                     | List of Kafka broker addresses                                          | ""              |
+
+### Proxy
+
+| Name                        | Description                             | Default Value                  |
+| --------------------------- | --------------------------------------- | ------------------------------ |
+| provider                    | Proxy/ingress provider                  | none                           |
+| external_url_suffix         | External URL suffix of the organization | org1.blockchaincloudpoc.com    |
+
+### Config
+
+| Name                          | Description                             | Default Value                  |
+| ---------------------------   | --------------------------------------- | ------------------------------ |
+| pod.resources.limits.memory   | Limit memory for node                   | 512M                           |
+| pod.resources.limits.cpu      | Limit CPU for node                      | 1                              |
+| pod.resources.requests.memory | Requested memory for node               | 512M                           |
+| pod.resources.requests.cpu    | Requested CPU for node                  | 0.25                           |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the orderernode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/orderernode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./orderernode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the orderernode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get statefulsets -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the StatefulSet was created. This command will display information about the StatefulSet, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/orderernode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./orderernode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the orderernode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Orderer Node Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/orderernode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/orderernode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for orderer
   #Eg. namespace: example-com
-  namespace: default
+  namespace: example-com
   images:
     #Provide the valid image name and version for fabric orderer
     #Eg.  orderer: hyperledger/fabric-orderer:1.4.0
-    orderer: 
+    orderer: hyperledger/fabric-orderer:2.2.2
     #Provide the valid image name and version to read certificates from vault server
      #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
    #Provide the valid image name and version for healthcheck of kafka
     #Eg. healthcheck: busybox
     healthcheck: busybox
@@ -28,16 +28,16 @@ metadata:
 orderer:
   #Provide the name for the orderer node
   #Eg. name: orderer
-  name:
+  name: orderer
   #Provide the loglevel for orderer deployment
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the localmspid for orderer deployment
   #Eg. localmspid: OrdererMSP
-  localmspid:
+  localmspid: OrdererMSP
   #Provide the value for tlsstatus to be true or false for orderer deployment
   #Eg. tlsstatus: true
-  tlsstatus: 
+  tlsstatus: true
   #Provide the interval in which the orderer to signal the connection has kept alive  
   #Eg. keepaliveserverinterval: 10s
   keepaliveserverinterval: 10s
@@ -45,15 +45,15 @@ orderer:
 consensus:
   #Provide name of the consensus. Currently support raft and kafka
   #Eg. name: raft
-  name:
+  name: raft
   
 storage:
   #Provide the storageclassname for orderer
   #Eg. storageclassname: aws-storage
-  storageclassname:
+  storageclassname: aws-storage
   #Provide the storagesize for storage class
   #Eg. storagesize: 512Mi
-  storagesize:
+  storagesize: 512Mi
 
 
 service:
@@ -64,7 +64,7 @@ service:
     grpc:
       #Provide a nodeport for orderer in the range of 30000-32767 (optional)
       #Eg. nodeport: 30001
-      nodeport:
+      nodeport: 
       #Provide a cluster IP port for orderer to be exposed.
       #Eg. clusteripport: 7050
       clusteripport: 7050
@@ -82,32 +82,32 @@ vault:
   address:
   #Provide the vaultrole for orderer deployment
   #Eg. vaultrole: orderer-vault-role
-  role:
+  role: vault-role
   #Provide the kubernetes auth backed configured in vault for orderer deployment
   #Eg. authpath: fra-demo-hlkube-cluster-orderer
-  authpath:
+  authpath: fra-demo-hlkube-cluster-orderer
   #Provide the value for vault secretprefix
   #Eg. secretprefix: secret/...
-  secretprefix:
+  secretprefix: secret/secretprefix/
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 kafka:
   #Provide the interval in seconds you want to iterate till all  kafka services to be ready
   #Eg. readinesscheckinterval: 5
-  readinesscheckinterval:
+  readinesscheckinterval: 5
   #Provide the threshold till you want to check if all specified kafka brokers are up and running
   #Eg. readinessthreshold: 4
-  readinessthreshold:  
+  readinessthreshold: 4
   #Provide the kafka broker list
   #Eg.  brokers:
   #       - kafka-0.broker.example-com.svc.cluster.local:9092
@@ -122,7 +122,7 @@ proxy:
   provider: "none"
   #This field contains the external URL of the organization
   #Eg. external_url_suffix: org1.blockchaincloudpoc.com
-  external_url_suffix:
+  external_url_suffix: org1.blockchaincloudpoc.com
 
 config:
   # Set limits and requests of pod  
@@ -140,5 +140,5 @@ config:
       # Eg. memory: 512M
         memory: 512M
       # Provide the requests cpu for node
-      # Eg. cpu: 0.5
-        cpu: 0.5
+      # Eg. cpu: 0.25
+        cpu: 0.25

--- a/platforms/hyperledger-fabric/charts/peernode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for peer node
+description: "Hyperledger Fabric: Deploys peer node."
 name: peernode
 version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/peernode/README.md
+++ b/platforms/hyperledger-fabric/charts/peernode/README.md
@@ -1,0 +1,248 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "peer-node-hyperledger-fabric-deployment"></a>
+# Peer Node Hyperledger Fabric Deployment
+
+- [Peer Node Hyperledger Fabric Deployment Helm Chart](#peer-node-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "peer-node-hyperledger-fabric-deployment-helm-chart"></a>
+## Peer Node Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/peernode) for peer node.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Either HAproxy or Ambassador is required as ingress controller.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+peernode/
+  |- conf/
+      |- default_core.yaml
+  |- templates/
+      |- _helpers.yaml
+      |- configmap.yaml
+      |- deployment.yaml
+      |- service.yaml
+      |- servicemonitor.yaml      
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `default_core.yaml`: Default configuration file for the peer node.
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `configmap.yaml`: Provides a way to configure the Hyperledger Fabric peer and enable it to join the network, interact with other nodes. The environment variables that are defined in the peer-config ConfigMap are used to configure the peer's runtime behavior. The configuration for the MSP is defined in the msp-config ConfigMap. The core.yaml file is used to configure the chaincode builder
+- `deployment.yaml`: The certificates-init container fetches TLS certificates and other secrets from Vault. The couchdb container runs a CouchDB database that is used to store the ledger state. The {{ $.Values.peer.name }} container runs a Hyperledger Fabric peer that manages the ledger and provides access to the blockchain network. The grpc-web container runs a gRPC-Web proxy that allows gRPC services to be accessed via a web browser.
+- `service.yaml`: Ensures internal and external access with exposed ports for gRPC (7051), events (7053), CouchDB (5984), gRPC-Web (7443), and operations (9443), and optionally uses Ambassador or HAProxy for external exposure and secure communication.
+- `servicemonitor.yaml`: Define a ServiceMonitor resource that allows Prometheus to collect metrics from the peer node's "operations" port. The configuration is conditionally applied based on the availability of the Prometheus Operator's API version and whether metrics are enabled for the peer service.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/peernode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                                           | Default Value                                     |
+| ----------------------| ----------------------------------------------------------------------| --------------------------------------------------|
+| namespace             | Provide the namespace for organization's peer                         | org1-example-com                                  |
+| images.couchdb        | valid image name and version for fabric couchdb                       | couchdb:3.1                                       |
+| images.peer           | valid image name and version for fabric peer                          | hyperledger/fabric-peer::2.2.2                    |
+| images.alpineutils    | valid image name and version to read certificates from vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Provide custom labels                                                 | ""                                                |
+
+### Annotations
+
+| Name           | Description                             | Default Value |
+| ---------------| --------------------------------------- | --------------|
+| service        | Extra annotations for service           | ""            |
+| pvc            | Extra annotations for pvc               | ""            |
+| deployment     | Extra annotations for deployment        | ""            |
+
+### Peer
+
+| Name                                      | Description                                                           | Default Value                                 |
+| ------------------------------------------| ----------------------------------------------------------------------| ----------------------------------------------|
+| name                                      | Name of the peer as per deployment yaml                               | peer0                                         |
+| gossippeeraddress                         | URL of gossipping peer and port for grpc                              | peer1.org1-example-com.svc.cluster.local:7051 |
+| gossipexternalendpoint                    | URL of gossip external endpoint and port for ambassador https service | peer1-ext.org1-example-com:443                |
+| localmspid                                | Local MSP ID for the organization                                     | Org1MSP                                       |
+| loglevel                                  | Log level for organization's peer                                     | info                                          |
+| tlsstatus                                 | Set to true or false for organization's peer                          | true                                          |
+| builder                                   | Valid chaincode builder image for Fabric                              | hyperledger/fabric-ccenv:1.4.8                |
+| couchdb.username                          | CouchDB username (mandatory if provided)                              | org1-user                                     |
+| configpath                                | Provide the configuration path                                        | ""                                            |
+| core                                      | Provide core configuration                                            | ""                                            |
+| mspconfig.organizationalunitidentifiers   | Provide the members of the MSP in organizational unit identifiers     | ""                                            |
+| mspconfig.nodeOUs.clientOUidentifier.organizationalunitidentifier  | Organizational unit identifier for client nodes          | client                            |
+| mspconfig.nodeOUs.peerOUidentifier.organizationalunitidentifier    | Organizational unit identifier for peer nodes            | peer                              |
+| mspconfig.nodeOUs.adminOUidentifier.organizationalunitidentifier   | Organizational unit identifier for admin nodes (2.2.x)   | admin                             |
+| mspconfig.nodeOUs.ordererOUidentifier.organizationalunitidentifier | Organizational unit identifier for orderer nodes (2.2.x) | orderer                           |
+
+### Storage
+
+| Name                      | Description                      | Default Value       |
+| --------------------------| -------------------------------- | ------------------- |
+| peer.storageclassname     | Storage class name for peer      | aws-storage         |
+| peer.storagesize          | Storage size for peer            | 512Mi               |
+| couchdb.storageclassname  | Storage class name for CouchDB   | aws-storage         |
+| couchdb.storagesize       | Storage size for CouchDB         | 512Mi               |
+
+### Vault
+
+| Name                  | Description                                                           | Default Value                                     |
+| ----------------------| ----------------------------------------------------------------------| --------------------------------------------------|
+| role                  | Vault role for the organization                                       | vault-role                                        |
+| address               | Vault server address                                                  | ""                                                |
+| authpath              | Kubernetes auth backend configured in vault for the organization      | fra-demo-hlkube-cluster-org1                      |
+| secretprefix          | Vault secret prefix                                                   | secret/secretprefix/                              |
+| serviceaccountname    | Service account name for vault                                        | vault-auth                                        |
+| imagesecretname       | Image secret name for vault                                           | ""                                                |
+| secretcouchdbpass     | Vault path for secret CouchDB password                                | secret/credentials/org1-example-com/couchdb/org1  |
+| tls                   | Enable or disable TLS for vault communication                         | vaultca                                           |
+
+### Service
+
+| Name                          | Description                               | Default Value       |
+| ----------------------------- | ------------------------------------------| ------------------- |
+| servicetype                   | Service type for the peer                 | ClusterIP           |
+| loadBalancerType              | Load balancer type for the peer           | ""                  |
+| ports.grpc.nodeport           | Cluster IP port for grpc service          | ""                  |
+| ports.grpc.clusteripport      | Cluster IP port for grpc service          | 7051                |
+| ports.events.nodeport         | Cluster IP port for event service         | ""                  |
+| ports.events.clusteripport    | Cluster IP port for event service         | 7053                |
+| ports.couchdb.nodeport        | Cluster IP port for CouchDB service       | ""                  |
+| ports.couchdb.clusteripport   | Cluster IP port for CouchDB service       | 5984                |
+| ports.metrics.enabled         | Enable/disable metrics service            | false               |
+| ports.metrics.clusteripport   | Cluster IP port for metrics service       | 9443                |
+
+### Proxy
+
+| Name                  | Description                                               | Default Value       |
+| ----------------------| ----------------------------------------------------------| ------------------- |
+| provider              | Proxy/ingress provider (ambassador, haproxy, or none)     | none                |
+| external_url_suffix   | External URL of the organization                          | ""                  |
+| port                  | External port on ambassador                               | 443                 |
+
+### Config
+
+| Name                          | Description                 | Default Value       |
+| ----------------------------- | --------------------------- | ------------------- |
+| pod.resources.limits.memory   | Limit memory for node       | 512M                |
+| pod.resources.limits.cpu      | Limit CPU for node          | 1                   |
+| pod.resources.requests.memory | Requested memory for node   | 512M                |
+| pod.resources.requests.cpu    | Requested CPU for node      | 0.25                |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the peernode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/peernode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./peernode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the peernode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get statefulsets -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the StatefulSet was created. This command will display information about the StatefulSet, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/peernode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./peernode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the peernode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Peer Node Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/peernode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/peernode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/values.yaml
@@ -7,17 +7,17 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric couchdb
     #Eg. couchdb: hyperledger/fabric-couchdb:0.4.14
-    couchdb: 
+    couchdb: couchdb:3.1
     #Provide the valid image name and version for fabric peer
-    #Eg. hyperledger/fabric-peer:1.4.0
-    peer: 
+    #Eg. hyperledger/fabric-peer::2.2.2
+    peer: hyperledger/fabric-peer::2.2.2
     #Provide the valid image name and version to read certificates from vault server 
     #Eg. alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels  
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name, run
   #These lables will not be applied to VolumeClaimTemplate of StatefulSet as labels are automatically picked up by Kubernetes
@@ -32,30 +32,30 @@ annotations:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the url of gossipping peer and port to be mentioned is grpc cluster IP port
   #Eg. gossippeeraddress: peer1.org1-example-com.svc.cluster.local:7051
-  gossippeeraddress:
+  gossippeeraddress: peer1.org1-example-com.svc.cluster.local:7051
   #Provide the url of gossip external endpoint and  port to be mentioned is ambassador https service port
-  #Eg. gossipexternalendpoint: peer1-ext.org1-example-com:8443
-  gossipexternalendpoint:  
+  #Eg. gossipexternalendpoint: peer1-ext.org1-example-com:443
+  gossipexternalendpoint: peer1-ext.org1-example-com:443
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
   #Provide a valid chaincode builder image for Fabric
   #Eg. builder: hyperledger/fabric-ccenv:1.4.8
-  builder:
+  builder: hyperledger/fabric-ccenv:1.4.8
   couchdb:
     #Provide the username for couchdb login
     #If couchdb username is provided, it is mandatory to provide password for the same
     #Eg. username: org1-user
-    username:
+    username: org1-user
   configpath:
   core: 
   mspconfig:
@@ -86,46 +86,46 @@ storage:
   peer:
     #Provide the storageclassname for peer
     #Eg. storageclassname: aws-storage
-    storageclassname:
+    storageclassname: aws-storage
     #Provide the storagesize for storage class
     #Eg. storagesize: 512Mi
-    storagesize:
+    storagesize: 512Mi
   couchdb:
     #Provide the storageclassname for couchdb
     #Eg. storageclassname: aws-storage
-    storageclassname:
+    storageclassname: aws-storage
     #Provide the storagesize for storage class
     #Eg. storagesize: 512Mi
-    storagesize:
+    storagesize: 512Mi
 
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
-  address:
+  address: 
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. secretprefix: secret/...
-  secretprefix:
+  secretprefix: secret/secretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Provide the vault path for secret couchdb password
   #Eg. secretcouchdbpass: secret/credentials/org1-example-com/couchdb/org1?user
-  secretcouchdbpass:
+  secretcouchdbpass: secret/credentials/org1-example-com/couchdb/org1
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 service:
@@ -167,8 +167,8 @@ proxy:
   #Eg. external_url_suffix: org1.blockchaincloudpoc.com
   external_url_suffix:
   #This field contains the external port on ambassador and is defaulted to 15010
-  #Eg. port: 8443
-  port: 8443
+  #Eg. port: 443
+  port: 443
   
 config:
   # Set limits and requests of pod  
@@ -186,5 +186,5 @@ config:
       # Eg. memory: 512M
         memory: 512M
       # Provide the requests cpu for node
-      # Eg. cpu: 0.5
-        cpu: 0.5
+      # Eg. cpu: 0.25
+        cpu: 0.25

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode upgrade on a peer
+description: "Hyperledger Fabric: Upgrades chaincode on a peer."
 name: upgrade_chaincode
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/README.md
@@ -1,0 +1,200 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "upgrade-chaincode-hyperledger-fabric-deployment"></a>
+# Upgrade Chaincode Hyperledger Fabric Deployment
+
+- [Upgrade Chaincode Hyperledger Fabric Deployment Helm Chart](#upgrade-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "upgrade-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Upgrade Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/upgrade_chaincode) for chaincode upgrade on a peer.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+upgrade_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- upgrade_chaincode.yaml   
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `upgrade_chaincode.yaml`: The certificates-init fetches TLS  and MSP certificates from Vault and stores them in a volume mounted to the upgradechaincode container. The upgradechaincode container upgrades the chaincode to the specified version. Both containers are used to deploy and upgrade chaincode on a Hyperledger Fabric network.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/upgrade_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                       | Default Value                                     |
+| ----------------------| --------------------------------------------------| --------------------------------------------------|
+| namespace             | Namespace for organization's peer                 | default                                           |
+| images.fabrictools    | Image for Hyperledger Fabric tools                | hyperledger/fabric-tools:2.2.2                    |
+| images.alpineutils    | Image to read certificates from Vault server      | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Custom labels                                     | ""                                                |
+
+### Peer
+
+| Name                  | Description                                           | Default Value       |
+| ----------------------| ------------------------------------------------------| ------------------- |
+| name                  | Name of the peer as per deployment YAML               | peer0               |
+| address               | Address of the peer and grpc cluster IP port          | ""                  |
+| localmspid            | Local MSP ID for organization                         | Org1MSP             |
+| loglevel              | Log level for organization's peer                     | info                |
+| tlsstatus             | TLS status (true or false) for organization's peer    | true                |
+
+### Vault
+
+| Name                  | Description                                       | Default Value                 |
+| ----------------------| --------------------------------------------------| ------------------------------|
+| role                  | Vault role for the organization                   | vault-role                    |
+| address               | Vault server address                              | ""                            |
+| authpath              | Kubernetes auth backend configured in Vault       | fra-demo-hlkube-cluster-org1  |
+| adminsecretprefix     | Vault secret prefix for admin                     | secret/adminsecretprefix/     |
+| orderersecretprefix   | Vault secret prefix for orderer                   | secret/orderersecretprefix/   |
+| serviceaccountname    | Service account name for Vault                    | vault-auth                    |
+| imagesecretname       | Image secret name for Vault (Optional)            | ""                            |
+| tls                   | Enable or disable TLS for Vault communication     | vaultca                       |
+
+### Orderer
+
+| Name           | Description               | Default Value                |
+| ---------------| --------------------------| -----------------------------|
+| address        | Address for the orderer   | orderer-ext.example-com:443  |
+
+### Chaincode
+
+| Name                  | Description                                       | Default Value                     |
+| ----------------------| --------------------------------------------------| ----------------------------------|
+| builder               | Chaincode builder image for Fabric                | hyperledger/fabric-ccenv:2.2.2    |
+| name                  | Name of the chaincode to be upgraded              | cc                                |
+| version               | Chaincode version to be upgraded                  | "1.0"                             |
+| upgradearguments      | Upgrade arguments for the chaincode               | ""                                |
+| endorsementpolicies   | Endorsement policies for the chaincode (Optional) | ""                                |
+
+### Channel
+
+| Name     | Description          | Default Value  |
+| ---------| ---------------------| ---------------|
+| name     | Name of the channel  | mychannel      |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the upgrade_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/upgrade_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./upgrade_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the upgrade_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/upgrade_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./upgrade_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the upgrade_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Upgrade Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/upgrade_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: 
+    fabrictools: hyperledger/fabric-tools:1.4.0
     #Provide the valid image name and version to read certificates from vault server
      #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: 
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -25,65 +25,65 @@ metadata:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
-  address:
+  address: peer0.org1-example-com:7051
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
-  address:
+  #Eg. address: orderer-ext.example-com:443
+  address: orderer-ext.example-com:443
 
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
   #Eg. builder: hyperledger/fabric-ccenv:1.4.8
-  builder:
+  builder: hyperledger/fabric-ccenv:2.2.2
   #Provide the name of the chaincode to be upgraded
   #Eg. name: cc
-  name:
+  name: cc
   #Provide the chaincode version to be upgraded
-  #Eg. name: "1.0"
-  version:
+  #Eg. version: "1.0"
+  version: "1.0"
   #Provide the upgrade arguments
   #Eg. upgradearguments: '"init","a","200","b","400"'
   upgradearguments:
@@ -95,4 +95,4 @@ chaincode:
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for chaincode verify a peer
+description: "Hyperledger Fabric: Verifies chaincode."
 name: verify_chaincode
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/README.md
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/README.md
@@ -1,0 +1,200 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "verify-chaincode-hyperledger-fabric-deployment"></a>
+# Verify Chaincode Hyperledger Fabric Deployment
+
+- [Verify Chaincode Hyperledger Fabric Deployment Helm Chart](#verify-chaincode-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "verify-chaincode-hyperledger-fabric-deployment-helm-chart"></a>
+## Verify Chaincode Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/verify_chaincode) to Verify a chaincode.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+verify_chaincode/
+  |- templates/
+      |- _helpers.yaml
+      |- verify_chaincode.yaml   
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `verify_chaincode.yaml`: The certificates-init container retrieves TLS certificates and secrets from Vault, storing them within the pod. The verifychaincode container interacts with the Hyperledger Fabric blockchain, invoking specified chaincode, utilizing the retrieved certificates and necessary configurations for communication and endorsement.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/verify_chaincode/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                                               | Default                           |
+|-----------------------|---------------------------------------------------------------------------|-----------------------------------|
+| namespace             | Provide the namespace for the organization's peer                         | org1-example-com                           |
+| images.fabrictools    | Valid image name and version for fabric tools                             | hyperledger/fabric-tools:2.2.2    |
+| images.alpineutils    | Valid image name and version to read certificates from the vault server   | index.docker.io/hyperledgerlabs/alpine-utils:1.0  |
+| labels                | Custom labels                                                             | ""                                |
+
+### Peer
+
+| Name          | Description                                          | Default    |
+|---------------| -----------------------------------------------------|------------|
+| name          | Provide the name of the peer                         | peer0      |
+| address       | Address of the peer who creates the channel          | ""         |
+| localmspid    | Provide the local MSPID for the organization         | Org1MSP    |
+| loglevel      | Provide the log level for the organization's peer    | info       |
+| tlsstatus     | Provide the value for TLS status for the peer        | true       |
+
+### Vault
+
+| Name                  | Description                                         | Default                       |
+|-----------------------| ----------------------------------------------------|-------------------------------|
+| role                  | Vault role for the organization                     | vault-role                    |
+| address               | Vault server address                                | ""                            |
+| authpath              | Kubernetes auth backend configured in vault         | fra-demo-hlkube-cluster-org1  |
+| adminsecretprefix     | Provide the value for vault admin secret prefix     | secret/adminsecretprefix/     |
+| orderersecretprefix   | Provide the value for vault orderer secret prefix   | secret/orderersecretprefix/   |
+| serviceaccountname    | Provide the service account name for vault          | vault-auth                    |
+| imagesecretname       | Provide the image secret name for vault             | ""                            |
+| tls                   | Enable or disable TLS for vault communication       | vaultca                       |
+
+### Orderer
+
+| Name       | Description                              | Default   |
+|------------|------------------------------------------|-----------|
+| address    | Provide the address for the orderer      | ""        |
+
+### Chaincode
+
+| Name                  | Description                                               | Default                           |
+|-----------------------|---------------------------------------------------------- |-----------------------------------|
+| builder               | Valid chaincode builder image for Fabric                  | hyperledger/fabric-ccenv:1.4.8    |
+| name                  | Provide the name of the chaincode to be upgraded          | cc                                |
+| version               | Provide the chaincode version to be upgraded              | "1.0"                             |
+| upgradearguments      | Provide the upgrade arguments for the chaincode           | ""                                |
+| endorsementpolicies   | Provide the endorsement policies for the chaincode        | ""                                |
+
+### Channel
+
+| Name       | Description                        | Default     |
+|------------| -----------------------------------|-------------|
+| name       | Provide the name of the channel    | mychannel   |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the verify_chaincode Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/verify_chaincode/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./verify_chaincode
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the verify_chaincode node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get jobs -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the Job was created. This command will display information about the Job, including the number of completions and the current status of the Job's pods.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/verify_chaincode/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./verify_chaincode
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the verify_chaincode node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Verify Chaincode Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/verify_chaincode), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's peer
   #Eg. namespace: org1-example-com
-  namespace: default
+  namespace: org1-example-com
   images:
     #Provide the valid image name and version for fabric tools
     #Eg. fabrictools: hyperledger/fabric-tools:1.4.0
-    fabrictools: hyperledger/fabric-tools:1.4.0
+    fabrictools: hyperledger/fabric-tools:2.2.2
     #Provide the valid image name and version to read certificates from vault server
      #Eg.alpineutils: hyperledgerlabs/alpine-utils:1.0
-    alpineutils: hyperledgerlabs/alpine-utils:1.0
+    alpineutils: index.docker.io/hyperledgerlabs/alpine-utils:1.0
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:
@@ -25,65 +25,65 @@ metadata:
 peer:
   #Provide the name of the peer as per deployment yaml.
   #Eg. name: peer0
-  name:
+  name: peer0
   #Provide the address of the peer who creates the channel and port to be mentioned is grpc cluster IP port
   #Eg. address: peer0.org1-example-com:7051
   address:
   #Provide the localmspid for organization
   #Eg. localmspid: Org1MSP
-  localmspid:
+  localmspid: Org1MSP
   #Provide the loglevel for organization's peer
   #Eg. loglevel: info
-  loglevel:
+  loglevel: info
   #Provide the value for tlsstatus to be true or false for organization's peer
   #Eg. tlsstatus: true
-  tlsstatus:
+  tlsstatus: true
 
 
 vault:
   #Provide the vaultrole for an organization
   #Eg. vaultrole: org1-vault-role
-  role:
+  role: vault-role
   #Provide the vault server address
   #Eg. vaultaddress: http://Vault-884963190.eu-west-1.elb.amazonaws.com
   address:
   #Provide the kubernetes auth backed configured in vault for an organization
   #Eg. authpath: fra-demo-hlkube-cluster-org1
-  authpath:
+  authpath: fra-demo-hlkube-cluster-org1
   #Provide the value for vault secretprefix
   #Eg. adminsecretprefix: secret/...
-  adminsecretprefix:
+  adminsecretprefix: secret/adminsecretprefix/
   #Provide the value for vault secretprefix
   #Eg. orderersecretprefix: secret/...
-  orderersecretprefix:
+  orderersecretprefix: secret/orderersecretprefix/
   #Provide the serviceaccountname for vault
   #Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  serviceaccountname: vault-auth
   #Provide the imagesecretname for vault
   #Eg. imagesecretname: regcred
-  imagesecretname:
+  imagesecretname: ""
   #Kuberenetes secret for vault ca.cert
   #Enable or disable TLS for vault communication if value present or not
   #Eg. tls: vaultca
-  tls:
+  tls: vaultca
 
 
 orderer:
   #Provide the address for orderer
-  #Eg. address: orderer-ext.example-com:8443
+  #Eg. address: orderer-ext.example-com:443
   address:
 
 
 chaincode:
   #Provide a valid chaincode builder image for Fabric
   #Eg. builder: hyperledger/fabric-ccenv:1.4.8
-  builder:
+  builder: hyperledger/fabric-ccenv:1.4.8
   #Provide the name of the chaincode to be upgraded
   #Eg. name: cc
-  name:
+  name: cc
   #Provide the chaincode version to be upgraded
-  #Eg. name: "1.0"
-  version:
+  #Eg. version: "1.0"
+  version: "1.0"
   #Provide the upgrade arguments
   #Eg. upgradearguments: '"init","a","200","b","400"'
   upgradearguments:
@@ -95,4 +95,4 @@ chaincode:
 channel:
   #Provide the name of the channel
   #Eg. name: mychannel
-  name:
+  name: mychannel

--- a/platforms/hyperledger-fabric/charts/zkkafka/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/zkkafka/Chart.yaml
@@ -6,6 +6,6 @@
 
 apiVersion: v1
 appVersion: "2.0"
-description: A Helm chart for zookeeper & kafka
+description: "Hyperledger Fabric: Deploys zookeeper & kafka."
 name: zkkafka
-version: '0.14.0'
+version: '0.14.1'

--- a/platforms/hyperledger-fabric/charts/zkkafka/README.md
+++ b/platforms/hyperledger-fabric/charts/zkkafka/README.md
@@ -1,0 +1,191 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+<a name = "zookeeper-and-kafka-chaincode-hyperledger-fabric-deployment"></a>
+# Zookeeper and Kafka Hyperledger Fabric Deployment
+
+- [Zookeeper and Kafka Hyperledger Fabric Deployment Helm Chart](#zookeeper-and-kafka-hyperledger-fabric-deployment-helm-chart)
+- [Prerequisites](#prerequisites)
+- [Chart Structure](#chart-structure)
+- [Configuration](#configuration)
+- [Deployment](#deployment)
+- [Verification](#verification)
+- [Updating the Deployment](#updating-the-deployment)
+- [Deletion](#deletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+<a name = "zookeeper-and-kafka-hyperledger-fabric-deployment-helm-chart"></a>
+## Zookeeper and Kafka Hyperledger Fabric Deployment Helm Chart
+---
+A [Helm chart](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/zkkafka) to deploy zookeeper & kafka.
+
+
+<a name = "prerequisites"></a>
+## Prerequisites
+---
+Before deploying the Helm chart, make sure to have the following prerequisites:
+
+- Kubernetes cluster up and running.
+- A HashiCorp Vault instance is set up and configured to use Kubernetes service account token-based authentication.
+- The Vault is unsealed and initialized.
+- Helm installed.
+
+
+<a name = "chart-structure"></a>
+## Chart Structure
+---
+The structure of the Helm chart is as follows:
+
+```
+zkkafka/
+  |- templates/
+      |- _helpers.yaml
+      |- deployment.yaml
+      |- service.yaml
+      |- volume.yaml
+  |- Chart.yaml
+  |- README.md
+  |- values.yaml
+```
+
+- `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
+- `helpers.tpl`: Contains custom label definitions used in other templates.
+- `deployment.yaml`: Deploy a Zookeeper and Kafka in a Kubernetes cluster and also defines an initContainer that is used to check the health of the Zookeeper pod before the Kafka pods are started.
+- `service.yaml`: Defines two services, one for ZooKeeper and another for Kafka. These services expose specific ports and are responsible for routing traffic to the corresponding pods based on their label selectors with in cluster only. 
+- `volume.yaml`: Creates the persistent volumes that are used by each Kafka pods.
+- `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
+- `README.md`: Provides information and instructions about the Helm chart.
+- `values.yaml`: Contains the default configuration values for the Helm chart.
+
+
+<a name = "configuration"></a>
+## Configuration
+---
+The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hyperledger-fabric/charts/zkkafka/values.yaml) file contains configurable values for the Helm chart. We can modify these values according to the deployment requirements. Here are some important configuration options:
+
+### Metadata
+
+| Name                  | Description                                                    | Default Value                         |
+| ----------------------| ---------------------------------------------------------------| --------------------------------------|
+| namespace             | Provide the namespace for organization's Zookeeper and Kafka   | example-com                           |
+| images.kafka          | Valid image name and version for Fabric Kafka                  | hyperledger/fabric-kafka:0.4.18       |
+| images.zookeeper      | Valid image name and version for Fabric Zookeeper              | hyperledger/fabric-zookeeper:0.4.18   |
+| images.healthcheck    | Valid image name and version for Zookeeper health check        | busybox                               |
+| labels                | Custom labels for the deployment                               | ""                                    |
+
+### Deployment
+
+| Name          | Description                      | Default Value |
+| ------------- | ---------------------------------| --------------|
+| annotations   | Annotations for the deployment   | ""            |
+
+### Storage
+
+| Name              | Description                     | Default Value  |
+| ------------------| --------------------------------| ---------------|
+| storagesize       | Storagesize for storage class   | 512Mi          |
+| storageclassname  | Storageclassname for orderer    | aws-storage    |
+
+### Kafka
+
+| Name                  | Description                               | Default Value  |
+| ----------------------| ------------------------------------------| ---------------|
+| name                  | Name for Kafka deployment                 | kafka          |
+| brokerservicename     | Brokerservicename for Kafka and orderer   | broker         |
+| replicas              | Number of replicas for Kafka              | 4              |
+
+### Zookeeper
+
+| Name                      | Description                                                           | Default Value |
+| --------------------------| ----------------------------------------------------------------------|---------------|
+| name                      | Name for Zookeeper deployment                                         | zookeeper     |
+| peerservicename           | Peerservicename for Zookeeper peers and leader election               | zoo           |
+| replicas                  | Number of replicas for Zookeeper                                      | 4             |
+| readinessthreshold        | Threshold to check if all specified Zookeeper are up and running      | 4             |
+| readinesscheckinterval    | Interval in seconds to check readiness of Zookeeper services          | 5             |
+
+
+<a name = "deployment"></a>
+## Deployment
+---
+
+To deploy the zkkafka Helm chart, follow these steps:
+
+1. Modify the [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/zkkafka/values.yaml) file to set the desired configuration values.
+2. Run the following Helm command to install the chart:
+    ```
+    $ helm repo add bevel https://hyperledger.github.io/bevel/
+    $ helm install <release-name> ./zkkafka
+    ```
+Replace `<release-name>` with the desired name for the release.
+
+This will deploy the zkkafka node to the Kubernetes cluster based on the provided configurations.
+
+
+<a name = "verification"></a>
+## Verification
+---
+
+To verify the deployment, we can use the following command:
+```
+$ kubectl get statefulsets -n <namespace>
+```
+Replace `<namespace>` with the actual namespace where the StatefulSet was created. This command will display information about the StatefulSet, including the number of replicas and their current status.
+
+
+<a name = "updating-the-deployment"></a>
+## Updating the Deployment
+---
+
+If we need to update the deployment with new configurations or changes, modify the same [values.yaml](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/zkkafka/values.yaml) file with the desired changes and run the following Helm command:
+```
+$ helm upgrade <release-name> ./zkkafka
+```
+Replace `<release-name>` with the name of the release. This command will apply the changes to the deployment, ensuring the zkkafka node is up to date.
+
+
+<a name = "deletion"></a>
+## Deletion
+---
+
+To delete the deployment and associated resources, run the following Helm command:
+```
+$ helm uninstall <release-name>
+```
+Replace `<release-name>` with the name of the release. This command will remove all the resources created by the Helm chart.
+
+
+<a name = "contributing"></a>
+## Contributing
+---
+If you encounter any bugs, have suggestions, or would like to contribute to the [Zookeeper and Kafka Hyperledger Fabric Deployment Helm Chart](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/zkkafka), please feel free to open an issue or submit a pull request on the [project's GitHub repository](https://github.com/hyperledger/bevel).
+
+
+<a name = "license"></a>
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Accenture
+
+### Attribution
+
+This chart is adapted from the [charts](https://hyperledger.github.io/bevel/) which is licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/platforms/hyperledger-fabric/charts/zkkafka/values.yaml
+++ b/platforms/hyperledger-fabric/charts/zkkafka/values.yaml
@@ -7,14 +7,14 @@
 metadata:
   #Provide the namespace for organization's zookeeper and kafka
   #Eg. namespace: example-com
-  namespace: default
+  namespace: example-com
   images:  
     #Provide the valid image name and version for fabric kafka 
     #Eg. kafka: hyperledger/fabric-kafka:0.4.14
-    kafka:
+    kafka: hyperledger/fabric-kafka:0.4.18
     #Provide the valid image name and version for fabric zookeeper 
     #Eg. zookeeper: hyperledger/fabric-zookeeper:0.4.14
-    zookeeper:
+    zookeeper: hyperledger/fabric-zookeeper:0.4.18
     #Provide the valid image name and version for healthcheck of zookeeper
     #Eg. healthcheck: busybox
     healthcheck: busybox
@@ -30,10 +30,10 @@ deployment:
 storage:
   #Provide the storagesize for storage class
   #Eg. storagesize: 512Mi
-  storagesize: 
+  storagesize: 512Mi
   #Provide the storageclassname for orderer
   #Eg. storageclassname: aws-storage
-  storageclassname: 
+  storageclassname: aws-storage
 
 kafka:
   #Provide the name for kafka 
@@ -44,7 +44,7 @@ kafka:
   brokerservicename: broker
   #Provide the value for replicas you want to create for kafka
   #Eg. replicas: 4
-  replicas:   
+  replicas: 4
 
 zookeeper:
   #Provide the name for zookeeper 
@@ -54,17 +54,11 @@ zookeeper:
   #Eg. peerservicename: zoo
   peerservicename: zoo
   #Provide the value for replicas you want to create for zookeeper
-  #Eg. replicas: 4    
-  replicas: 
+  #Eg. replicas: 4   
+  replicas: 4
   #Provide the threshold till you want to check if all specified zookeeper are up and running
   #Eg. readinessthreshold: 4
-  readinessthreshold:  
+  readinessthreshold: 4
   #Provide the interval in seconds you want to iterate till all zookeeper services are ready 
   #Eg. readinesscheckinterval: 5
-  readinesscheckinterval: 
-
-  
-
-  
-
-
+  readinesscheckinterval: 5


### PR DESCRIPTION
### **Commit to be reviewed**
---

**docs(fabric): add README.md files for each Fabric Helm chart**

```
This commit adds the README.md file for each Fabric Helm chart. The README.md files provide essential information and instructions about the respective Helm charts, enabling users and developers to deploy each chart individually.

Additionally, the following changes have been made:

 • Updated values.yaml of each Helm chart with default values to provide a clear configuration reference.
 • Added helpers.tpl template file only to Helm charts where it was missing, ensuring consistency across the charts.
 • Updated the description and version fields of each Fabric Helm chart.

These changes enhance the usability and documentation of the Fabric Helm charts, making it easier for users and developers to understand and work with the charts.
```

fixes #2283