### PR TITLE
[r3-corda-ent] upgrade to version 4.10

### DIFF
--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -56,7 +56,7 @@
             {"if": {"properties": { "type": { "const": "corda-enterprise" } } },
              "then": {
               "properties":{
-                "version":{ "type": "number","enum":[4.4,4.7]},
+                "version":{ "type": "string","enum": ["4.4","4.7","4.10"]},
                 "env": { "$ref":"#/definitions/shared_env_ambassador"},
                 "frontend": { "type": "string", "enum": ["enabled","disabled"]},
                 "network_services": { "type":"array","items":{ "$ref":"#/definitions/corda_enterprise_network_service"}},

--- a/platforms/r3-corda-ent/charts/corda-ent-node/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/corda-ent-node/templates/deployment.yaml
@@ -295,7 +295,10 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |-
-          mkdir -p ${BASE_DIR}/etc
+          # Create directory
+          # mkdir -p ${BASE_DIR}/etc
+
+          # Create node.conf configuration file
           echo 'myLegalName: "{{ .Values.nodeConf.legalName }}"
           emailAddress: "{{ .Values.nodeConf.emailAddress }}"
           p2pAddress: "{{ .Values.service.p2pAddress }}:{{ .Values.service.p2pPort }}"
@@ -358,49 +361,54 @@ spec:
           {{- end}}
           }' > ${BASE_DIR}/node.conf
 
+          # Replace placeholders in node.conf with actual passwords
           export TRUSTSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/credentials/truststorepass)
           sed -i -e "s*TRUSTSTORE_PASSWORD*${TRUSTSTORE_PASSWORD}*g" ${BASE_DIR}/node.conf
           export KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/credentials/keystorepass)
           sed -i -e "s*KEYSTORE_PASSWORD*${KEYSTORE_PASSWORD}*g" ${BASE_DIR}/node.conf
 
-          # to clean network-parameters on every restart
+          # Clean or remove network-parameters on every restart
           rm -rf ${BASE_DIR}/network-parameters
+
+          # Import certificates into truststore.jks
           yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/networkmap.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.networkMapDomain }} -keystore ${BASE_DIR}/certificates/truststore.jks
           yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/idman.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.idmanDomain }} -keystore ${BASE_DIR}/certificates/truststore.jks
           yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/node.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.nodeName }} -keystore ${BASE_DIR}/certificates/truststore.jks
 
+          # Start a new shell session
           /bin/sh
           
+          # Retrieve keystore password again
           KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/credentials/keystorepass)
+
+          # Check if the 'corda.jar' file exists
           if [ -f {{ .Values.nodeConf.jarPath }}/corda.jar ]
           then
-              echo
-              echo "Starting Node node ..."
-              echo
-              # command to run corda jar, we are setting javax.net.ssl.keyStore as ${BASE_DIR}/certificates/sslkeystore.jks since keystore gets reset when using h2 ssl 
-              java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks \
-                   -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks \
-                   -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
-                   -jar {{ .Values.nodeConf.jarPath }}/corda.jar \
-                   -f ${BASE_DIR}/node.conf --base-directory ${BASE_DIR} \
-                   --log-to-console
+              echo -e "\nStarting Node node ...\n"
+
+              # Run migration scripts for database schema upgradation and then start the Corda-ent 'node' node
+              java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar run-migration-scripts --core-schemas --app-schemas -f ${BASE_DIR}/node.conf --base-directory ${BASE_DIR} --log-to-console
+              # start the Corda-ent 'node' node, setting javax.net.ssl.keyStore as ${BASE_DIR}/certificates/sslkeystore.jks since keystore gets reset when using h2 ssl 
+              java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar -f ${BASE_DIR}/node.conf --base-directory ${BASE_DIR} --log-to-console
+              # Capture the exit code of the previous command
               EXIT_CODE=${?}
           else
-              echo "Missing node jar file in {{ .Values.nodeConf.jarPath }} folder:"
+              echo "Error: 'corda.jar' file is not found in the {{ .Values.nodeConf.jarPath }} folder."
+              # Additionally, manually check the availability of 'corda.jar' file at the same path
               ls -al {{ .Values.nodeConf.jarPath }}
+              # Set to '1' to indicate an error
               EXIT_CODE=1
           fi
 
+          # Handle node failure
           if [ "${EXIT_CODE}" -ne "0" ]
           then
               HOW_LONG={{ .Values.sleepTimeAfterError }}
-              echo
-              echo "Node failed - exit code: ${EXIT_CODE} (error)"
-              echo
-              echo "Going to sleep for requested ${HOW_LONG} seconds to let you login and investigate."
-              echo
+              echo "\nNode failed - exit code: ${EXIT_CODE} (error)\n"
+              echo "Going to sleep for requested ${HOW_LONG} seconds to let you login and investigate.\n"
               sleep ${HOW_LONG}
           fi
+
           echo "DONE"
         volumeMounts:
         - name: node-volume
@@ -421,9 +429,11 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |-
+          # Change directory to the specified base directory for Corda-ent node logs
           cd {{ .Values.nodeConf.volume.baseDir }}/
+          # Continuously display the content of all log files in the 'logs' directory
           tail -f logs/*.log 2>/dev/null
-          # in case sth went wrong just wait indefinitely ...
+          # If the logs are not available, enter an indefinite wait state
           tail -f /dev/null
         volumeMounts:
         - name: node-volume

--- a/platforms/r3-corda-ent/charts/corda-ent-notary/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/corda-ent-notary/templates/deployment.yaml
@@ -303,7 +303,10 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |-
+          # Create directory
           mkdir -p ${BASE_DIR}/etc
+
+          # Create notary.conf configuration file
           echo 'networkServices {
               doormanURL="{{ .Values.networkServices.doormanURL }}"
               networkMapURL="{{ .Values.networkServices.networkMapURL }}"
@@ -350,52 +353,61 @@ spec:
               port={{ .Values.service.sshdPort }}
           }' > ${BASE_DIR}/etc/notary.conf
 
+          # Replace placeholders in notary.conf with actual passwords
           export TRUSTSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/tspass)
           sed -i -e "s*TRUSTSTORE_PASSWORD*${TRUSTSTORE_PASSWORD}*g" ${BASE_DIR}/etc/notary.conf
           export KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/kspass)
           sed -i -e "s*KEYSTORE_PASSWORD*${KEYSTORE_PASSWORD}*g" ${BASE_DIR}/etc/notary.conf
 
 
-          # to clean network-parameters on every restart
+          # Clean or remove network-parameters on every restart
           rm -rf ${BASE_DIR}/network-parameters
 
           {{- if eq .Values.nodeConf.notary.type "cenm" }}
-          # add ssl-truststore to truststore
+          # Add ssl-truststore to truststore
           export SSLTRUSTSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/sslpass)
           keytool -importkeystore -srckeystore ${BASE_DIR}/certificates/corda-ssl-trust-store.jks -srcstorepass $SSLTRUSTSTORE_PASSWORD -destkeystore ${BASE_DIR}/certificates/truststore.jks -deststorepass $TRUSTSTORE_PASSWORD -srcalias cordasslrootca -destalias cordasslrootca
           {{- else }}
-          # add idman and networkmap certificates to truststore          
+          # Add idman and networkmap certificates to truststore          
           yes | keytool -importcert -file ${BASE_DIR}/certificates/networkmap.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.networkMapDomain }} -keystore ${BASE_DIR}/certificates/truststore.jks
           yes | keytool -importcert -file ${BASE_DIR}/certificates/idman.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.idmanDomain }} -keystore ${BASE_DIR}/certificates/truststore.jks          
           {{- end }}
-          
+
+          # Start a new shell session
           /bin/sh
+
+          # Retrieve keystore password again
           KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/kspass)
+
+          # Check if the 'corda.jar' file exists
           if [ -f {{ .Values.nodeConf.jarPath }}/corda.jar ]
           then
-              echo
-              echo "CENM: starting Notary node ..."
-              echo
-              # command to run corda jar, we are setting javax.net.ssl.keyStore as ${BASE_DIR}/certificates/sslkeystore.jks since keystore gets reset when using h2 ssl 
+              echo "\nCENM: starting Notary node ...\n"
+
+              # Run migration scripts for database schema upgradation and then start the Corda-ent 'notary' node
+              java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks -Djavax.net.ssl.trustStorePassword=$TRUSTSTORE_PASSWORD -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar run-migration-scripts --core-schemas --app-schemas -f ${BASE_DIR}/etc/notary.conf --base-directory=${BASE_DIR} -v --logging-level=DEBUG
+              # start the Corda-ent 'notary' node, setting javax.net.ssl.keyStore as ${BASE_DIR}/certificates/sslkeystore.jks since keystore gets reset when using h2 ssl 
               java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks -Djavax.net.ssl.trustStorePassword=$TRUSTSTORE_PASSWORD -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar -f ${BASE_DIR}/etc/notary.conf --base-directory=${BASE_DIR} -v --logging-level=DEBUG
+              # Capture the exit code of the previous command
               EXIT_CODE=${?}
           else
-              echo "Missing notary jar file in {{ .Values.nodeConf.jarPath }} folder:"
+              echo "Error: 'corda.jar' file is not found in the {{ .Values.nodeConf.jarPath }} folder."
+              # Additionally, manually check the availability of 'corda.jar' file at the same path
               ls -al {{ .Values.nodeConf.jarPath }}
+              # Set to '1' to indicate an error
               EXIT_CODE=1
           fi
 
+          # Handle node failure
           if [ "${EXIT_CODE}" -ne "0" ]
           then
               HOW_LONG={{ .Values.sleepTimeAfterError }}
-              echo
-              echo "Notary failed - exit code: ${EXIT_CODE} (error)"
-              echo
-              echo "Going to sleep for requested ${HOW_LONG} seconds to let you login and investigate."
-              echo
+              echo "\nNotary failed - exit code: ${EXIT_CODE} (error).\n"
+              echo "Going to sleep for requested ${HOW_LONG} seconds to let you login and investigate.\n"
               sleep ${HOW_LONG}
           fi
-          echo
+
+          echo "DONE"
         volumeMounts:
         - name: notary-certificates
           mountPath: {{ $.Values.nodeConf.volume.baseDir }}/certificates
@@ -417,9 +429,11 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |-
+          # Change directory to the specified base directory for Corda-ent notary logs
           cd {{ $.Values.nodeConf.volume.baseDir }}/
+          # Continuously display the content of all log files in the 'logs' directory
           tail -f logs/*.log 2>/dev/null
-          # in case sth went wrong just wait indefinitely ...
+          # If the logs are not available, enter an indefinite wait state
           tail -f /dev/null
         volumeMounts:
         - name: notary-volume

--- a/platforms/r3-corda-ent/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -113,6 +113,8 @@
     vault kv delete {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/credentials/truststore
     vault kv delete {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/credentials/ssl
     vault kv delete {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/credentials/cordapps
+    vault kv delete {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/credentials/user
+    vault kv delete {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/gateway/tlscerts
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -219,7 +221,7 @@
 # Delete the policies
 - name: Delete vault access control policy for organizations
   shell: |
-    vault policy delete vault-crypto-{{ component_name }}-{{ org.name | lower }}-ro
+    vault policy delete vault-crypto-{{ org.type | lower }}-{{ org.name | lower }}-vaultk8s-job-ro
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
@@ -22,21 +22,28 @@ helm_templates:
   node: node.tpl
 docker_images:
   cenm:
+    # list of various nodes supporting version 1.2
     pki-1.2: corda/enterprise-pki:1.2-zulu-openjdk8u242
-    pki-1.5: corda/enterprise-pki:1.5.1-zulu-openjdk8u242
-    auth-1.5: corda/enterprise-auth:1.5.1-zulu-openjdk8u242
     signer-1.2: corda/enterprise-signer:1.2-zulu-openjdk8u242
-    signer-1.5: corda/enterprise-signer:1.5.1-zulu-openjdk8u242
-    networkmap-1.2: corda/enterprise-networkmap:1.2-zulu-openjdk8u242
-    networkmap-1.5: corda/enterprise-networkmap:1.5.1-zulu-openjdk8u242
     idman-1.2: corda/enterprise-identitymanager:1.2-zulu-openjdk8u242
+    networkmap-1.2: corda/enterprise-networkmap:1.2-zulu-openjdk8u242
+    # list of various nodes supporting version 1.5
+    pki-1.5: corda/enterprise-pki:1.5.1-zulu-openjdk8u242
+    signer-1.5: corda/enterprise-signer:1.5.1-zulu-openjdk8u242
     idman-1.5: corda/enterprise-identitymanager:1.5.1-zulu-openjdk8u242
+    networkmap-1.5: corda/enterprise-networkmap:1.5.1-zulu-openjdk8u242
+    auth-1.5: corda/enterprise-auth:1.5.1-zulu-openjdk8u242
     zone-1.5: corda/enterprise-zone:1.5.1-zulu-openjdk8u242
-    notary-4.4: corda/enterprise-node:4.4
-    notary-4.7: corda/enterprise-node:4.7
-    firewall-4.4: corda/enterprise-firewall:4.4
-    node-4.4: corda/enterprise-node:4.4
-    node-4.7: corda/enterprise-node:4.7
     gateway-1.5: corda/enterprise-gateway:1.5.0-zulu-openjdk8u242
     enterpriseCli-1.5: corda/enterprise-cli:1.5.1-zulu-openjdk8u242
+    # list of various nodes supporting version 4.4
+    firewall-4.4: corda/enterprise-firewall:4.4
+    node-4.4: corda/enterprise-node:4.4
+    notary-4.4: corda/enterprise-node:4.4
+    # list of various nodes supporting version 4.7
+    node-4.7: corda/enterprise-node:4.7
+    notary-4.7: corda/enterprise-node:4.7
+    # list of various nodes supporting version 4.10
+    node-4.10: corda/enterprise-node:4.10
+    notary-4.10: corda/enterprise-node:4.10
   init_container: alpine-utils:1.0

--- a/platforms/r3-corda-ent/configuration/samples/network-addNotary.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-addNotary.yaml
@@ -12,13 +12,14 @@ network:
   # Network level configuration specifies the attributes required for each organization
   # to join an existing network.
   type: corda-enterprise
-  version: 4.7        # Hyperledger Bevel deployment supports node and notary enterprise 4.7 version (use older tag for other version supports)
+  version: "4.7"        # Hyperledger Bevel deployment supports node and notary enterprise 4.7 version (use older tag for other version supports)
   frontend: enabled   #Flag for frontend to enabled for nodes/peers
 
   #Environment section for Kubernetes setup
   env:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
+    proxy_namespace: "ambassador"   # Namespace required for Ambassador Edge-Stack deployment
     ambassadorPorts:                # Any additional Ambassador ports can be given here, this is valid only if proxy='ambassador'
       portRange:              # For a range of ports 
         from: 15005 
@@ -121,7 +122,7 @@ network:
           tlscrlsigner: password
         truststore:
           truststore: trustpass
-          rootca: password
+          rootca: rootpassword
           ssl: password
         ssl:
           networkmap: password

--- a/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
@@ -13,13 +13,14 @@ network:
   # Network level configuration specifies the attributes required for each organization
   # to join an existing network.
   type: corda-enterprise
-  version: 4.7        # Hyperledger Bevel deployment supports node and notary enterprise 4.7 version (use older tag for other version supports)
+  version: "4.7"        # Hyperledger Bevel deployment supports node and notary enterprise 4.7 version (use older tag for other version supports)
   frontend: enabled   #Flag for frontend to enabled for nodes/peers
 
   #Environment section for Kubernetes setup
   env:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
+    proxy_namespace: "ambassador"   # Namespace required for Ambassador Edge-Stack deployment
     ambassadorPorts:                # Any additional Ambassador ports can be given here, this is valid only if proxy='ambassador'
       portRange:              # For a range of ports 
         from: 15005 
@@ -122,7 +123,7 @@ network:
           tlscrlsigner: password
         truststore:
           truststore: trustpass
-          rootca: password
+          rootca: rootpassword
           ssl: password
         ssl:
           networkmap: password
@@ -181,7 +182,7 @@ network:
           serviceName: "O=Notary Service,OU=Notary1,L=London,C=GB"
           type: notary
           validating: true
-          emailAddress: "dev@bevel.com"      
+          emailAddress: "dev@bevel.com"
           p2p:
             port: 10002
             targetPort: 10002

--- a/platforms/r3-corda-ent/images/node4.10.dockerfile
+++ b/platforms/r3-corda-ent/images/node4.10.dockerfile
@@ -1,0 +1,3 @@
+FROM corda/corda-enterprise:4.10.3-zulu-openjdk8-alpine
+USER root
+WORKDIR /opt/corda


### PR DESCRIPTION
# Commit to be reviewed
---
### feat(r3-corda-ent): upgrade to version 4.10

**Changes:**

- `Node` and `Notary` nodes have been upgraded to version 4.10 (specifically, version 4.10.3) from 4.7.
- Introduced a new Dockerfile, named `node4.10.dockerfile`, to build the version 4.10 image.
- Updated the codebase to fetch the latest version 4.10 properly when the user defines it in the network configuration file.

**Additional changes:**
- Added the missing vault delete commands.
- Fixed the code to delete the vault policy correctly.
- Updated sample network configuration files to facilitate smooth deployment.

---

fixes #2398