### PR TITLE
[r3-corda-ent] enable DLT deployment via GitHub Workflow & Action

### DIFF
--- a/.github/workflows/aws_corda_ent_deploy.yaml
+++ b/.github/workflows/aws_corda_ent_deploy.yaml
@@ -1,0 +1,137 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+##############################################################################################
+# Workflow: Deploy Hyperledger Bevel's R3-CORDA-ENT DLT Platform to an EKS Cluster.
+
+# Prerequisites:
+# 1. An accessible EKS Cluster
+# 2. A Vault instance accessible from GitHub Runner
+# 3. A completed network.yaml file stored in GitHub Secrets
+
+# Workflow Overview:
+# 1. This GitHub Actions workflow automates the seamless deployment of "BEVEL's R3-CORDA-ENT" platform to an EKS cluster.
+# 2. Utilizing secure environment variables, the workflow manages sensitive information related to AWS, Docker, Cluster, Vault, and Git.
+# 3. The workflow dynamically customizes a network configuration file by substituting placeholders with values derived from environment variables.
+# 4. It uses tool Ansible to deploy the platform.
+##############################################################################################
+
+# Name of the workflow
+name: Deploy R3-Corda-Ent to an EKS Cluster
+
+# Triggers for the workflow
+on:
+  # Manually trigger the workflow through the GitHub Actions UI
+  workflow_dispatch:
+    # Ignore certain paths to avoid unnecessary triggering
+    paths-ignore:
+      - 'docs/**'
+      - '**/charts/**'
+      - '**/releases/**'
+
+# Jobs to be executed
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment: Bevel-AWS-Deployment
+    env:
+      AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"             # AWS Access Key ID
+      AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"     # AWS Secret Access Key
+      AWS_REGION: "${{ secrets.AWS_REGION }}"                           # EKS cluster zone
+      CLUSTER_CONTEXT: "${{ secrets.CLUSTER_CONTEXT }}"                 # Context name for the EKS cluster
+      KUBECONFIG: "${{ secrets.ENCODED_KUBECONFIG }}"                   # Provide Kubernetes configuration file in encoded base64 format
+      DOCKER_URL: "${{ secrets.DOCKER_URL }}"                           # URL of the Docker registry
+      DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"                 # Docker registry username
+      DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"                 # Docker registry password
+      EXTERNAL_URL_SUFFIX: "${{ secrets.EXTERNAL_URL_SUFFIX }}"         # Suffix for external URLs
+      GIT_USER_NAME: "${{ secrets.GIT_USER_NAME }}"                     # Git username for Git operations
+      GIT_EMAIL_ADDR: "${{ secrets.GIT_EMAIL_ADDR }}"                   # Git email address for Git operations
+      GIT_TOKEN: "${{ secrets.GIT_TOKEN }}"                             # Git token with required permissions for authentication
+      GIT_BRANCH: "${{ vars.GIT_BRANCH }}"                              # Git branch to be used in the deployment
+      GIT_PRIVATE_SSH_KEY: "${{ secrets.GIT_PRIVATE_SSH_KEY }}"         # Private SSH key for Git authentication in encoded base64 format
+      VAULT_ADDR: "${{ secrets.VAULT_ADDR }}"                           # Vault Server DNS name
+      VAULT_TOKEN: "${{ secrets.VAULT_TOKEN }}"                         # Token for authentication with Vault
+
+    # Steps to be executed within the job
+    steps:
+      # Checkout the repository code
+      - name: Checkout Repository
+        uses: actions/checkout@v2.4.0
+
+      # Configure AWS credentials
+      - name: AWS Setup
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: "${{ env.AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ env.AWS_SECRET_ACCESS_KEY }}"
+          aws-region: "${{ env.AWS_REGION }}"
+
+      # Set up BEVEL's R3-CORDA-ENT network configuration file
+      - name: BEVEL's R3-CORDA-ENT Network Configuration file Setup
+        run: |
+          # Prepare network configuration file for deployment
+          mkdir -p build/
+          cp "platforms/r3-corda-ent/configuration/samples/workflow/network-proxy-cordaent.yaml" "build/network-cordaent.yaml"
+          NETWORK_CONF_FILE="build/network-cordaent.yaml"
+          
+          # Decode and store private SSH key
+          echo "${{ env.GIT_PRIVATE_SSH_KEY }}" | base64 --decode > /home/runner/private_ssh_key
+          
+          # Define placeholder values for the network configuration file
+          declare -A placeholders=(
+            ["NETWORK_VERSION"]="4.10"
+            ["FLUX_SUFFIX"]="corda-ent"
+            ["PORT_RANGE_FROM"]=15010
+            ["PORT_RANGE_TO"]=15090
+            ["DOCKER_URL"]="${{ env.DOCKER_URL }}"
+            ["DOCKER_USERNAME"]="${{ env.DOCKER_USERNAME }}"
+            ["DOCKER_PASSWORD"]="${{ env.DOCKER_PASSWORD }}"
+            ["USER_DIRECTORY"]="$(pwd)"
+            ["EXTERNAL_URL_SUFFIX"]="${{ env.EXTERNAL_URL_SUFFIX }}"
+            ["AWS_ACCESS_KEY"]="${{ env.AWS_ACCESS_KEY_ID }}"
+            ["AWS_SECRET_KEY"]="${{ env.AWS_SECRET_ACCESS_KEY }}"
+            ["CLUSTER_CONTEXT"]="${{ env.CLUSTER_CONTEXT }}"
+            ["CLUSTER_CONFIG"]="/home/runner/.kube/build_config/kubeconfig"
+            ["VAULT_ADDR"]="${{ env.VAULT_ADDR }}"
+            ["VAULT_ROOT_TOKEN"]="${{ env.VAULT_TOKEN }}"
+            ["GIT_USERNAME"]="${{ env.GIT_USER_NAME }}"
+            ["GIT_TOKEN"]="${{ env.GIT_TOKEN }}"
+            ["GIT_EMAIL_ADDR"]="${{ env.GIT_EMAIL_ADDR }}"
+            ["GIT_BRANCH"]="${{ env.GIT_BRANCH }}"
+            ["PRIVATE_KEY_PATH"]="/home/runner/private_ssh_key"
+          )
+          
+          # Replace placeholders in the network configuration file
+          for placeholder in "${!placeholders[@]}"; do
+            sed -i "s#${placeholder}#${placeholders[$placeholder]}#g" "$NETWORK_CONF_FILE"
+          done
+
+      # Deploy BEVEL's R3-CORDA-ENT Platform
+      - name: Deploy BEVEL's R3-CORDA-ENT Platform
+        run: |
+          # Setup Kubernetes configuration
+          mkdir -p /home/runner/.kube/build_config
+          echo "${{ env.KUBECONFIG }}" | base64 --decode > /home/runner/.kube/build_config/kubeconfig
+          export KUBECONFIG="/home/runner/.kube/build_config/kubeconfig"
+          
+          # Configure Git user settings
+          git config --global user.email "${{ env.GIT_EMAIL_ADDR }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          
+          # Install required tools and Ansible collections
+          mkdir -p ~/bin
+          export PATH=$PATH:~/bin
+          pip3 install openshift=='0.13.1'
+          pip install ansible jmespath jinja2-time
+          ansible-galaxy collection install -r platforms/shared/configuration/requirements.yaml
+          
+          # Deploy the BEVEL's R3-CORDA-ENT DLT platform
+          ansible-playbook platforms/shared/configuration/site.yaml \
+            -i platforms/shared/inventory/ansible_provisioners \
+            -e @build/network-cordaent.yaml \
+            -e 'ansible_python_interpreter=/usr/bin/python3'

--- a/platforms/r3-corda-ent/configuration/roles/create/namespace_serviceaccount/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/namespace_serviceaccount/tasks/main.yaml
@@ -30,16 +30,6 @@
     release_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}"
   when: get_namespace.resources|length == 0
 
-# Create vault auth service account for organisation
-- name: Create vault auth service account for {{ organisation }}
-  include_role:
-    name: create/k8_component
-  vars:
-    component_name: "{{ component_ns }}"
-    component_type: "vaultAuth"
-    helm_lint: "false"
-    release_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}"
-
 # Create vault reviewer service account for organisation
 - name: Create vault reviewer for {{ organisation }}
   include_role:
@@ -47,16 +37,6 @@
   vars:
     component_name: "{{ component_ns }}"
     component_type: "vault-reviewer"
-    helm_lint: "false"
-    release_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}"
-
-# Create clusterrolebinding
-- name: Create clusterrolebinding for {{ organisation }}
-  include_role:
-    name: create/k8_component
-  vars:
-    component_name: "{{ component_ns }}"
-    component_type: "reviewer_rbac"
     helm_lint: "false"
     release_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}"
 

--- a/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
@@ -17,17 +17,6 @@
     component_name: "{{ component_ns }}"
     type: "retry"
 
-# Wait for vault-auth creation
-- name: "Wait for vault-auth creation for {{ organisation }}"
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
-  vars:
-    component_type: "ServiceAccount"
-    component_name: "vault-auth"
-    type: "retry"
-  tags:
-    - notest    
-
 # Wait for vault-reviewer creation
 - name: "Wait for vault-reviewer creation for {{ organisation }}"
   include_role:
@@ -37,18 +26,7 @@
     component_name: "vault-reviewer"
     type: "retry"
   tags:
-    - notest    
-
-# Wait for ClusterRoleBinding creation
-- name: "Wait for ClusterRoleBinding creation for {{ organisation }}"
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
-  vars:
-    component_type: "ClusterRoleBinding"
-    component_name: "{{ component_ns }}-role-tokenreview-binding"
-    type: "retry"
-  tags:
-    - notest    
+    - notest
 
 # Create vault access policies
 - name: "Setup vault access for cenm"

--- a/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
@@ -20,7 +20,10 @@
     git_branch: "{{ item.gitops.branch }}"
     git_path: "{{ item.gitops.release_dir }}"
     git_host: "{{ item.gitops.git_repo.split('/')[0] | lower }}" # extract the hostname from the git_repo
-    ssh: "{{ item.gitops.ssh | default(false) }}"
+    git_protocol: "{{ item.gitops.git_protocol | default('https') }}"
+    git_url: "{{ item.gitops.git_url }}"
+    git_key: "{{ item.gitops.private_key | default() }}"
+    flux_version: "0.35.0"
     helm_operator_version: "1.2.0"
     aws_authenticator:
       os: "{{ install_os }}"
@@ -31,15 +34,14 @@
 # Setup ambassador for float cluster
 - name: Setup ambassador for float cluster
   include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/ambassador"
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/edge-stack"
   vars:
     item: "{{ org.services.float }}"
     kubeconfig_path: "{{ item.k8s.config_file }}"
     kubecontext: "{{ item.k8s.context }}"
     aws: "{{ item.aws }}"
-    ambassador:
-      item: "{{ org.services.float }}"
-  
+  when: network.env.proxy == 'ambassador'
+
 # Create Storageclass that will be used for this deployment
 - name: Create Storageclass
   include_role:

--- a/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
@@ -17,17 +17,6 @@
     component_name: "{{ component_ns }}"
     type: "retry"
 
-# Wait for vault-auth creation
-- name: "Wait for vault-auth creation for {{ organisation }}"
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
-  vars:
-    component_type: "ServiceAccount"
-    component_name: "vault-auth"
-    type: "retry"
-  tags:
-    - notest    
-
 # Wait for vault-reviewer creation
 - name: "Wait for vault-reviewer creation for {{ organisation }}"
   include_role:
@@ -35,17 +24,6 @@
   vars:
     component_type: "ServiceAccount"
     component_name: "vault-reviewer"
-    type: "retry"
-  tags:
-    - notest
-
-# Wait for ClusterRoleBinding creation
-- name: "Wait for ClusterRoleBinding creation for {{ organisation }}"
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
-  vars:
-    component_type: "ClusterRoleBinding"
-    component_name: "{{ component_ns }}-role-tokenreview-binding"
     type: "retry"
   tags:
     - notest

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/notary_node.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/notary_node.yaml
@@ -15,18 +15,7 @@
   vars:
     component_type: "Namespace"
     component_name: "{{ component_ns }}"
-    type: "retry"
-
-# Wait for vault-auth creation
-- name: "Wait for vault-auth creation for {{ organisation }}"
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
-  vars:
-    component_type: "ServiceAccount"
-    component_name: "vault-auth"
-    type: "retry"
-  tags:
-    - notest    
+    type: "retry"    
 
 # Wait for vault-reviewer creation
 - name: "Wait for vault-reviewer creation for {{ organisation }}"
@@ -35,17 +24,6 @@
   vars:
     component_type: "ServiceAccount"
     component_name: "vault-reviewer"
-    type: "retry"
-  tags:
-    - notest    
-
-# Wait for ClusterRoleBinding creation
-- name: "Wait for ClusterRoleBinding creation for {{ organisation }}"
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
-  vars:
-    component_type: "ClusterRoleBinding"
-    component_name: "{{ component_ns }}-role-tokenreview-binding"
     type: "retry"
   tags:
     - notest

--- a/platforms/r3-corda-ent/configuration/samples/workflow/network-no-proxy-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/workflow/network-no-proxy-cordaent.yaml
@@ -1,0 +1,703 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+# yaml-language-server: $schema=../../../../platforms/network-schema.json
+# This is a sample configuration file for Corda Enterprise network for SupplyChain App usecase on Single K8s Cluster.
+# For multiple K8s clusters, there should be multiple configuration files or refer to configuration guide on the below link.
+# https://hyperledger-bevel.readthedocs.io/en/latest/operations/corda_networkyaml.html
+network:
+  type: corda-enterprise
+  version: "NETWORK_VERSION"        # Hyperledger Bevel deployment supports node and notary enterprise 4.7 version (use older tag for other version supports)
+  frontend: enabled   #Flag for frontend to enabled for nodes/peers
+
+  #Environment section for Kubernetes setup
+  env:
+    type: "FLUX_SUFFIX"
+    proxy: "none"
+    proxy_namespace: "ambassador"
+    ambassadorPorts:
+      portRange:
+        from: PORT_RANGE_FROM
+        to: PORT_RANGE_TO
+    loadBalancerSourceRanges:
+    retry_count: 20
+    external_dns: enabled
+
+  docker:
+    url: "DOCKER_URL"
+    username: "DOCKER_USERNAME"
+    password: "DOCKER_PASSWORD"
+
+  network_services:
+    - service:
+      name: idman
+      type: idman
+      uri: "https://idman.EXTERNAL_URL_SUFFIX"
+      certificate: USER_DIRECTORY/platforms/r3-corda-ent/configuration/build/ambassador/idman/ambassador.pem
+      crlissuer_subject: "CN=Corda TLS CRL Authority,OU=Corda UAT,O=R3 HoldCo LLC,L=New York,C=US"
+    - service:
+      name: networkmap
+      type: networkmap
+      uri: "https://networkmap.EXTERNAL_URL_SUFFIX"
+      certificate: USER_DIRECTORY/platforms/r3-corda-ent/configuration/build/ambassador/networkmap/ambassador.pem
+      truststore: USER_DIRECTORY/platforms/r3-corda-ent/configuration/build/networkroottruststore.jks
+      truststore_pass: rootpassword
+  
+  organizations:
+    - organization:
+      name: supplychain
+      country: UK
+      state: London
+      location: London
+      subject: "CN=DLT Root CA,OU=DLT,O=DLT,L=London,C=GB"
+      subordinate_ca_subject: "CN=Test Subordinate CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+      type: cenm
+      version: 1.5
+      external_url_suffix: 
+
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      credentials:
+        keystore:
+          keystore: cordacadevpass
+          idman: password
+          networkmap: password
+          subordinateca: password
+          rootca: password
+          tlscrlsigner: password
+        truststore:
+          truststore: trustpass
+          rootca: rootpassword
+          ssl: password
+        ssl:
+          networkmap: password
+          idman: password
+          signer: password
+          root: password
+          auth: password
+
+      services:
+        zone:
+          name: zone
+          type: cenm-zone
+          ports:
+            enm: 25000
+            admin: 12345
+        auth:
+          name: auth
+          subject: "CN=Test TLS Auth Service Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-auth
+          port: 8081
+          username: admin
+          userpwd: p4ssWord
+        gateway:
+          name: gateway
+          subject: "CN=Test TLS Gateway Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-gateway
+          ports: 
+            servicePort: 8080
+            ambassadorPort: 15008
+        idman:
+          name: idman
+          subject: "CN=Test Identity Manager Service Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          crlissuer_subject: "CN=Corda TLS CRL Authority,OU=Corda UAT,O=R3 HoldCo LLC,L=New York,C=US"
+          type: cenm-idman
+          port: 10000
+        networkmap:
+          name: networkmap
+          subject: "CN=Test Network Map Service Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-networkmap
+          ports:
+            servicePort: 10000
+            targetPort: 10000
+        signer:
+          name: signer
+          subject: "CN=Test TLS Signer Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-signer
+          ports:
+            servicePort: 8080
+            targetPort: 8080  
+        notaries:
+        - notary:
+          name: notary-1
+          subject: "O=Notary,OU=Notary1,L=London,C=GB"
+          serviceName: "O=Notary Service,OU=Notary1,L=London,C=GB"
+          type: notary
+          validating: true
+          emailAddress: "dev@bevel.com"
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15005
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+
+    - organization:
+      name: manufacturer
+      version: 4.7
+      cenm_version: 1.5
+      country: CH
+      state: Zurich
+      location: Zurich
+      subject: "O=Manufacturer,OU=Manufacturer,L=Zurich,C=CH"
+      type: node
+      external_url_suffix: 
+      firewall:
+        enabled: false          # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+
+      cloud_provider: aws       # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: 
+          cloud_provider: aws                   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+            secret_path: "secretsv2"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15021
+            ambassador_p2p_port: 15020
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: manufacturer
+          subject: "O=Manufacturer,OU=Manufacturer,L=47.38/8.54/Zurich,C=CH"
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass
+          hsm:                      # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15010       # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000
+
+    - organization:
+      name: carrier
+      version: 4.7
+      cenm_version: 1.5
+      country: GB
+      state: London
+      location: London
+      subject: "O=Carrier,OU=Carrier,L=London,C=GB"
+      type: node
+      external_url_suffix: 
+      firewall:
+        enabled: false         # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+      
+      cloud_provider: aws     # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+  
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+      
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: 
+          cloud_provider: aws   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files 
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/float"    # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15031
+            ambassador_p2p_port: 15030
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: carrier
+          subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass         
+          hsm:                  # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15030   # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000
+
+    - organization:
+      name: store
+      version: 4.7
+      cenm_version: 1.5
+      country: US
+      state: New York
+      location: New York
+      subject: "O=Store,OU=Store,L=New York,C=US"
+      type: node
+      external_url_suffix: 
+      firewall:
+        enabled: false        # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+      
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+  
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: 
+          cloud_provider: aws   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files   
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/float"    # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15041
+            ambassador_p2p_port: 15040
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: store
+          subject: "O=Store,OU=Store,L=40.73/-74/New York,C=US" # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass
+          hsm:                      # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15040       # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000
+
+    - organization:
+      name: warehouse
+      version: 4.7
+      cenm_version: 1.5
+      country: US
+      state: Massachusetts
+      location: Boston
+      subject: "O=Warehouse,OU=Warehouse,L=Boston,C=US"
+      type: node
+      external_url_suffix: 
+      firewall:
+        enabled: false        # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+      
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+      
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+        
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: 
+          cloud_provider: aws   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files 
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/float"    # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15051
+            ambassador_p2p_port: 15050
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: warehouse
+          subject: "O=Warehouse,OU=Warehouse,L=42.36/-71.06/Boston,C=US"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass             
+          hsm:                      # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15050       # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000

--- a/platforms/r3-corda-ent/configuration/samples/workflow/network-proxy-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/workflow/network-proxy-cordaent.yaml
@@ -1,0 +1,703 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+# yaml-language-server: $schema=../../../../platforms/network-schema.json
+# This is a sample configuration file for Corda Enterprise network for SupplyChain App usecase on Single K8s Cluster.
+# For multiple K8s clusters, there should be multiple configuration files or refer to configuration guide on the below link.
+# https://hyperledger-bevel.readthedocs.io/en/latest/operations/corda_networkyaml.html
+network:
+  type: corda-enterprise
+  version: "NETWORK_VERSION"        # Hyperledger Bevel deployment supports node and notary enterprise 4.7 version (use older tag for other version supports)
+  frontend: enabled   #Flag for frontend to enabled for nodes/peers
+
+  #Environment section for Kubernetes setup
+  env:
+    type: "FLUX_SUFFIX"
+    proxy: "ambassador"
+    proxy_namespace: "ambassador"
+    ambassadorPorts:
+      portRange:
+        from: PORT_RANGE_FROM
+        to: PORT_RANGE_TO
+    loadBalancerSourceRanges:
+    retry_count: 20
+    external_dns: enabled
+
+  docker:
+    url: "DOCKER_URL"
+    username: "DOCKER_USERNAME"
+    password: "DOCKER_PASSWORD"
+
+  network_services:
+    - service:
+      name: idman
+      type: idman
+      uri: "https://idman.EXTERNAL_URL_SUFFIX"
+      certificate: USER_DIRECTORY/platforms/r3-corda-ent/configuration/build/ambassador/idman/ambassador.pem
+      crlissuer_subject: "CN=Corda TLS CRL Authority,OU=Corda UAT,O=R3 HoldCo LLC,L=New York,C=US"
+    - service:
+      name: networkmap
+      type: networkmap
+      uri: "https://networkmap.EXTERNAL_URL_SUFFIX"
+      certificate: USER_DIRECTORY/platforms/r3-corda-ent/configuration/build/ambassador/networkmap/ambassador.pem
+      truststore: USER_DIRECTORY/platforms/r3-corda-ent/configuration/build/networkroottruststore.jks
+      truststore_pass: rootpassword
+  
+  organizations:
+    - organization:
+      name: supplychain
+      country: UK
+      state: London
+      location: London
+      subject: "CN=DLT Root CA,OU=DLT,O=DLT,L=London,C=GB"
+      subordinate_ca_subject: "CN=Test Subordinate CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+      type: cenm
+      version: 1.5
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar" # ?
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      credentials:
+        keystore:
+          keystore: cordacadevpass
+          idman: password
+          networkmap: password
+          subordinateca: password
+          rootca: password
+          tlscrlsigner: password
+        truststore:
+          truststore: trustpass
+          rootca: rootpassword
+          ssl: password
+        ssl:
+          networkmap: password
+          idman: password
+          signer: password
+          root: password
+          auth: password
+
+      services:
+        zone:
+          name: zone
+          type: cenm-zone
+          ports:
+            enm: 25000
+            admin: 12345
+        auth:
+          name: auth
+          subject: "CN=Test TLS Auth Service Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-auth
+          port: 8081
+          username: admin
+          userpwd: p4ssWord
+        gateway:
+          name: gateway
+          subject: "CN=Test TLS Gateway Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-gateway
+          ports: 
+            servicePort: 8080
+            ambassadorPort: 15008
+        idman:
+          name: idman
+          subject: "CN=Test Identity Manager Service Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          crlissuer_subject: "CN=Corda TLS CRL Authority,OU=Corda UAT,O=R3 HoldCo LLC,L=New York,C=US"
+          type: cenm-idman
+          port: 10000
+        networkmap:
+          name: networkmap
+          subject: "CN=Test Network Map Service Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-networkmap
+          ports:
+            servicePort: 10000
+            targetPort: 10000
+        signer:
+          name: signer
+          subject: "CN=Test TLS Signer Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          type: cenm-signer
+          ports:
+            servicePort: 8080
+            targetPort: 8080  
+        notaries:
+        - notary:
+          name: notary-1
+          subject: "O=Notary,OU=Notary1,L=London,C=GB"
+          serviceName: "O=Notary Service,OU=Notary1,L=London,C=GB"
+          type: notary
+          validating: true
+          emailAddress: "dev@bevel.com"
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15005
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+
+    - organization:
+      name: manufacturer
+      version: 4.7
+      cenm_version: 1.5
+      country: CH
+      state: Zurich
+      location: Zurich
+      subject: "O=Manufacturer,OU=Manufacturer,L=Zurich,C=CH"
+      type: node
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      firewall:
+        enabled: false          # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+
+      cloud_provider: aws       # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: "EXTERNAL_URL_SUFFIX"
+          cloud_provider: aws                   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+            secret_path: "secretsv2"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15021
+            ambassador_p2p_port: 15020
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: manufacturer
+          subject: "O=Manufacturer,OU=Manufacturer,L=47.38/8.54/Zurich,C=CH"
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass
+          hsm:                      # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15010       # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000
+
+    - organization:
+      name: carrier
+      version: 4.7
+      cenm_version: 1.5
+      country: GB
+      state: London
+      location: London
+      subject: "O=Carrier,OU=Carrier,L=London,C=GB"
+      type: node
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      firewall:
+        enabled: false         # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+      
+      cloud_provider: aws     # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+  
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+      
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: "EXTERNAL_URL_SUFFIX"
+          cloud_provider: aws   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files 
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/float"    # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15031
+            ambassador_p2p_port: 15030
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: carrier
+          subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass         
+          hsm:                  # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15030   # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000
+
+    - organization:
+      name: store
+      version: 4.7
+      cenm_version: 1.5
+      country: US
+      state: New York
+      location: New York
+      subject: "O=Store,OU=Store,L=New York,C=US"
+      type: node
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      firewall:
+        enabled: false        # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+      
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+  
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https url for flux value files
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: "EXTERNAL_URL_SUFFIX"
+          cloud_provider: aws   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files   
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/float"    # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15041
+            ambassador_p2p_port: 15040
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: store
+          subject: "O=Store,OU=Store,L=40.73/-74/New York,C=US" # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass
+          hsm:                      # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15040       # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000
+
+    - organization:
+      name: warehouse
+      version: 4.7
+      cenm_version: 1.5
+      country: US
+      state: Massachusetts
+      location: Boston
+      subject: "O=Warehouse,OU=Warehouse,L=Boston,C=US"
+      type: node
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      firewall:
+        enabled: false        # true if firewall components are to be deployed
+        subject: "CN=Test Firewall CA Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        credentials:
+            firewallca: firewallcapassword
+            float: floatpassword
+            bridge: bridgepassword
+      
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+      
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https"                                   # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"                                    # Git branch where release is being made
+        release_dir: "platforms/r3-corda-ent/releases/dev"      # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+        username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+        git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+        private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      
+      # Cordapps Repository details (optional if cordapps jar are store in a repository)
+      cordapps:
+        jars: 
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-supply-chain/4.7/cordapp-supply-chain-4.7.jar
+            url: "https://repo/path/cordapp1.jar"
+        - jar:
+            # e.g https://maven.pkg.github.com/hyperledger/bevel/com.supplychain.bcc.cordapp-contracts-states/4.7/cordapp-contracts-states-4.7.jar
+            url: "https://repo/path/cordapp2.jar"
+        username: "GIT_USERNAME"
+        password: "GIT_TOKEN"
+        
+      services:
+        float: 
+          name: float
+          subject: "CN=Test Float Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+          external_url_suffix: "EXTERNAL_URL_SUFFIX"
+          cloud_provider: aws   # Options: aws, azure, gcp
+          aws:
+            access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+            secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+          k8s:
+            context: "CLUSTER_CONTEXT"
+            config_file: "CLUSTER_CONFIG"
+          vault:
+            url: "VAULT_ADDR"
+            root_token: "VAULT_ROOT_TOKEN"
+          gitops:
+            git_protocol: "https"                                   # Option for git over https or ssh
+            git_url: "https://github.com/GIT_USERNAME/bevel.git"    # Gitops https or ssh url for flux value files 
+            branch: "GIT_BRANCH"                                    # Git branch where release is being made
+            release_dir: "platforms/r3-corda-ent/releases/float"    # Relative Path in the Git repo for flux sync per environment. 
+            chart_source: "platforms/r3-corda-ent/charts"           # Relative Path where the Helm charts are stored in Git repo
+            username: "GIT_USERNAME"                                # Git Service user who has rights to check-in in all branches
+            password: "GIT_TOKEN"                                   # Git Server user password/token (Optional for ssh; Required for https)
+            email: "GIT_EMAIL_ADDR"                                 # Email to use in git config
+            git_repo: "github.com/GIT_USERNAME/bevel.git"           # Gitops git repository URL for git push 
+            private_key: "PRIVATE_KEY_PATH"                         # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+          ports:
+            p2p_port: 40000
+            tunnelport: 39999
+            ambassador_tunnel_port: 15051
+            ambassador_p2p_port: 15050
+        bridge:
+          name: bridge
+          subject: "CN=Test Bridge Certificate, OU=HQ, O=HoldCo LLC, L=New York, C=US"
+        peers:
+        - peer:
+          name: warehouse
+          subject: "O=Warehouse,OU=Warehouse,L=42.36/-71.06/Boston,C=US"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          type: node
+          credentials:
+            truststore: trustpass
+            keystore: cordacadevpass             
+          hsm:                      # hsm support for future release
+            enabled: false 
+          p2p:
+            port: 10002
+            targetPort: 10002
+            ambassador: 15050       # Port for ambassador service (must be from env.ambassadorPorts above)
+          rpc:
+            port: 30000
+            targetPort: 10003
+          rpcadmin:
+            port: 30009
+            targetPort: 10005
+          dbtcp:
+            port: 9101
+            targetPort: 1521
+          dbweb:             
+            port: 8080
+            targetPort: 81
+          springboot:
+            targetPort: 20001
+            port: 20001 
+          expressapi:
+            targetPort: 3000
+            port: 3000


### PR DESCRIPTION
### **Commit to be reviewed**
---

**feat(r3-corda-ent): enable DLT deployment via GitHub Workflow & Action**

**Changes**:
- Introduced a new GitHub Workflow enabling the deployment of Hyperledger Bevel's R3-CORDA-ENT DLT Platform to an EKS Cluster.
- Introduced a new directory at path: `platforms/r3-corda-ent/configuration/samples/workflow`, containing two new sample network configuration files:
   1. `network-proxy-cordaent.yaml`: Supports deployment with Ingress controller.
   2. `network-no-proxy-cordaent.yaml`: Supports deployment without an Ingress controller, specifically designed for deployment on Minikube.

**Additional Changes**:
- Resolved duplicacy in code related to `ServiceAccount` and `Cluster-role-binding`.
- Replaced the Ambassador Ansible task with new Ambassador-Edge-Stack.

**fixes #2416**