### PR TITLE
[fabric] Allow invoke chaincode job to run

### DIFF
--- a/platforms/hyperledger-fabric/configuration/external-chaincode-ops.yaml
+++ b/platforms/hyperledger-fabric/configuration/external-chaincode-ops.yaml
@@ -202,7 +202,7 @@
         docker_url: "{{ network.docker.url }}"
         approvers: "{{ item.endorsers | default('', true) }}"
       loop: "{{ network['channels'] }}"
-      when: add_new_org == 'true' or '2.2.' in network.version    
+      when: add_new_org == 'true' or '2.' in network.version    
 
   vars: #These variables can be overriden from the command line
     privilege_escalate: false           #Default to NOT escalate to root privledges


### PR DESCRIPTION
**Primary Changes**
1. Allow invoke chaincode job to run on version 2.5.4 when chaincode is external.