### PR TITLE
feat(besu): enable DLT deployment via GitHub Workflow & Action.

### DIFF
--- a/.github/workflows/aws_besu_deploy.yaml
+++ b/.github/workflows/aws_besu_deploy.yaml
@@ -1,0 +1,140 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+##############################################################################################
+# Workflow: Deploy Hyperledger Bevel's BESU DLT Platform to an EKS Cluster.
+
+# Prerequisites:
+# 1. An accessible EKS Cluster
+# 2. A Vault instance accessible from GitHub Runner
+# 3. A completed network.yaml file stored in GitHub Secrets
+
+# Workflow Overview:
+# 1. This GitHub Actions workflow automates the seamless deployment of "BEVEL's BESU" platform to an EKS cluster.
+# 2. Utilizing secure environment variables, the workflow manages sensitive information related to AWS, Docker, Cluster, Vault, and Git.
+# 3. The workflow dynamically customizes a network configuration file by substituting placeholders with values derived from environment variables.
+# 4. It uses tool Ansible to deploy the platform.
+##############################################################################################
+
+# Name of the workflow
+name: Deploy BESU to an EKS Cluster
+
+# Triggers for the workflow
+on:
+  # Manually trigger the workflow through the GitHub Actions UI
+  workflow_dispatch:
+    paths-ignore:
+      - 'docs/**'
+      - '**/charts/**'
+      - '**/releases/**'
+
+# Jobs to be executed
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment: Bevel-AWS-Deployment
+    env:
+      AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"             # AWS Access Key ID
+      AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"     # AWS Secret Access Key
+      AWS_REGION: "${{ secrets.AWS_REGION }}"                           # EKS cluster zone
+      CLUSTER_CONTEXT: "${{ secrets.CLUSTER_CONTEXT }}"                 # Context name for the EKS cluster
+      KUBECONFIG: "${{ secrets.ENCODED_KUBECONFIG }}"                   # Provide Kubernetes configuration file in encoded base64 format
+      DOCKER_URL: "${{ secrets.DOCKER_URL }}"                           # URL of the Docker registry
+      DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"                 # Docker registry username
+      DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"                 # Docker registry password
+      EXTERNAL_URL_SUFFIX: "${{ secrets.EXTERNAL_URL_SUFFIX }}"         # Suffix for external URLs
+      GIT_USER_NAME: "${{ secrets.GIT_USER_NAME }}"                     # Git username for Git operations
+      GIT_EMAIL_ADDR: "${{ secrets.GIT_EMAIL_ADDR }}"                   # Git email address for Git operations
+      GIT_TOKEN: "${{ secrets.GIT_TOKEN }}"                             # Git token with required permissions for authentication
+      GIT_BRANCH: "${{ vars.GIT_BRANCH }}"                              # Git branch to be used in the deployment
+      GIT_PRIVATE_SSH_KEY: "${{ secrets.GIT_PRIVATE_SSH_KEY }}"         # Private SSH key for Git authentication in encoded base64 format
+      VAULT_ADDR: "${{ secrets.VAULT_ADDR }}"                           # Vault Server DNS name
+      VAULT_TOKEN: "${{ secrets.VAULT_TOKEN }}"                         # Token for authentication with Vault
+
+    # Steps to be executed within the job
+    steps:
+      # Checkout the repository code
+      - name: Checkout Repository
+        uses: actions/checkout@v2.4.0
+
+      # Configure AWS credentials
+      - name: AWS Setup
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: "${{ env.AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ env.AWS_SECRET_ACCESS_KEY }}"
+          aws-region: "${{ env.AWS_REGION }}"
+      
+      # Set up BEVEL's BESU network configuration file
+      - name: BEVEL's BESU Network Configuration file Setup
+        run: |
+          # Prepare network configuration file for deployment
+          mkdir -p build/
+
+          cp "./platforms/hyperledger-besu/configuration/samples/workflow/network-proxy-besu.yaml" "build/network-besu.yaml"
+
+          NETWORK_CONF_FILE="build/network-besu.yaml"
+          
+          # Decode and store private SSH key
+          echo "${{ env.GIT_PRIVATE_SSH_KEY }}" | base64 --decode > /home/runner/private_ssh_key
+          
+          # Define placeholder values for the network configuration file
+          declare -A placeholders=(
+            ["NETWORK_VERSION"]="22.10.2"
+            ["FLUX_SUFFIX"]="besu"
+            ["PORT_RANGE_FROM"]=15010
+            ["PORT_RANGE_TO"]=15090
+            ["DOCKER_URL"]="${{ env.DOCKER_URL }}"
+            ["DOCKER_USERNAME"]="${{ env.DOCKER_USERNAME }}"
+            ["DOCKER_PASSWORD"]="${{ env.DOCKER_PASSWORD }}"
+            ["USER_DIRECTORY"]="$(pwd)"
+            ["EXTERNAL_URL_SUFFIX"]="${{ env.EXTERNAL_URL_SUFFIX }}"
+            ["AWS_ACCESS_KEY"]="${{ env.AWS_ACCESS_KEY_ID }}"
+            ["AWS_SECRET_KEY"]="${{ env.AWS_SECRET_ACCESS_KEY }}"
+            ["AWS_REGION"]="${{ env.AWS_REGION}}"
+            ["CLUSTER_CONTEXT"]="${{ env.CLUSTER_CONTEXT }}"
+            ["CLUSTER_CONFIG"]="/home/runner/.kube/build_config/kubeconfig"
+            ["VAULT_ADDR"]="${{ env.VAULT_ADDR }}"
+            ["VAULT_ROOT_TOKEN"]="${{ env.VAULT_TOKEN }}"
+            ["GIT_USERNAME"]="${{ env.GIT_USER_NAME }}"
+            ["GIT_TOKEN"]="${{ env.GIT_TOKEN }}"
+            ["GIT_EMAIL_ADDR"]="${{ env.GIT_EMAIL_ADDR }}"
+            ["GIT_BRANCH"]="${{ env.GIT_BRANCH }}"
+            ["PRIVATE_KEY_PATH"]="/home/runner/private_ssh_key"
+          )
+          
+          # Replace placeholders in the network configuration file
+          for placeholder in "${!placeholders[@]}"; do
+            sed -i "s#${placeholder}#${placeholders[$placeholder]}#g" "$NETWORK_CONF_FILE"
+          done
+
+      # Deploy BEVEL's BESU Platform
+      - name: Deploy BEVEL's BESU Platform
+        run: |
+          # Setup Kubernetes configuration
+          mkdir -p /home/runner/.kube/build_config
+          echo "${{ env.KUBECONFIG }}" | base64 --decode > /home/runner/.kube/build_config/kubeconfig
+          export KUBECONFIG="/home/runner/.kube/build_config/kubeconfig"
+
+          
+          # Configure Git user settings
+          git config --global user.email "${{ env.GIT_EMAIL_ADDR }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          
+          # Install required tools and Ansible collections
+          mkdir -p ~/bin
+          export PATH=$PATH:~/bin
+          pip3 install openshift=='0.13.1'
+          pip install ansible jmespath jinja2-time
+          ansible-galaxy collection install -r platforms/shared/configuration/requirements.yaml
+          
+          # Deploy the BEVEL's BESU DLT platform
+          ansible-playbook platforms/shared/configuration/site.yaml \
+            -i platforms/shared/inventory/ansible_provisioners \
+            -e @build/network-besu.yaml \
+            -e 'ansible_python_interpreter=/usr/bin/python3'

--- a/platforms/hyperledger-besu/configuration/samples/workflow/network-no-proxy-besu.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/workflow/network-no-proxy-besu.yaml
@@ -1,0 +1,451 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+# yaml-language-server: $schema=../../../../platforms/network-schema.json
+# This is a sample configuration file for Hyperledger Besu network which has 4 nodes and created in a single Kubernetes cluster
+# proxy = none. DO NOT use this for production. Also, add-newnode will not work on such a network
+# All text values are case-sensitive
+network:
+  # Network level configuration specifies the attributes required for each organization
+  # to join an existing network.
+  type: besu
+  version: "NETWORK_VERSION"  #this is the version of Besu docker image that will be deployed.
+  # onchain permissioning - ref https://besu.hyperledger.org/en/stable/private-networks/tutorials/permissioning/onchain
+  permissioning:
+    enabled: false
+
+  #Environment section for Kubernetes setup
+  env:
+    type: "FLUX_SUFFIX"              # tag for the environment. Important to run multiple flux on single cluster
+    proxy: none               # use 'none' when not using 'ambassador' for a single cluster environment
+    proxy_namespace: "ambassador"
+    #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
+    #  This sample uses a single cluster, so we have to open 3 ports for each Node. These ports are again specified for each organization below
+    ambassadorPorts:                # Any additional Ambassador ports can be given here, this is valid only if proxy='ambassador'
+      portRange:              # For a range of ports 
+        from: PORT_RANGE_FROM 
+        to: PORT_RANGE_TO
+    # ports: [15020,15021]      # For specific ports; needs to be an array or list
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
+    retry_count: 20                 # Retry count for the checks on Kubernetes cluster
+    external_dns: disabled           # Should be enabled if using external-dns for automatic route configuration
+    labels:
+      service:
+        component: besu
+      pvc: {}
+      deployment:
+          owner: bevel
+          component: besu
+
+  # Prometheus setup section
+  prometheus:
+    enabled: true                   # Set to "true" to enable Prometheus monitoring, or "false" to disable it.
+    ambassador_mapping: enabled     # Choose "enabled" to make Prometheus publically accessible through Ambassador, or "disabled" to restrict access to local use via port-forwarding.
+    prometheus_prefix: bevelprom    # The prefix added to the organization's external_url_suffix to create the hostname.
+    port: 80                        # The port will be used by Ambassador for Prometheus. Supported values include 80, 443, or any unused port from the network.env.ambassadorPorts range.
+    # To access Prometheus publicly:
+    # - Use <prometheus_prefix>.<organization's external_url_suffix> if using port 80 or 443.
+    # - Use <random-string>.<organization's external_url_suffix>:<port> if selecting a port from network.env.ambassadorPorts range.   
+  
+  # Docker registry details where images are stored. This will be used to create k8s secrets
+  # Please ensure all required images are built and stored in this registry. 
+  # Do not check-in docker_password.
+  docker:
+    url: "DOCKER_URL"
+    username: "DOCKER_USERNAME"
+    password: "DOCKER_PASSWORD"
+  
+  # Following are the configurations for the common Besu network
+  config:    
+    consensus: "ibft"                 # Options are "ibft", "qbft", "ethash" and "clique".
+    ## Certificate subject for the root CA of the network. 
+    #  This is for development usage only where we create self-signed certificates and the truststores are generated automatically.
+    #  Production systems should generate proper certificates and configure truststores accordingly.
+    subject: "CN=DLT Root CA,OU=DLT,O=DLT,L=London,C=GB"
+    transaction_manager: "tessera"    # Transaction manager can be "tessera"
+    # This is the version of transaction_manager docker image that will be deployed
+    tm_version: "21.7.3"               
+    # TLS can be True or False for the transaction manager
+    tm_tls: True
+    # Tls trust value
+    tm_trust: "tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
+    ## File location for saving the genesis file should be provided.
+    genesis: "USER_DIRECTORY/build/besu_genesis"   # Location where genesis file will be saved
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
+    ## At least one Transaction Manager nodes public addresses should be provided.
+    #  - "https://carrier-tessera.carrier-bes" for tessera
+    # The above domain name is formed by the (http or https)://(peer.name).(org.external_url_suffix):(ambassador tm_nodeport)
+    tm_nodes: 
+      - "https://carrier-EXTERNAL_URL_SUFFIX"
+  
+  # Allows specification of one or many organizations that will be connecting to a network.
+  organizations:
+    # Specification for the 1st organization. Each organization should map to a VPC and a separate k8s cluster for production deployments
+    - organization:
+      name: supplychain
+      type: validator
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      # This is same as the org namespace when proxy=none
+      external_url_suffix: "supplychain-bes.EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push 
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      # As this is the validator org, it is hosting a few validators as services
+      services:
+        validators:
+        - validator:
+          name: validator1
+          bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+        - validator:
+          name: validator2
+          bootnode: true          # true if the validator node is used also a bootnode for the network
+          p2p:
+            port: 30303
+            ambassador: 15012       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node.  
+        - validator:
+          name: validator3
+          bootnode: false          # true if the validator node is used also a bootnode for the network
+          p2p:
+            port: 30303
+            ambassador: 15014       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node.       
+        - validator:
+          name: validator4
+          bootnode: false          # true if the validator node is used also a bootnode for the network
+          p2p:
+            port: 30303
+            ambassador: 15016       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    - organization:
+      name: carrier
+      type: member
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      # This is same as the org namespace when proxy=none
+      external_url_suffix: "carrier-bes.EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push 
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      # The participating nodes are named as peers
+      services:
+        peers:
+        - peer:
+          name: carrier
+          subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15020       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443    
+            ambassador: 443
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node.       
+
+    # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
+    - organization:
+      name: manufacturer
+      type: member
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      # This is same as the org namespace when proxy=none
+      external_url_suffix: "manufacturer-bes.EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push 
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      # The participating nodes are named as peers 
+      services:
+        peers:
+        - peer:
+          name: manufacturer
+          subject: "O=Manufacturer,OU=Manufacturer,L=47.38/8.54/Zurich,C=CH"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          p2p:
+            port: 30303
+            ambassador: 15030       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443
+            ambassador: 443
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    - organization:
+      name: store
+      type: member        
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      # This is same as the org namespace when proxy=none
+      external_url_suffix: "store-bes.EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push 
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      services:
+        peers:
+        - peer:
+          name: store
+          subject: "O=Store,OU=Store,L=40.73/-74/New York,C=US" # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          p2p:
+            port: 30303
+            ambassador: 15040       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443
+            ambassador: 443
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    - organization:
+      name: warehouse
+      type: member         
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      # This is same as the org namespace when proxy=none
+      external_url_suffix: "warehouse-bes.EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:        
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push 
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      services:
+        peers:
+        - peer:
+          name: warehouse
+          subject: "O=Warehouse,OU=Warehouse,L=42.36/-71.06/Boston,C=US"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          p2p:
+            port: 30303
+            ambassador: 15050       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443
+            ambassador: 443
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 

--- a/platforms/hyperledger-besu/configuration/samples/workflow/network-proxy-besu.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/workflow/network-proxy-besu.yaml
@@ -1,0 +1,448 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+# yaml-language-server: $schema=../../../../platforms/network-schema.json
+# This is a sample configuration file for Hyperledger Besu network which has 4 nodes.
+# All text values are case-sensitive
+network:
+  # Network level configuration specifies the attributes required for each organization
+  # to join an existing network.
+  type: besu
+  version: "NETWORK_VERSION"        # Supported Besu versions are 21.1.1, 21.10.6, 22.10.2
+  # onchain permissioning - ref https://besu.hyperledger.org/en/stable/private-networks/tutorials/permissioning/onchain
+  permissioning:
+    enabled: false
+
+  #Environment section for Kubernetes setup
+  env:
+    type: "FLUX_SUFFIX"              # tag for the environment. Important to run multiple flux on single cluster
+    proxy: "ambassador"               # value can be 'ambassador' or 'none' as 'haproxy' has not been implemented for Besu
+    proxy_namespace: "ambassador"
+    #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
+    #  This sample uses a single cluster, so we have to open 3 ports for each Node. These ports are again specified for each organization below
+    ambassadorPorts:                # Any additional Ambassador ports can be given here, this is valid only if proxy='ambassador'
+      portRange:              # For a range of ports
+        from: PORT_RANGE_FROM
+        to: PORT_RANGE_TO
+    # ports: [15020,15021]      # For specific ports; needs to be an array or list
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
+    retry_count: 20                 # Retry count for the checks on Kubernetes cluster
+    external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
+    labels:
+      service:
+        component: besu
+      pvc: {}
+      deployment:
+        owner: bevel
+        component: besu
+
+  # Prometheus setup section
+  prometheus:
+    enabled: true                   # Set to "true" to enable Prometheus monitoring, or "false" to disable it.
+    ambassador_mapping: enabled     # Choose "enabled" to make Prometheus publically accessible through Ambassador, or "disabled" to restrict access to local use via port-forwarding.
+    prometheus_prefix: bevelprom    # The prefix added to the organization's external_url_suffix to create the hostname.
+    port: 80                        # The port will be used by Ambassador for Prometheus. Supported values include 80, 443, or any unused port from the network.env.ambassadorPorts range.
+    # To access Prometheus publicly:
+    # - Use <prometheus_prefix>.<organization's external_url_suffix> if using port 80 or 443.
+    # - Use <random-string>.<organization's external_url_suffix>:<port> if selecting a port from network.env.ambassadorPorts range.   
+
+  # Docker registry details where images are stored. This will be used to create k8s secrets
+  # Please ensure all required images are built and stored in this registry.
+  # Do not check-in docker_password.
+  docker:
+    url: "DOCKER_URL"
+    username: "DOCKER_USERNAME"
+    password: "DOCKER_PASSWORD"
+
+  # Following are the configurations for the common Besu network
+  config:
+    consensus: "ibft"                 # Options are "ibft", "qbft", "ethash" and "clique".
+    ## Certificate subject for the root CA of the network.
+    #  This is for development usage only where we create self-signed certificates and the truststores are generated automatically.
+    #  Production systems should generate proper certificates and configure truststores accordingly.
+    subject: "CN=DLT Root CA,OU=DLT,O=DLT,L=London,C=GB"
+    transaction_manager: "tessera"    # Transaction manager can be "tessera", "tessera" or "none"; 21.x.x features are same for both
+    # This is the version of transaction_manager docker image that will be deployed
+    tm_version: "21.7.3"
+    # TLS can be True or False for the transaction manager
+    tm_tls: True
+    # Tls trust value
+    tm_trust: "tofu"                  # Options are: "ca-or-tofu", "ca", "tofu"
+    ## File location for saving the genesis file should be provided.
+    genesis: "USER_DIRECTORY/build/besu_genesis"   # Location where genesis file will be saved
+    # Add public key of accounts without 0x which will have 90000 ETH at genesis. Accounts created on external system like Metamask
+    accounts:
+      - "75a3505cd50Cfc418e59458d0E23c8bd9f6B52a0"
+      - "e668554c28e81535B8679ff9de128203Fdedc212"
+    ## At least one Transaction Manager nodes public addresses should be provided.
+    #  - "https://node.test.besu.blockchaincloudpoc-develop.com" for tessera
+    # The above domain name is formed by the (http or https)://(peer.name).(org.external_url_suffix):(ambassador tm_nodeport)
+    tm_nodes:
+      - "https://carrier.EXTERNAL_URL_SUFFIX"
+
+  # Allows specification of one or many organizations that will be connecting to a network.
+  organizations:
+    # Specification for the 1st organization. Each organization should map to a VPC and a separate k8s cluster for production deployments
+    - organization:
+      name: supplychain
+      type: validator
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files
+        branch: "GIT_BRANCH"          # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      # As this is the validator org, it is hosting a few validators as services
+      services:
+        validators:
+        - validator:
+          name: validator1
+          bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15010       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: true      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545         # Specify the port that Prometheus will use to collect metrics for this node. 
+        - validator:
+          name: validator2
+          bootnode: true          # true if the validator node is used also a bootnode for the network
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15012       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: true      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545         # Specify the port that Prometheus will use to collect metrics for this node. 
+        - validator:
+          name: validator3
+          bootnode: false          # true if the validator node is used also a bootnode for the network
+          p2p:
+            port: 30303
+            ambassador: 15014       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+        - validator:
+          name: validator4
+          bootnode: false          # true if the validator node is used also a bootnode for the network
+          p2p:
+            port: 30303
+            ambassador: 15016       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    - organization:
+      name: carrier
+      type: member
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files
+        branch: "GIT_BRANCH"            # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"          # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      # The participating nodes are named as peers
+      services:
+        peers:
+        - peer:
+          name: carrier
+          subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15020       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443          # use port: 15022 when transaction_manager = "tessera"
+            ambassador: 443    # use ambassador: 15022 when transaction_manager = "tessera"
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    # Specification for the 2nd organization. Each organization maps to a VPC and a separate k8s cluster
+    - organization:
+      name: manufacturer
+      type: member
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"         # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      # The participating nodes are named as peers
+      services:
+        peers:
+        - peer:
+          name: manufacturer
+          subject: "O=Manufacturer,OU=Manufacturer,L=47.38/8.54/Zurich,C=CH"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15030       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443          # use port: 15032 when transaction_manager = "tessera"
+            ambassador: 443    # use ambassador: 15032 when transaction_manager = "tessera"
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    - organization:
+      name: store
+      type: member
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"         # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      services:
+        peers:
+        - peer:
+          name: store
+          subject: "O=Store,OU=Store,L=40.73/-74/New York,C=US" # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          cactus_connector: disabled  # set to enabled to create a cactus connector for Besu
+          p2p:
+            port: 30303
+            ambassador: 15040       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443          # use port: 15042 when transaction_manager = "tessera"
+            ambassador: 443    # use ambassador: 15042 when transaction_manager = "tessera"
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 
+
+    - organization:
+      name: warehouse
+      type: member
+      # Provide the url suffix that will be added in DNS recordset. Must be different for different clusters
+      external_url_suffix: "EXTERNAL_URL_SUFFIX"
+      #Providing issuer as letsencrypt would create tls certificate using letsencrypt CA, 
+      #This is Optional, if no value or default is provided, self signed certificates will be created
+      issuer: default
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+        region: "AWS_REGION"                # AWS Region where cluster and EIPs are created
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "CLUSTER_CONFIG"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "VAULT_ADDR"
+        root_token: "VAULT_ROOT_TOKEN"
+        secret_path: "secretsv2"
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files
+        branch: "GIT_BRANCH"           # Git branch where release is being made
+        release_dir: "platforms/hyperledger-besu/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        chart_source: "platforms/hyperledger-besu/charts"     # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push
+        username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"         # Git Server user password/token (Optional for ssh; Required for https)
+        email: "GIT_EMAIL_ADDR"                # Email to use in git config
+        private_key: "PRIVATE_KEY_PATH"          # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+
+      services:
+        peers:
+        - peer:
+          name: warehouse
+          subject: "O=Warehouse,OU=Warehouse,L=42.36/-71.06/Boston,C=US"  # This is the node identity. L=lat/long is mandatory for supplychain sample app
+          geth_passphrase: "12345"  # Passphrase to be used to generate geth account
+          lock: true        # Sets Besu node to lock or unlock mode. Can be true or false
+          p2p:
+            port: 30303
+            ambassador: 15050       #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 8545
+            ambassador: 80       # Will only support port 80
+          ws:
+            port: 8546
+          db:
+            port: 3306        # Only applicable for tessra where mysql db is used
+          tm_nodeport:
+            port: 443          # use port: 15052 when transaction_manager = "tessera"
+            ambassador: 443    # use ambassador: 15052 when transaction_manager = "tessera"
+          tm_clientport:
+            port: 8888
+          metrics:
+            enabled: false      # Set this to true to enable Prometheus monitoring for this node, or false to disable it.
+            port: 9545          # Specify the port that Prometheus will use to collect metrics for this node. 

--- a/platforms/shared/charts/bevel-vault-mgmt/templates/serviceAccount.yaml
+++ b/platforms/shared/charts/bevel-vault-mgmt/templates/serviceAccount.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.metadata.namespace }}
 {{- end }}
 ---
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/platforms/shared/configuration/roles/setup/kubectl/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/kubectl/tasks/main.yaml
@@ -57,7 +57,7 @@
       - kubectl
 
   - name: Test kubectl installation
-    command: "kubectl version --client --short"
+    command: kubectl version 
     changed_when: false
 
   - name: Changing the current context namespace to default


### PR DESCRIPTION
Changes:

Introduced a new GitHub Workflow enabling the deployment of Hyperledger Bevel's BESU DLT Platform to an EKS Cluster. Introduced a new directory at path: platforms/hyperledger-besu/configuration/samples/workflow, containing two new sample network configuration files: 
network-proxy-besu: Supports deployment with Ingress controller. 
network-no-proxy-besu: Supports deployment without an Ingress controller, specifically designed for deployment on Minikube.

Additional Changes:

1)Replaced the Ambassador Ansible task with new Ambassador-Edge-Stack. 
2)platforms/shared/charts/bevel-vault-mgmt/templates/serviceAccount.yaml 3)platforms/shared/configuration/roles/setup/kubectl/tasks/main.yaml

fixes #2416