### PR TITLE
[shared] enable OS-specific command handling in helm charts

### DIFF
--- a/platforms/hyperledger-besu/charts/generate_ambassador_certs/templates/job.yaml
+++ b/platforms/hyperledger-besu/charts/generate_ambassador_certs/templates/job.yaml
@@ -77,7 +77,7 @@ spec:
         command: ["sh", "-c"]
         args:
         - |-
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           echo "Getting the vault Token..."
           vaultBevelFunc "init"
           
@@ -245,7 +245,7 @@ spec:
                 echo "$line\n";
               done < ${1} > ${2}/${NAME}.txt
             }
-            source /scripts/bevel-vault.sh
+            . /scripts/bevel-vault.sh
             echo "Getting the vault Token.."
             vaultBevelFunc 'init'
             

--- a/platforms/hyperledger-besu/charts/node_besu/templates/deployment.yaml
+++ b/platforms/hyperledger-besu/charts/node_besu/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           echo "Getting the vault Token..."
           vaultBevelFunc 'init'
           
@@ -204,7 +204,6 @@ spec:
             then
               metrics_args="--metrics-enabled --metrics-port={{ template "metrics_port" . }} --metrics-host=0.0.0.0"
             fi
-            
             if {{ $.Values.node.permissioning.enabled }} == "true"
             then
               permissioning_args="--permissions-accounts-contract-enabled --permissions-accounts-contract-address=0x0000000000000000000000000000000000008888 --permissions-nodes-contract-enabled  --permissions-nodes-contract-address=0x0000000000000000000000000000000000009999 --permissions-nodes-contract-version=2"

--- a/platforms/hyperledger-besu/charts/node_key_mgmt/templates/job.yaml
+++ b/platforms/hyperledger-besu/charts/node_key_mgmt/templates/job.yaml
@@ -74,7 +74,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           echo "Getting the vault Token..."
           vaultBevelFunc 'init'
 
@@ -153,7 +153,7 @@ spec:
           args:
             - |-
               #!/usr/bin/env sh
-              source /scripts/bevel-vault.sh
+              . /scripts/bevel-vault.sh
               echo "Work on mount path.."
               cd ${MOUNT_PATH}
               

--- a/platforms/hyperledger-besu/charts/node_tessera/templates/deployment.yaml
+++ b/platforms/hyperledger-besu/charts/node_tessera/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
         args:
         - |-
           #!/bin/bash
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           echo "Getting the vault Token..."
           vaultBevelFunc 'init'
           

--- a/platforms/hyperledger-besu/charts/node_validator/templates/deployment.yaml
+++ b/platforms/hyperledger-besu/charts/node_validator/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           echo "Getting the vault Token..."
           vaultBevelFunc 'init'
 
@@ -255,13 +255,13 @@ spec:
     - metadata:
         name: {{ .Values.node.name }}-pv
         labels:
-           {{- if $.Values.labels }}
-           {{- range $key, $value := $.Values.labels.pvc }}
-           {{- range $k, $v := $value }}
-           {{ $k }}: {{ $v | quote }}
-           {{- end }}
-           {{- end }}
-           {{- end }}
+          {{- if $.Values.labels }}
+          {{- range $key, $value := $.Values.labels.pvc }}
+          {{- range $k, $v := $value }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
 
       spec:
         storageClassName: {{ .Values.storage.storageclassname }}

--- a/platforms/hyperledger-besu/charts/tessera_key_mgmt/templates/job.yaml
+++ b/platforms/hyperledger-besu/charts/tessera_key_mgmt/templates/job.yaml
@@ -75,7 +75,7 @@ spec:
          command: ["sh", "-c"]
          args:
             - |-
-              source /scripts/bevel-vault.sh
+              . /scripts/bevel-vault.sh
               echo "Getting the vault Token..."
               vaultBevelFunc 'init'
 

--- a/platforms/hyperledger-besu/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-besu/configuration/deploy-network.yaml
@@ -53,12 +53,13 @@
     loop_control:
       loop_var: org
 
-  # Create Vault scrit as configmap for Vault CRUD operations
-  - name: setup vault script
+  # Setup script for Vault and OS Package Manager
+  - name: Setup script for Vault and OS Package Manager
     include_role:
-      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault-script"
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
     vars:
-      component_ns: "{{ org.name | lower }}-bes"
+      namespace: "{{ org.name | lower }}-bes"
+      network_type: "{{ network.type | lower }}"
       kubernetes: "{{ org.k8s }}"
     loop: "{{ network['organizations'] }}"
     loop_control:

--- a/platforms/hyperledger-fabric/charts/anchorpeer/templates/anchorpeer.yaml
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/templates/anchorpeer.yaml
@@ -72,7 +72,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
@@ -76,7 +76,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/catools/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/templates/deployment.yaml
@@ -133,6 +133,9 @@ spec:
       - name: scripts-volume
         configMap:
           name: bevel-vault-script
+      - name: package-manager
+        configMap:
+          name: package-manager
       initContainers:
         - name: init-check-certificates
           image: {{ $.Values.image.alpineutils }}
@@ -176,7 +179,7 @@ spec:
           args:
             - |-
               #!/usr/bin/env sh
-              source /scripts/bevel-vault.sh
+              . /scripts/bevel-vault.sh
 
               # Calling a function to retrieve the vault token.
               vaultBevelFunc "init"
@@ -529,8 +532,12 @@ spec:
           command: ["sh", "-c"]
           args:
             - |-
-              apk update && apk add jq curl bash;
-              
+              . /scripts/package-manager.sh
+
+              # Define the packages to install
+              packages_to_install="jq curl bash"
+              install_packages "$packages_to_install"
+
               while ! [ -f ${MOUNT_PATH}/flag_finish.txt ]
               do
                 echo 'Waiting for completion of scripts'
@@ -595,3 +602,6 @@ spec:
             subPath: {{ $orderers.name }}.crt
           {{- end }}
           {{- end }}
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
@@ -89,7 +89,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           formatCertificate () {
             NAME="${1##*/}"

--- a/platforms/hyperledger-fabric/charts/create_channel/templates/create_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/templates/create_channel.yaml
@@ -77,7 +77,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           vaultBevelFunc "init"
 

--- a/platforms/hyperledger-fabric/charts/external_chaincode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/external_chaincode/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/fabric_cli/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/generate_cacerts/templates/job.yaml
+++ b/platforms/hyperledger-fabric/charts/generate_cacerts/templates/job.yaml
@@ -39,6 +39,9 @@ spec:
       - name: scripts-volume
         configMap:
           name: bevel-vault-script
+      - name: package-manager
+        configMap:
+          name: package-manager
       initContainers:
         - name: init-check-certificates
           image: {{ $.Values.metadata.images.alpineutils }}
@@ -62,7 +65,7 @@ spec:
           args:
             - |-
               #!/usr/bin/env sh
-              source /scripts/bevel-vault.sh
+              . /scripts/bevel-vault.sh
 
               # Calling a function to retrieve the vault token.
               vaultBevelFunc "init"
@@ -126,8 +129,12 @@ spec:
           command: ["sh", "-c"]
           args:
             - |-
-              apk update && apk add jq curl openssl;
-              source /scripts/bevel-vault.sh
+              . /scripts/bevel-vault.sh
+              . /scripts/package-manager.sh
+
+              # Define the packages to install
+              packages_to_install="jq curl openssl"
+              install_packages "$packages_to_install"
 
               if [ -e /certcheck/absent_cacert.txt ]
               then
@@ -202,3 +209,6 @@ spec:
           - name: scripts-volume
             mountPath: /scripts/bevel-vault.sh
             subPath: bevel-vault.sh
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh

--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -48,6 +48,9 @@ spec:
       - name: scripts-volume
         configMap:
           name: bevel-vault-script
+      - name: package-manager
+        configMap:
+          name: package-manager
       initContainers:
       - name: certificates-init
         image: {{ $.Values.metadata.images.alpineutils }}
@@ -137,9 +140,15 @@ spec:
         args:
         - |-
           #!/bin/bash sh
+
+          . /scripts/package-manager.sh
+          # Define the packages to install
+          packages_to_install="curl openssh"
+          install_packages "$packages_to_install"
+
           ## Git repository clone for chaincode
           mkdir -p /root/.ssh/          
-          apk add curl openssh
+
           ssh-keyscan {{ $.Values.chaincode.repository.hostname }} > /root/.ssh/known_hosts
           git_password=$(cat /opt/gopath/src/github.com/hyperledger/fabric/crypto/user_cred)
           cd /tmp && git clone https://{{ $.Values.chaincode.repository.git_username }}:$git_password@{{ $.Values.chaincode.repository.url }} -b {{ $.Values.chaincode.repository.branch }} chaincode > git.log 2>&1
@@ -175,10 +184,16 @@ spec:
             mkdir -p $GOPATH/src/github.com/chaincode
             cp -R /tmp/chaincode/{{ $.Values.chaincode.repository.path }}/* $GOPATH/src/github.com/chaincode/
 
-            # Get dependencies
-            apk add openjdk8
+            # Get dependencies: Define the packages to install
+            packages_to_install="openjdk8"
+            install_packages "$packages_to_install"
+
             java -version
-            apk add gradle
+
+            # Define the packages to install
+            packages_to_install="gradle"
+            install_packages "$packages_to_install"
+
             gradle -v
             cd $GOPATH/src/github.com/chaincode && dep ensure
 
@@ -307,3 +322,6 @@ spec:
         - name: certificates
           mountPath: /opt/gopath/src/github.com/hyperledger/fabric/crypto
           readOnly: true
+        - name: package-manager
+          mountPath: /scripts/package-manager.sh
+          subPath: package-manager.sh

--- a/platforms/hyperledger-fabric/charts/install_external_chaincode/templates/install_external_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_external_chaincode/templates/install_external_chaincode.yaml
@@ -76,7 +76,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"
@@ -160,7 +160,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
@@ -88,7 +88,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           formatCertificate () {
             NAME="${1##*/}"

--- a/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/orderernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/templates/deployment.yaml
@@ -141,7 +141,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"

--- a/platforms/hyperledger-fabric/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/deploy-network.yaml
@@ -18,7 +18,6 @@
   gather_facts: no
   no_log: "{{ no_ansible_log | default(false) }}"
   tasks:
-  
     # delete build directory
     - name: Remove build directory
       file:
@@ -36,17 +35,18 @@
         release_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
       loop: "{{ network['organizations'] }}"
 
-    #Create Vault scrit as configmap for Vault CURD operations
-    - name: Setup vault script
+    # Setup script for Vault and OS Package Manager
+    - name: "Setup script for Vault and OS Package Manager"
       include_role:
-        name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault-script"
+        name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
       vars:
-        component_ns: "{{ org.name | lower }}-net"
+        namespace: "{{ org.name | lower }}-net"
+        network_type: "{{ network.type | lower }}"
         kubernetes: "{{ org.k8s }}"
       loop: "{{ network['organizations'] }}"
       loop_control:
         loop_var: org
-    
+
     #Setup Vault-Kubernetes accesses and Regcred for docker registry
     - name: Setup Vault Kubernetes for each organization
       include_role: 
@@ -102,7 +102,7 @@
       loop: "{{ network['organizations'] }}"
       loop_control:
         loop_var: org
-        
+
     # Create CA Server helm-value files and check-in
     - name: Create CA server for each organization
       include_role:
@@ -121,7 +121,7 @@
         values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
       loop: "{{ network['organizations'] }}"
       when: item.services.ca is defined
-        
+
     # Create generate_crypto script for each organization
     - name: Create generate_crypto.sh for each organization
       include_role:
@@ -136,7 +136,7 @@
     - pause:
         prompt: "Sleeping... so that the client certificates are valid"
         minutes: 6
-    
+
     # Create CA Tools helm-value files and check-in
     - name: Create CA tools for each organization
       include_role:

--- a/platforms/quorum/charts/certs-ambassador-quorum/templates/job.yaml
+++ b/platforms/quorum/charts/certs-ambassador-quorum/templates/job.yaml
@@ -50,7 +50,7 @@ spec:
           args:
           - |-
               #!/usr/bin/env sh
-              source /scripts/bevel-vault.sh
+              . /scripts/bevel-vault.sh
               
               # Calling a function to retrieve the vault token.
               vaultBevelFunc "init"
@@ -198,7 +198,7 @@ spec:
           args:
           - |-
             #!/usr/bin/env sh
-            source /scripts/bevel-vault.sh
+            . /scripts/bevel-vault.sh
 
             # Skip secret creation if "present.txt" exists in /certcheck/
             if [ -e /certcheck/present.txt ]

--- a/platforms/quorum/charts/crypto_ibft/templates/job.yaml
+++ b/platforms/quorum/charts/crypto_ibft/templates/job.yaml
@@ -57,7 +57,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env bash
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           mkdir -p ${MOUNT_PATH}
 
           # Calling a function to retrieve the vault token.
@@ -88,6 +88,9 @@ spec:
           - name: scripts-volume
             mountPath: /scripts/bevel-vault.sh
             subPath: bevel-vault.sh
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh
         env:
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}
@@ -113,9 +116,14 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          apk update && apk add jq curl openssl;
-          source /scripts/bevel-vault.sh
+          . /scripts/package-manager.sh
 
+          # Define the packages to install
+          packages_to_install="jq curl openssl"
+          install_packages "$packages_to_install"
+
+          . /scripts/bevel-vault.sh
+          
           # Skip secret creation if "present.txt" exists in /certcheck/
           if [ -e /certcheck/present.txt ]
           then
@@ -154,7 +162,7 @@ spec:
               \"db_password\": \"${DB_PASSWORD}\",
               \"geth_password\": \"${GETH_PASSPHRASE}\",
               \"db_user\": \"${DB_USER}\"
-           }}" > finalJSON.json
+            }}" > finalJSON.json
 
           # Calling a function to write secrets to the Vault.
           vaultBevelFunc 'write' "${CERTS_SECRET_PREFIX}/crypto/${PEER_NAME}/quorum" 'finalJSON.json'
@@ -185,4 +193,6 @@ spec:
         - name: scripts-volume
           configMap:
             name: bevel-vault-script
-
+        - name: package-manager
+          configMap:
+            name: package-manager

--- a/platforms/quorum/charts/crypto_raft/templates/job.yaml
+++ b/platforms/quorum/charts/crypto_raft/templates/job.yaml
@@ -57,7 +57,7 @@ spec:
         args:
         - |-
           #!/usr/bin/env bash
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           mkdir -p ${MOUNT_PATH}
 
           # Calling a function to retrieve the vault token.
@@ -88,6 +88,9 @@ spec:
           - name: scripts-volume
             mountPath: /scripts/bevel-vault.sh
             subPath: bevel-vault.sh
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh
         env:
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}
@@ -113,8 +116,12 @@ spec:
         args:
         - |-
           #!/usr/bin/env sh
-          source /scripts/bevel-vault.sh
-          apk update && apk add jq curl openssl;
+          . /scripts/bevel-vault.sh
+          . /scripts/package-manager.sh
+
+          # Define the packages to install
+          packages_to_install="jq curl openssl"
+          install_packages "$packages_to_install"
 
           # Skip secret creation if "present.txt" exists in /certcheck/
           if [ -e /certcheck/present.txt ]
@@ -154,7 +161,7 @@ spec:
               \"db_password\": \"${DB_PASSWORD}\",
               \"geth_password\": \"${GETH_PASSPHRASE}\",
               \"db_user\": \"${DB_USER}\"
-           }}" > finalJSON.json
+            }}" > finalJSON.json
 
           # Calling a function to write secrets to the Vault.
           vaultBevelFunc 'write' "${CERTS_SECRET_PREFIX}/crypto/${PEER_NAME}/quorum" 'finalJSON.json'
@@ -177,7 +184,6 @@ spec:
             fi
             COUNTER=`expr "$COUNTER" + 1`
           fi
-
       volumes:
         - name: certcheck
           emptyDir:
@@ -185,3 +191,6 @@ spec:
         - name: scripts-volume
           configMap:
             name: bevel-vault-script
+        - name: package-manager
+          configMap:
+            name: package-manager

--- a/platforms/quorum/charts/node_quorum_member/templates/deployment.yaml
+++ b/platforms/quorum/charts/node_quorum_member/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - name: scripts-volume
           configMap:
             name: bevel-vault-script
+        - name: package-manager
+          configMap:
+            name: package-manager
       initContainers:
       - name: certificates-init
         image: {{ .Values.images.alpineutils }}
@@ -82,7 +85,7 @@ spec:
         args:
         - |-
           #!/bin/bash
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"
@@ -154,7 +157,12 @@ spec:
         - "-cx"
         - |-
           #!/usr/bin/env sh
-          apk add curl;
+          . /scripts/package-manager.sh
+
+          # Define the packages to install
+          packages_to_install="curl"
+          install_packages "$packages_to_install"
+
           echo -n {{ .Values.staticnodes | toRawJson  | quote }} > $QUORUM_DATA_DIR/static-nodes.json
           mkdir -p $QUORUM_DATA_DIR/geth
           mkdir -p $QUORUM_DATA_DIR/keystore          
@@ -203,24 +211,24 @@ spec:
           fi
 
           /usr/local/bin/geth \
-           --datadir $QUORUM_DATA_DIR \
-           $args \
-           --identity {{ .Values.node.subject | quote }} \
-           --vmdebug \
-           --gcmode=archive \
-           --nodiscover \
-           --nat=none \
-           --verbosity 9 \
-           --emitcheckpoints \
-           --http \
-           --http.addr 0.0.0.0 \
-           --http.port {{ .Values.node.ports.rpc }} \
-           --http.corsdomain "*" \
-           --http.vhosts "*" \
-           --allow-insecure-unlock \
-           --port {{ .Values.node.ports.quorum }} \
-           $ptm_url \
-           --password $QUORUM_DATA_DIR/password.txt 2>&1 | tee -a $QUORUM_HOME/logs/quorum.log;
+            --datadir $QUORUM_DATA_DIR \
+            $args \
+            --identity {{ .Values.node.subject | quote }} \
+            --vmdebug \
+            --gcmode=archive \
+            --nodiscover \
+            --nat=none \
+            --verbosity 9 \
+            --emitcheckpoints \
+            --http \
+            --http.addr 0.0.0.0 \
+            --http.port {{ .Values.node.ports.rpc }} \
+            --http.corsdomain "*" \
+            --http.vhosts "*" \
+            --allow-insecure-unlock \
+            --port {{ .Values.node.ports.quorum }} \
+            $ptm_url \
+            --password $QUORUM_DATA_DIR/password.txt 2>&1 | tee -a $QUORUM_HOME/logs/quorum.log;
 
         ports:
           - containerPort: {{ .Values.node.ports.rpc }}
@@ -244,6 +252,9 @@ spec:
           mountPath: {{ .Values.node.mountPath }}/crypto/
         - name: {{ .Values.node.name }}-pv
           mountPath: {{ .Values.node.mountPath }}
+        - name: package-manager
+          mountPath: /scripts/package-manager.sh
+          subPath: package-manager.sh
       restartPolicy: Always
   volumeClaimTemplates:
     - metadata:

--- a/platforms/quorum/charts/node_quorum_validator/templates/deployment.yaml
+++ b/platforms/quorum/charts/node_quorum_validator/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - name: scripts-volume
           configMap:
             name: bevel-vault-script
+        - name: package-manager
+          configMap:
+            name: package-manager
       initContainers:
       - name: certificates-init
         image: {{ .Values.images.alpineutils }}
@@ -82,7 +85,7 @@ spec:
         args:
         - |-
           #!/bin/bash
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
 
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"
@@ -144,7 +147,12 @@ spec:
         - "-cx"
         - |-
           #!/usr/bin/env sh
-          apk add curl;
+          . /scripts/package-manager.sh
+
+          # Define the packages to install
+          packages_to_install="curl"
+          install_packages "$packages_to_install"
+
           echo -n {{ .Values.staticnodes | toRawJson | quote }} > $QUORUM_DATA_DIR/static-nodes.json
           mkdir -p $QUORUM_DATA_DIR/geth
           mkdir -p $QUORUM_DATA_DIR/keystore          
@@ -168,31 +176,30 @@ spec:
           fi;
           if [ $CONSENSUS == 'ibft' ]; then
             args=" --istanbul.blockperiod 3 --syncmode full --mine --miner.threads 1 --rpcapi admin,debug,web3,eth,txpool,personal,istanbul,miner,net,quorumExtension"
-                                                                                              
-            
           fi;
+
           LOCK_STATUS={{ .Values.node.lock }}
           if [ $LOCK_STATUS = false ]
           then
             args=" ${args} --unlock 0 "
           fi
           /usr/local/bin/geth \
-           --datadir $QUORUM_DATA_DIR \
-           $args \
-           --identity {{ .Values.node.subject | quote }} \
-           --vmdebug \
-           --gcmode=archive \
-           --nodiscover \
-           --nat=none \
-           --verbosity 9 \
-           --emitcheckpoints \
-           --rpc \
-           --rpcaddr 0.0.0.0 \
-           --rpcport {{ .Values.node.ports.rpc }} \
-           --rpcvhosts=* \
-           --allow-insecure-unlock \
-           --port {{ .Values.node.ports.quorum }} \
-           --password $QUORUM_DATA_DIR/password.txt 2>&1 | tee -a $QUORUM_HOME/logs/quorum.log;
+            --datadir $QUORUM_DATA_DIR \
+            $args \
+            --identity {{ .Values.node.subject | quote }} \
+            --vmdebug \
+            --gcmode=archive \
+            --nodiscover \
+            --nat=none \
+            --verbosity 9 \
+            --emitcheckpoints \
+            --rpc \
+            --rpcaddr 0.0.0.0 \
+            --rpcport {{ .Values.node.ports.rpc }} \
+            --rpcvhosts=* \
+            --allow-insecure-unlock \
+            --port {{ .Values.node.ports.quorum }} \
+            --password $QUORUM_DATA_DIR/password.txt 2>&1 | tee -a $QUORUM_HOME/logs/quorum.log;
         ports:
           - containerPort: {{ .Values.node.ports.rpc }}
           - containerPort: {{ .Values.node.ports.quorum }}
@@ -215,6 +222,9 @@ spec:
           mountPath: {{ .Values.node.mountPath }}/crypto/
         - name: {{ .Values.node.name }}-pv
           mountPath: {{ .Values.node.mountPath }}
+        - name: package-manager
+          mountPath: /scripts/package-manager.sh
+          subPath: package-manager.sh
       restartPolicy: Always
   volumeClaimTemplates:
     - metadata:

--- a/platforms/quorum/charts/quorum_node_tessera/templates/deployment.yaml
+++ b/platforms/quorum/charts/quorum_node_tessera/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - name: scripts-volume
           configMap:
             name: bevel-vault-script
+        - name: package-manager
+          configMap:
+            name: package-manager
       initContainers:
       - name: certificates-init
         image: {{ .Values.images.alpineutils }}
@@ -82,7 +85,7 @@ spec:
         args:
         - |-
           #!/bin/bash
-          source /scripts/bevel-vault.sh
+          . /scripts/bevel-vault.sh
           
           # Calling a function to retrieve the vault token.
           vaultBevelFunc "init"
@@ -162,12 +165,18 @@ spec:
       - name: tessera
         image: {{ .Values.images.tessera }}
         imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
+        command: ["/bin/sh", "-c"]
         args:
           - |-
             #!/usr/bin/env bash
-            apt-get update && apt-get install -y jq curl
-            source /scripts/bevel-vault.sh
+
+            . /scripts/bevel-vault.sh
+            . /scripts/package-manager.sh
+
+            # Define the packages to install
+            packages_to_install="jq curl"
+            install_packages "$packages_to_install"
+
             mkdir -p $TESSERA_HOME/logs;
             mkdir -p $TESSERA_HOME/tm;
             DDIR=$TESSERA_HOME/tm;
@@ -214,6 +223,9 @@ spec:
           - name: scripts-volume
             mountPath: /scripts/bevel-vault.sh
             subPath: bevel-vault.sh
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh
       restartPolicy: Always
   volumeClaimTemplates:
     - metadata:

--- a/platforms/quorum/charts/quorum_tessera_key_mgmt/templates/job.yaml
+++ b/platforms/quorum/charts/quorum_tessera_key_mgmt/templates/job.yaml
@@ -34,6 +34,9 @@ spec:
         - name: scripts-volume
           configMap:
             name: bevel-vault-script
+        - name: package-manager
+          configMap:
+            name: package-manager
       containers:
         - name:  "tessera-crypto"
           image: "{{ $.Values.image.repository }}"
@@ -55,12 +58,18 @@ spec:
             value: "{{ $.Values.vault.tmprefix }}"
           - name: VAULT_TYPE
             value: "{{ $.Values.vault.type }}"
-          command: ["bash", "-c"]
+          command: ["/bin/sh", "-c"]
           args:
             - |-
               #!/usr/bin/env bash
-              apt-get update && apt-get install -y jq curl
-              source /scripts/bevel-vault.sh
+
+              . /scripts/bevel-vault.sh
+              . /scripts/package-manager.sh
+
+              # Define the packages to install
+              packages_to_install="jq curl"
+              install_packages "$packages_to_install"
+
               # Calling a function to retrieve the vault token.
               vaultBevelFunc "init"
               # Generate tessera keys
@@ -70,3 +79,6 @@ spec:
           - name: scripts-volume
             mountPath: /scripts/bevel-vault.sh
             subPath: bevel-vault.sh
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh

--- a/platforms/quorum/configuration/deploy-network.yaml
+++ b/platforms/quorum/configuration/deploy-network.yaml
@@ -50,12 +50,13 @@
     loop_control:
       loop_var: org
 
-  #Create Vault scrit as configmap for Vault CURD operations
-  - name: setup vault script
+  # Setup script for Vault and OS Package Manager
+  - name: "Setup script for Vault and OS Package Manager"
     include_role:
-      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault-script"
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
     vars:
-      component_ns: "{{ org.name | lower }}-quo"
+      namespace: "{{ org.name | lower }}-quo"
+      network_type: "{{ network.type | lower }}"
       kubernetes: "{{ org.k8s }}"
     loop: "{{ network['organizations'] }}"
     loop_control:

--- a/platforms/shared/charts/bevel-scripts/Chart.yaml
+++ b/platforms/shared/charts/bevel-scripts/Chart.yaml
@@ -1,0 +1,10 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+apiVersion: v2
+name: bevel-scripts
+description: "shared: configmaps using scripts"
+version: '0.14.0'
+appVersion: "1.16.0"

--- a/platforms/shared/charts/bevel-scripts/scripts/package-manager.sh
+++ b/platforms/shared/charts/bevel-scripts/scripts/package-manager.sh
@@ -1,0 +1,76 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to determine the Linux distribution
+get_linux_distro() {
+    if [ "$(uname -s)" == "Linux" ]; then
+        if command_exists lsb_release; then
+            DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
+        elif [ -f "/etc/os-release" ]; then
+            . /etc/os-release
+            DISTRO=$(echo "$ID" | tr '[:upper:]' '[:lower:]')
+        else
+            echo "Unable to determine the Linux distribution."
+            exit 1
+        fi
+    else
+        echo "This is not a Linux system."
+        exit 1
+    fi
+}
+
+# Function to determine the package manager based on the distribution
+get_package_manager() {
+    case "$DISTRO" in
+    debian|ubuntu)
+        PACKAGE_MNG="apt-get"
+        ;;
+    alpine)
+        PACKAGE_MNG="apk"
+        ;;
+    centos|rhel)
+        PACKAGE_MNG="yum"
+        ;;
+    *)
+        echo "Unsupported Linux distribution: $DISTRO"
+        exit 1
+        ;;
+    esac
+}
+
+# Function to install packages using the detected package manager
+install_packages() {
+    # Invoking function to determine the Linux distribution
+    get_linux_distro
+    # Invoking function to determine the package manager based on the distribution
+    get_package_manager
+
+    PACKAGES="$1"
+    
+    echo "Update package list and install packages using $PACKAGE_MNG package manager."
+    case "$PACKAGE_MNG" in
+    apt-get)
+        apt-get update
+        apt-get install -y $PACKAGES
+        ;;
+    apk)
+        apk update
+        apk add $PACKAGES
+        ;;
+    yum)
+        yum install -y $PACKAGES
+        ;;
+    *)
+        echo "Unsupported package manager: $PACKAGE_MNG"
+        exit 1
+        ;;
+    esac
+}

--- a/platforms/shared/charts/bevel-scripts/templates/configmap.yaml
+++ b/platforms/shared/charts/bevel-scripts/templates/configmap.yaml
@@ -1,0 +1,27 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+{{- if or (eq .Values.network_type "besu") (eq .Values.network_type "quorum") (eq .Values.network_type "fabric") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bevel-vault-script
+  namespace: {{ $.Values.namespace }}
+data:
+{{ (.Files.Glob "scripts/bevel-vault.sh").AsConfig | indent 2 }}
+{{- end }}
+
+{{- if or (eq .Values.network_type "quorum") (eq .Values.network_type "fabric") (eq .Values.network_type "substrate") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: package-manager
+  namespace: {{ $.Values.namespace }}
+data:
+{{ (.Files.Glob "scripts/package-manager.sh").AsConfig | indent 2 }}
+{{- end }}

--- a/platforms/shared/charts/storage_class/values.yaml
+++ b/platforms/shared/charts/storage_class/values.yaml
@@ -56,4 +56,3 @@ allowedTopologies:
         values:
           # The allowed zones.
           - "eu-west-1a"
-          - "eu-west-1b"

--- a/platforms/shared/configuration/roles/create/shared_helm_component/templates/storage_class.tpl
+++ b/platforms/shared/configuration/roles/create/shared_helm_component/templates/storage_class.tpl
@@ -16,5 +16,4 @@ allowedTopologies:
       - key: failure-domain.beta.kubernetes.io/zone
         values:
           - "{{ region }}a"
-          - "{{ region }}b"
 {% endif %}

--- a/platforms/shared/configuration/roles/setup/scripts/tasks/main.yml
+++ b/platforms/shared/configuration/roles/setup/scripts/tasks/main.yml
@@ -1,0 +1,16 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+---
+- name: "Create ConfigMaps Using Scripts"
+  kubernetes.core.helm:
+    name: bevel-script
+    chart_ref: "{{ playbook_dir }}/../../shared/charts/bevel-scripts"
+    release_namespace: "{{ namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ kubernetes.config_file }}"
+    values:
+      network_type: "{{ network_type }}"
+      namespace: "{{ namespace }}"

--- a/platforms/substrate/charts/dscp-ipfs-node/templates/statefulset.yaml
+++ b/platforms/substrate/charts/dscp-ipfs-node/templates/statefulset.yaml
@@ -23,6 +23,10 @@ spec:
     spec:
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
       {{- include "dscp-ipfs.imagePullSecrets" . | indent 6 }}
+      volumes:
+        - name: package-manager
+          configMap:
+            name: package-manager
       initContainers:
         - name: {{ include "dscp-ipfs.initIpfsConfig.name" . }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -96,6 +100,9 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.config.ipfsDataPath }}
               name: ipfs-data
+            - name: package-manager
+              mountPath: /scripts/package-manager.sh
+              subPath: package-manager.sh
           command: ["sh", "-c"]
           args:
             - |-
@@ -124,7 +131,11 @@ spec:
               }
               echo "done validating vault response"
 
-              apk update && apk add jq 
+              . /scripts/package-manager.sh
+              # Define the packages to install
+              packages_to_install="jq"
+              install_packages "$packages_to_install"
+
               cd $MOUNT_PATH
 
               peer_id=$(cat config | jq -r .Identity.PeerID)

--- a/platforms/substrate/charts/substrate-genesis/templates/job.yaml
+++ b/platforms/substrate/charts/substrate-genesis/templates/job.yaml
@@ -37,6 +37,9 @@ spec:
         volumeMounts:
           - name: certcheck
             mountPath: certcheck
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh
         env:    
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}
@@ -54,7 +57,11 @@ spec:
           #!/usr/bin/env bash
 
           {{- if ne $.Values.node.image "docker.io/paritytech/substrate-playground-template-node-template" }}
-          apt-get update && apt-get install -y jq bc curl unzip;
+          . /scripts/package-manager.sh
+          # Define the packages to install
+          packages_to_install="jq bc curl unzip"
+          install_packages "$packages_to_install"
+
           if [[ $? > 0 ]]
           then
             # download jq
@@ -182,3 +189,6 @@ spec:
         - name: certcheck
           emptyDir:
             medium: Memory
+        - name: package-manager
+          configMap:
+            name: package-manager

--- a/platforms/substrate/charts/substrate-key-mgmt/templates/job.yaml
+++ b/platforms/substrate/charts/substrate-key-mgmt/templates/job.yaml
@@ -109,6 +109,9 @@ spec:
         volumeMounts:
           - name: certcheck
             mountPath: /certcheck
+          - name: package-manager
+            mountPath: /scripts/package-manager.sh
+            subPath: package-manager.sh
         env:
         - name: VAULT_ADDR
           value: {{ $.Values.vault.address }}
@@ -128,8 +131,11 @@ spec:
           #!/usr/bin/env bash
 
           {{- if ne $.Values.node.image "docker.io/paritytech/substrate-playground-template-node-template:latest" }}
-          
-          apt-get update && apt-get install -y jq curl;
+          . /scripts/package-manager.sh
+          # Define the packages to install
+          packages_to_install="jq curl"
+          install_packages "$packages_to_install"
+
           if [[ $? > 0 ]]
           then
             # download jq
@@ -156,8 +162,8 @@ spec:
               if test "$http_code" != "200" ; then
                   echo "Http response code from Vault - $http_code"
                   if test "$curl_response" != "0"; then
-                     echo "Error: curl command failed with error code - $curl_response"
-                     exit 1
+                      echo "Error: curl command failed with error code - $curl_response"
+                      exit 1
                   fi
               fi
             fi
@@ -243,3 +249,7 @@ spec:
         - name: certcheck
           emptyDir:
             medium: Memory
+        - name: package-manager
+          configMap:
+            name: package-manager
+

--- a/platforms/substrate/charts/vault-k8s-mgmt/templates/job.yaml
+++ b/platforms/substrate/charts/vault-k8s-mgmt/templates/job.yaml
@@ -51,6 +51,9 @@ spec:
           items:
             - key: policies-config.json
               path: policies-config.json
+      - name: package-manager
+        configMap:
+          name: package-manager
       containers:
         - name: "vault-kubernetes"
           image: {{ $.Values.metadata.images.alpineutils }}
@@ -82,7 +85,10 @@ spec:
           command: ["sh", "-c"]
           args:
             - |-
-              apk update && apk add jq curl;
+              . /scripts/package-manager.sh
+              # Define the packages to install
+              packages_to_install="jq curl"
+              install_packages "$packages_to_install"
 
               validateVaultResponse () {
                 if [ ${1} != 200 -a ${1} != 204 ]; then
@@ -194,3 +200,6 @@ spec:
             - name: policies-config
               mountPath: /policies/policies-config.json
               subPath: policies-config.json
+            - name: package-manager
+              mountPath: /scripts/package-manager.sh
+              subPath: package-manager.sh

--- a/platforms/substrate/configuration/deploy-network.yaml
+++ b/platforms/substrate/configuration/deploy-network.yaml
@@ -43,7 +43,19 @@
       org: "{{ item }}"
       kubernetes: "{{ item.k8s }}"
     loop: "{{ network['organizations'] }}"
-  
+
+  # Setup script for Vault and OS Package Manager
+  - name: "Setup script for Vault and OS Package Manager"
+    include_role:
+      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
+    vars:
+      namespace: "{{ org.name | lower }}-subs"
+      network_type: "{{ network.type | lower }}"
+      kubernetes: "{{ org.k8s }}"
+    loop: "{{ network['organizations'] }}"
+    loop_control:
+      loop_var: org
+
   # Setup Vault-Kubernetes accesses and Regcred for docker registry
   - name: "Setup vault"   
     include_role: 


### PR DESCRIPTION
### **Commit to be reviewed**
---
**feat(shared): enable OS-specific command handling in helm charts**

```
This PR improves the handling of OS-specific commands within Helm charts.

Changes:
- Introduced a script to check the Operating System and its supporting package manager for efficient package installation.
- Added a ConfigMap object to insert the same above-mentioned script into the container, improving flexibility and compatibility.

Additional change:
- Updated the StorageClass Helm chart to resolve the node affinity issue.

There are only 3 platforms that are currently using OS-Specific Command in Helm Charts directly, and this PR is also made for these 3 platforms only:
- Quorum
- Hyperledger-Fabric
- Substrate
```

fixes #2366