### PR TITLE
[fabric] Added 'node' option to fabric_chaincode network schema

### DIFF
--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -675,7 +675,7 @@
             "version":  { "type": "string","pattern": "^[0-9]{1,5}$","description":"Version of the chaincode. Please do not use . (dot) in the version."},
             "sequence":  { "type": "string","pattern": "^[0-9]{1,5}$","description":"Sequence of the chaincode. Update depending on your last chaincode version and sequence"},
             "maindirectory": { "type": "string","description":"Path of main.go file"},
-            "lang": {"type":"string","enum": ["golang","java"],"description":"The language in which the chaincode is written ( golang/ java)"},
+            "lang": {"type":"string","enum": ["golang","java","node"],"description":"The language in which the chaincode is written ( golang/java/node)"},
             "arguments": { "type": "string","description":"Init Arguments to the chaincode"},
             "endorsements": { "type": "string","description":"Endorsements (if any) provided along with the chaincode"},
             "repository": { "$ref":"#/definitions/fabric_chaincode_repository"},


### PR DESCRIPTION
The network schema doesn't have node in the validating enum so fails the build - #2375 