### PR TITLE
feat(shared): Simplifying storage class creation with helm module 

### DIFF
--- a/platforms/hyperledger-besu/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-besu/configuration/deploy-network.yaml
@@ -38,11 +38,12 @@
   # Create Storageclass
   - name: Create Storage Class
     include_role:
-      name: create/storageclass
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
     vars:
       org_name: "{{ org.name | lower }}"
       cloudProvider: "{{ org.cloud_provider | lower }}"
       sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
+      component_ns: "{{ org.name | lower }}-bes"
       kubernetes: "{{ org.k8s }}"
       region: "{{ org.k8s.region | default('eu-west-1') }}"
       git_dir: "{{ org.gitops.release_dir }}"
@@ -135,7 +136,6 @@
       build_path: "./build"
       kubernetes: "{{ item.k8s }}"
       consensus: "{{ network.config.consensus }}"
-      component_ns: "{{ item.name | lower }}-bes"
       name: "{{ item.name | lower }}"
       peers: "{{ item.services.validators}}"
       sc_name: "{{ name }}-{{ item.cloud_provider | lower }}-storageclass"

--- a/platforms/hyperledger-besu/configuration/generate-crypto.yaml
+++ b/platforms/hyperledger-besu/configuration/generate-crypto.yaml
@@ -30,10 +30,13 @@
   # Create Storageclass
   - name: Create Storage Class
     include_role:
-      name: create/storageclass
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
     vars:
-      storageclass_name: "{{ org.cloud_provider }}storageclass"
+      org_name: "{{ org.name | lower }}"
+      cloudProvider: "{{ org.cloud_provider | lower }}"
+      sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
       git_dir: "{{ org.gitops.release_dir }}"
+      charts_dir: "platforms/shared/charts"
       org: "{{ org }}"
       kubernetes: "{{ org.k8s }}"
     loop: "{{ network['organizations'] }}"

--- a/platforms/hyperledger-fabric/configuration/add-orderer-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-orderer-organization.yaml
@@ -60,19 +60,20 @@
     # Create Storageclass for new organization
     - name: "Create storageclass for new org"
       include_role:
-        name: "create/storageclass"
+        name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"  
       vars:
-        org_name: "{{ item.name | lower }}"
-        cloudProvider: "{{ item.cloud_provider | lower }}"
+        org_name: "{{ org.name | lower }}"
+        cloudProvider: "{{ org.cloud_provider | lower }}"
         sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-        component_type: "{{ item.type | lower }}"
-        region: "{{ item.k8s.region | default('eu-west-1') }}"
-        kubernetes: "{{ item.k8s }}"
+        component_type: "{{ org.type | lower }}"
+        region: "{{ org.k8s.region | default('eu-west-1') }}"
+        kubernetes: "{{ org.k8s }}"
         platform_suffix: "net"
         charts_dir: "platforms/shared/charts"
-        release_dir: "./build"
       loop: "{{ network['organizations'] }}"
-      when: item.org_status == 'new'
+      loop_control:
+        loop_var: org
+      when: org.org_status == 'new'
         
     # Create CA Server value files and check-in for new organization
     - name: "Create CA Server for new org"

--- a/platforms/hyperledger-fabric/configuration/add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-organization.yaml
@@ -58,19 +58,20 @@
 
     # Create Storageclass for new organization
     - include_role:
-        name: "create/storageclass"
+        name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"  
       vars:
-        org_name: "{{ item.name | lower }}"
-        cloudProvider: "{{ item.cloud_provider | lower }}"
+        org_name: "{{ org.name | lower }}"
+        cloudProvider: "{{ org.cloud_provider | lower }}"
         sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-        region: "{{ item.k8s.region | default('eu-west-1') }}"
-        component_type: "{{ item.type | lower}}"
-        kubernetes: "{{ item.k8s }}"
+        region: "{{ org.k8s.region | default('eu-west-1') }}"
+        component_type: "{{ org.type | lower}}"
+        kubernetes: "{{ org.k8s }}"
         platform_suffix: "net"
         charts_dir: "platforms/shared/charts"
-        release_dir: "./build"
       loop: "{{ network['organizations'] }}"
-      when: item.org_status == 'new'
+      loop_control:
+        loop_var: org
+      when: org.org_status == 'new'
         
     # Create CA Server value files and check-in for new organization
     - include_role:

--- a/platforms/hyperledger-fabric/configuration/add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-peer.yaml
@@ -55,18 +55,19 @@
 
   # Create Storageclass for new organization
   - include_role:
-      name: "create/storageclass"
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"  
     vars:
-      org_name: "{{ item.name | lower }}"
-      cloudProvider: "{{ item.cloud_provider | lower }}"
+      org_name: "{{ org.name | lower }}"
+      cloudProvider: "{{ org.cloud_provider | lower }}"
       sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-      component_type: "{{ item.type | lower}}"
-      region: "{{ item.k8s.region | default('eu-west-1') }}"
-      kubernetes: "{{ item.k8s }}"
+      component_type: "{{ org.type | lower}}"
+      region: "{{ org.k8s.region | default('eu-west-1') }}"
+      kubernetes: "{{ org.k8s }}"
       platform_suffix: "net"
       charts_dir: "platforms/shared/charts"
-      release_dir: "./build"
     loop: "{{ network['organizations'] }}"
+    loop_control:
+      loop_var: org
     
   # Create Organization crypto materials for new organization
   - include_role:
@@ -112,6 +113,7 @@
       values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
     loop: "{{ network['organizations'] }}"
     when: item.type == 'peer'
+
   # This role fetches block 0 and joins peers of new organizaion to the channel
   - include_role:
       name: "create/channels_join"

--- a/platforms/hyperledger-fabric/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/deploy-network.yaml
@@ -89,18 +89,19 @@
     # Create Storageclass 
     - name: Create storageclass for each organization
       include_role:
-        name: "create/storageclass"
+        name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass" 
       vars:
-        org_name: "{{ item.name | lower }}"
-        cloudProvider: "{{ item.cloud_provider | lower }}"
+        org_name: "{{ org.name | lower }}"
+        cloudProvider: "{{ org.cloud_provider | lower }}"
         sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-        component_type: "{{ item.type | lower }}"
-        region: "{{ item.k8s.region | default('eu-west-1') }}"
-        kubernetes: "{{ item.k8s }}"
+        component_type: "{{ org.type | lower }}"
+        region: "{{ org.k8s.region | default('eu-west-1') }}"
+        kubernetes: "{{ org.k8s }}"
         charts_dir: "platforms/shared/charts"
         platform_suffix: "net"
-        release_dir: "./build"
       loop: "{{ network['organizations'] }}"
+      loop_control:
+        loop_var: org
         
     # Create CA Server helm-value files and check-in
     - name: Create CA server for each organization

--- a/platforms/hyperledger-fabric/configuration/deploy-operator-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/deploy-operator-network.yaml
@@ -35,21 +35,25 @@
         release_dir: "./build"
       loop: "{{ network['organizations'] }}"
 
+    # Create Storageclass for new organization for when operator using
     - name: Create storageclass for each organization
       include_role:
-        name: "create/storageclass"
+        name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"  
       vars:
-        org_name: "{{ item.name | lower }}"
-        cloudProvider: "{{ item.cloud_provider | lower }}"
+        org_name: "{{ org.name | lower }}"
+        cloudProvider: "{{ org.cloud_provider | lower }}"
         sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-        component_type: "{{ item.type | lower }}"
-        region: "{{ item.k8s.region | default('eu-west-1') }}"
-        kubernetes: "{{ item.k8s }}"
+        component_type: "{{ org.type | lower}}"
+        kubernetes: "{{ org.k8s }}"
+        region: "{{ org.k8s.region | default('eu-west-1') }}"
         charts_dir: "platforms/shared/charts"
         platform_suffix: "net"
-        release_dir: "./build"
       loop: "{{ network['organizations'] }}"
-        
+      loop_control:
+        loop_var: org
+      when: 
+      - network.env.type == 'operator'  
+      
     - name: Create CA server for each organization
       include_role:
         name: "operator/create/ca/server"

--- a/platforms/hyperledger-indy/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-indy/configuration/deploy-network.yaml
@@ -56,20 +56,21 @@
   # Create StorageClass
   - name: Create Storage Class
     include_role:
-      name: create/storageclass
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
     vars:
-      organization: "{{ organizationItem.name | lower }}"
-      component_ns: "{{ organizationItem.name | lower }}-ns"
-      provider: "{{ organizationItem.cloud_provider }}"
-      storageclass_name: "{{ provider }}-storageclass"
-      component_name: "{{ organization }}-{{ storageclass_name }}"
-      gitops: "{{ organizationItem.gitops }}"
-      kubernetes: "{{ organizationItem.k8s }}"
-      aws: "{{ organizationItem.aws }}"
+      org_name: "{{ org.name | lower }}"
+      cloudProvider: "{{ org.cloud_provider | lower }}"
+      sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
+      region: "{{ org.k8s.region | default('eu-west-1') }}"
+      git_dir: "{{ org.gitops.release_dir }}"
+      gitops: "{{ org.gitops }}"
+      kubernetes: "{{ org.k8s }}"
+      charts_dir: "platforms/shared/charts"
+      platform_suffix: "ns"
     loop: "{{ network['organizations'] }}"
     loop_control:
-      loop_var: organizationItem
-    when: organizationItem.org_status is not defined or organizationItem.org_status == 'new'
+      loop_var: org
+    when: org.org_status is not defined or org.org_status == 'new'
 
   # Admin K8S auth
   - name: Admin K8S auth
@@ -194,6 +195,7 @@
       name: setup/node
     vars:
       organization: "{{ organizationItem.name | lower }}"
+      sc_name: "{{ organization }}-{{ organizationItem.cloud_provider | lower }}-storageclass"
       component_ns: "{{ organizationItem.name | lower }}-ns"
       services: "{{ organizationItem.services }}"
       kubernetes: "{{ organizationItem.k8s }}"

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/node/templates/node.tpl
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/node/templates/node.tpl
@@ -107,7 +107,7 @@ spec:
     storage:
       data:
         storagesize: 3Gi
-        storageClassName: {{ organizationItem.name }}-{{ organizationItem.cloud_provider }}-storageclass
+        storageClassName: {{ sc_name }}
       keys:
         storagesize: 3Gi
-        storageClassName: {{ organizationItem.name }}-{{ organizationItem.cloud_provider }}-storageclass
+        storageClassName: {{ sc_name }}

--- a/platforms/quorum/configuration/deploy-network.yaml
+++ b/platforms/quorum/configuration/deploy-network.yaml
@@ -36,18 +36,30 @@
   # Create Storageclass
   - name: Create Storage Class
     include_role:
-      name: create/storageclass
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
     vars:
-      org_name: "{{ item.name | lower }}"
-      cloudProvider: "{{ item.cloud_provider | lower }}"
+      org_name: "{{ org.name | lower }}"
+      cloudProvider: "{{ org.cloud_provider | lower }}"
       sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-      region: "{{ item.k8s.region | default('eu-west-1') }}"
-      git_dir: "{{ item.gitops.release_dir }}"
-      org: "{{ item }}"
-      kubernetes: "{{ item.k8s }}"
+      region: "{{ org.k8s.region | default('eu-west-1') }}"
+      git_dir: "{{ org.gitops.release_dir }}"
+      kubernetes: "{{ org.k8s }}"
       charts_dir: "platforms/shared/charts"
       platform_suffix: "quo"
     loop: "{{ network['organizations'] }}"
+    loop_control:
+      loop_var: org
+
+  #Create Vault scrit as configmap for Vault CURD operations
+  - name: setup vault script
+    include_role:
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault-script"
+    vars:
+      component_ns: "{{ org.name | lower }}-quo"
+      kubernetes: "{{ org.k8s }}"
+    loop: "{{ network['organizations'] }}"
+    loop_control:
+      loop_var: org
 
   #Create Vault scrit as configmap for Vault CURD operations
   - name: setup vault script
@@ -112,7 +124,6 @@
     when: network.config.consensus == 'raft'
     loop_control:
       loop_var: org
-
 
   # This role makes up the istanbul binary and place it in the bin directory
   - name: "Setup istanbul-tools"

--- a/platforms/r3-corda-ent/configuration/deploy-network.yaml
+++ b/platforms/r3-corda-ent/configuration/deploy-network.yaml
@@ -36,12 +36,12 @@
   # Create Storageclass that will be used for this deployment
   - name: Create Storage Class
     include_role:
-      name: create/storageclass
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
     vars:
       org_name: "{{ org.name | lower }}"
       cloudProvider: "{{ org.cloud_provider | lower }}"
       sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
-      region: "{{ item.k8s.region | default('eu-west-1') }}"
+      region: "{{ org.k8s.region | default('eu-west-1') }}"
       git_dir: "{{ org.gitops.release_dir }}"
       kubernetes: "{{ org.k8s }}"
       gitops: "{{ org.gitops }}"

--- a/platforms/r3-corda-ent/configuration/deploy-nodes.yaml
+++ b/platforms/r3-corda-ent/configuration/deploy-nodes.yaml
@@ -23,11 +23,14 @@
   # Create Storageclass that will be used for this deployment
   - name: Create Storage Class
     include_role:
-      name: create/storageclass
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
     vars:
-      storageclass_name: "cordaentsc"
+      org_name: "{{ org.name | lower }}"
+      cloudProvider: "{{ org.cloud_provider | lower }}"
+      sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
       git_dir: "{{ org.gitops.release_dir }}"
       kubernetes: "{{ org.k8s }}"
+      charts_dir: "platforms/shared/charts"
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: org

--- a/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
@@ -41,10 +41,13 @@
 # Create Storageclass that will be used for this deployment
 - name: Create Storage Class
   include_role:
-    name: create/storageclass
+    name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
   vars:
-    storageclass_name: "cordaentsc"
+    org_name: "{{ org.name | lower }}"
+    cloudProvider: "{{ org.cloud_provider | lower }}"
+    sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass"
     kubernetes: "{{ org.services.float.k8s }}"
+    charts_dir: "platforms/shared/charts"
     gitops: "{{ org.services.float.gitops }}"
 
 # create namespace, service account and clusterrolebinding

--- a/platforms/r3-corda/configuration/deploy-network.yaml
+++ b/platforms/r3-corda/configuration/deploy-network.yaml
@@ -18,24 +18,34 @@
       path: "./build"
       state: absent
 
-  # ----------------------------------------------------------------------
-  # Create Storageclass
-  - name: Create Storage Class
-    include_role:
-      name: create/storageclass
+# create namespace, service account and clusterrolebinding
+  - name: "Create namespace, service accounts and clusterrolebinding"
+    include_role: 
+      name: create/namespace 
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: org
     when: network['type'] == 'corda'
 
-  # create namespace, service account and clusterrolebinding
-  - name: "Create namespace, service accounts and clusterrolebinding"
-    include_role: 
-      name: create/namespace
+  # ----------------------------------------------------------------------
+  # Create Storageclass
+  - name: Create Storage Class
+    include_role:
+      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
+    vars:
+      org_name: "{{ org.name | lower }}"
+      cloudProvider: "{{ org.cloud_provider | lower }}"
+      sc_name: "{{ org_name }}-{{ cloudProvider }}-storageclass" 
+      region: "{{ org.k8s.region | default('eu-west-1') }}"
+      git_dir: "{{ org.gitops.release_dir }}"
+      kubernetes: "{{ org.k8s }}"
+      gitops: "{{ org.gitops }}"
+      charts_dir: "platforms/shared/charts"
+      platform_suffix: "ns" 
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: org
-    when: network['type'] == 'corda'  
+    when: network['type'] == 'corda'
 
   # ----------------------------------------------------------------------  
   # Deploy Doorman node
@@ -45,6 +55,7 @@
     vars:
      services: "{{ item.services }}"
      organisation: "{{ item.name | lower }}"
+     sc_name: "{{ organisation }}-{{ item.cloud_provider | lower }}-storageclass"
      component_ns: "{{ item.name | lower }}-ns"
      kubernetes: "{{ item.k8s }}"
      vault: "{{ item.vault }}"
@@ -60,6 +71,7 @@
     vars:
      services: "{{ item.services }}"
      organisation: "{{ item.name | lower }}"
+     sc_name: "{{ organisation }}-{{ item.cloud_provider | lower }}-storageclass"
      component_ns: "{{ item.name | lower }}-ns"
      kubernetes: "{{ item.k8s }}"
      vault: "{{ item.vault }}"
@@ -90,6 +102,7 @@
       services: "{{ item.services }}"
       node: "{{ item.services.notary }}"
       organisation: "{{ item.name | lower }}"
+      sc_name: "{{ organisation }}-{{ item.cloud_provider | lower }}-storageclass"
       component_ns: "{{ item.name | lower }}-ns"
       kubernetes: "{{ item.k8s }}"
       vault: "{{ item.vault }}"
@@ -105,6 +118,7 @@
       name: setup/node
     vars:
       organisation: "{{ item.name | lower }}"
+      sc_name: "{{ organisation }}-{{ item.cloud_provider | lower }}-storageclass"
       component_ns: "{{ item.name | lower }}-ns"
       services: "{{ item.services }}"
       kubernetes: "{{ item.k8s }}"

--- a/platforms/r3-corda/configuration/deploy-nodes.yaml
+++ b/platforms/r3-corda/configuration/deploy-nodes.yaml
@@ -34,6 +34,7 @@
       services: "{{ item.services }}"
       node: "{{ item.services.notary }}"
       organisation: "{{ item.name | lower }}"
+      sc_name: "{{ organisation }}-{{ item.cloud_provider | lower }}-storageclass"
       component_ns: "{{ item.name | lower }}-ns"
       kubernetes: "{{ item.k8s }}"
       vault: "{{ item.vault }}"
@@ -49,6 +50,7 @@
       name: setup/node
     vars:
       organisation: "{{ item.name | lower }}"
+      sc_name: "{{ organisation }}-{{ item.cloud_provider | lower }}-storageclass"
       component_ns: "{{ item.name | lower }}-ns"
       services: "{{ item.services }}"
       kubernetes: "{{ item.k8s }}"

--- a/platforms/r3-corda/configuration/roles/create/k8_component/templates/create_doorman.tpl
+++ b/platforms/r3-corda/configuration/roles/create/k8_component/templates/create_doorman.tpl
@@ -50,7 +50,7 @@ spec:
         basePath: /opt/doorman
     storage:
       memory: 512Mi
-      name: {{ org.cloud_provider }}storageclass
+      name: {{ sc_name }}
     mountPath:
       basePath: /opt/doorman
     vault:

--- a/platforms/r3-corda/configuration/roles/create/k8_component/templates/create_mongodb.tpl
+++ b/platforms/r3-corda/configuration/roles/create/k8_component/templates/create_mongodb.tpl
@@ -27,7 +27,7 @@ spec:
       initContainerName: {{ network.docker.url }}/alpine-utils:1.0
     storage:
       memory: 512Mi
-      name: {{ org.cloud_provider }}storageclass
+      name: {{ sc_name }}
       mountPath: /data/db
       volname: hostvol
     vault:

--- a/platforms/r3-corda/configuration/roles/create/k8_component/templates/network_map.tpl
+++ b/platforms/r3-corda/configuration/roles/create/k8_component/templates/network_map.tpl
@@ -55,7 +55,7 @@ spec:
     storage:
       memory: 512Mi
       mountPath: "/opt/h2-data"
-      name: {{ org.cloud_provider }}storageclass
+      name: {{ sc_name }}
     vault:
       address: {{ vault.url }}
       role: vault-role

--- a/platforms/r3-corda/configuration/roles/create/node_component/templates/h2.tpl
+++ b/platforms/r3-corda/configuration/roles/create/node_component/templates/h2.tpl
@@ -31,7 +31,7 @@ spec:
     storage:
       memory: 512Mi
       mountPath: "/opt/h2-data"
-      name: {{ item.cloud_provider }}storageclass
+      name: {{ sc_name }}
     service:
       type: NodePort
       p2p:

--- a/platforms/r3-corda/configuration/roles/create/node_component/templates/node.tpl
+++ b/platforms/r3-corda/configuration/roles/create/node_component/templates/node.tpl
@@ -110,7 +110,7 @@ spec:
       name: {{ component_name|e }}-pvc
       annotations: {}
       memory: 512Mi
-      storageClassName: {{ item.cloud_provider }}storageclass
+      storageClassName: {{ sc_name }}
 
     service:
       name: {{ component_name|e }}

--- a/platforms/shared/charts/storage_class/templates/_helpers.tpl
+++ b/platforms/shared/charts/storage_class/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "provisioner" -}}
 {{- if eq .Values.cloud_provider "aws" }}
-provisioner: ebs.csi.aws.com
+provisioner: kubernetes.io/aws-ebs
 {{- else if eq .Values.cloud_provider "gcp" }}
 provisioner: gce.csi.google.com
 {{- else if eq .Values.cloud_provider "minikube" }}

--- a/platforms/shared/configuration/roles/create/shared_helm_component/templates/storage_class.tpl
+++ b/platforms/shared/configuration/roles/create/shared_helm_component/templates/storage_class.tpl
@@ -1,0 +1,20 @@
+metadata:
+  name: "{{ sc_name }}"
+cloud_provider: "{{ cloudProvider }}"
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+{% if cloud_provider == "aws" %}
+provisioner: kubernetes.io/aws-ebs
+{% elif cloud_provider == "gcp" %}
+provisioner: gce.csi.google.com
+{% elif cloud_provider == "minikube" %}
+provisioner: k8s.io/minikube-hostpath
+{% endif %}
+{% if cloud_provider == "aws" %}
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: failure-domain.beta.kubernetes.io/zone
+        values:
+          - "{{ region }}a"
+          - "{{ region }}b"
+{% endif %}

--- a/platforms/shared/configuration/roles/delete/k8s_resources/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/delete/k8s_resources/tasks/main.yaml
@@ -23,3 +23,9 @@
     kubeconfig: "{{ kubernetes.config_file }}"
     namespace: "{{ organization_ns }}"
     name: "{{ organization_ns }}"
+    
+# Delete the existing build directory for StorageClass
+- name: Delete build directory for storageclass
+  file:
+    path: "{{ playbook_dir }}/../../../platforms/shared/configuration/build"
+    state: absent

--- a/platforms/shared/configuration/roles/setup/storageclass/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/storageclass/tasks/main.yaml
@@ -1,0 +1,68 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+#############################################################################################
+# This role creates value files for storage class
+#############################################################################################
+#############################################################################################
+
+- set_fact:
+    cloud_provider: "{{ org.cloud_provider }}"
+    
+# Check storageclass exists already
+- name: Check if storageclass exists
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"  
+  vars:
+    component_type: "StorageClass"
+    component_name: "{{ sc_name }}"
+    kubernetes: "{{ org.k8s }}"
+    type: "no_retry"
+
+- name: Set the storageclass check result to a local variable
+  set_fact:
+    storageclass_state: "{{ result }}"
+
+#############################################################################################
+# create the build directory for storageclass
+- name: Create build directory
+  file:
+    path: "{{ playbook_dir }}/../../../platforms/shared/configuration/build"
+    state: directory
+
+#############################################################################################
+# Creation of the value file for storage class
+- name: Create value file for storage class
+  template:
+    src: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/create/shared_helm_component/templates/storage_class.tpl"
+    dest: "{{ playbook_dir }}/../../../platforms/shared/configuration/build/{{ sc_name }}-storageclass.yaml"  
+  when: storageclass_state.resources|length == 0
+
+#############################################################################################
+# Create storageclass using helm chart
+- name: Create storageclass using helm chart
+  kubernetes.core.helm:
+    name: "{{ sc_name }}" 
+    chart_ref: "{{ playbook_dir }}/../../../platforms/shared/charts/storage_class"
+    release_namespace: default
+    values_files:
+      - "{{ playbook_dir }}/../../../platforms/shared/configuration/build/{{ sc_name }}-storageclass.yaml"
+    force: true
+  when: storageclass_state.resources|length == 0
+  
+#############################################################################################
+# Wait for storageclass creation
+- name: Wait for {{ component_name }} storageclass creation 
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
+  tags:
+    - notest
+  vars:
+    component_type: "StorageClass"
+    component_name: "{{ sc_name }}"
+    kubernetes: "{{ org.k8s }}"
+    type: "retry"
+  when: storageclass_state.resources|length == 0

--- a/platforms/shared/configuration/roles/setup/vault_kubernetes/templates/cordaos-policy.tpl
+++ b/platforms/shared/configuration/roles/setup/vault_kubernetes/templates/cordaos-policy.tpl
@@ -1,5 +1,5 @@
 {
-    "policy": "path \"{{ name }}/data/*\" {
+    "policy": "path \"{{ vault.secret_path | default('secretsv2') }}/data/{{ org.name | lower }}/*\"{ 
         capabilities = [\"read\", \"list\", \"create\", \"update\"]
     }"
 }


### PR DESCRIPTION
This pull request addresses to refactor the current implementation of creating helm releases using GitOps to a more flexible approach by leveraging the ansible helm module and moving the creation of storage class roles to a share folder.

The six platforms that have been modified to make them compatible with the shared "storage class" charts and roles are:
   • Hyperledger-Besu
   • Hyperledger-Fabric
   • R3-corda
   • R3-corda-Ent
   • Quorum
   • Hyperledger- Indy

Changes Made:

Instead of using gitOps to create helm release, used helm module from ansible by creating jinja(j2) template. Moved the creation of storage class roles to a shared folder to use them across all the platforms.

Fixes: #2306