### PR TITLE
bug(r3cordaos) vault k8s release files not getting removed on reset

### DIFF
--- a/platforms/hyperledger-fabric/configuration/add-new-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-new-channel.yaml
@@ -25,17 +25,24 @@
         path: "./build"
         state: absent
 
-    #Setup Vault-Kubernetes accesses and Regcred for docker registry
+    # Setup Vault-Kubernetes accesses and Regcred for docker registry
     - name: Setup Vault Kubernetes for each organization
       include_role: 
-        name: "{{playbook_dir}}/../../shared/configuration/roles/setup/vault_kubernetes"
+        name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault_kubernetes"
       vars:
-        component_name: "{{ item.name | lower }}-net"
-        kubernetes: "{{ item.k8s }}"
-        vault: "{{ item.vault }}"
-        component_type: "{{ item.type | lower }}"
-        auth_path: "{{ network.env.type }}{{ item.name | lower }}-net-auth"
-      loop: "{{ network['organizations'] }}"        
+        name: "{{ org.name | lower }}"
+        component_name: "{{ org.name | lower }}-vaultk8s-job"
+        component_type: "{{ org.type | lower }}"
+        component_ns: "{{ org.name | lower }}-net"
+        component_auth: "{{ network.env.type }}{{ org.name | lower }}-net-auth"
+        policy_type: "fabric"
+        kubernetes: "{{ org.k8s }}"
+        vault: "{{ org.vault }}"
+        gitops: "{{ org.gitops }}"
+        reset_path: "platforms/hyperledger-fabric/configuration"
+      loop: "{{ network['organizations'] }}"
+      loop_control:
+        loop_var: org       
         
     # Create generate_crypto script for each organization
     - include_role:

--- a/platforms/shared/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -114,9 +114,7 @@
     policydata: "{{ lookup('file', '{{ playbook_dir }}/build/vault-crypto-{{ component_type }}-{{ name }}-ro.hcl') }}"
     create_serviceAccount: "{{ check_serviceAccount }}"
     create_clusterRoleBinding: "{{ check_clusterRoleBinding }}"
-    values_dir: "{{ playbook_dir }}/../../../{{gitops.release_dir}}/{{ name }}"
-  when:
-  - check_serviceAccount or check_clusterRoleBinding
+    values_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}/{{ org_name | default(name) }}"
 
 # Git Push : Pushes the above generated files to git directory 
 - name: Git Push
@@ -124,7 +122,6 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    gitops: "{{ org.gitops }}"
     msg: "[ci skip] Pushing vault_kubernetes files"
    
 # Check if vault_kubernetes is completed


### PR DESCRIPTION
**Fix**
- Doorman, NMS and notary vault k8s release files will be created under the org name folder, which is deleted on reset.
- Added missing variables in `setup vault kubernetes` task, in add-new-channel playbook.
- Removed service account and clusterolebinding checks. This fixes nms and notary vault k8 jobs getting skipped.