### PR TITLE
[fabric] Support add-orderer-organization.yaml playbook

### DIFF
--- a/platforms/hyperledger-fabric/charts/fabric-cli/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-cli/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
       - name: scripts-volume
         configMap:
           name: bevel-vault-script
+      - name: package-manager
+        configMap:
+          name: package-manager
       initContainers:
       - name: certificates-init
         image: {{ $.Values.metadata.images.alpineutils }}
@@ -112,6 +115,9 @@ spec:
         - name: scripts-volume
           mountPath: /scripts/bevel-vault.sh
           subPath: bevel-vault.sh
+        - name: package-manager
+          mountPath: /scripts/package-manager.sh
+          subPath: package-manager.sh
       containers:
       - name: cli
         image: {{ $.Values.metadata.images.fabrictools }}
@@ -146,3 +152,6 @@ spec:
           mountPath: /opt/gopath/src/github.com/hyperledger/fabric/crypto
         - name: {{ .Values.peer.name }}-cli-pv
           mountPath: /opt/gopath/src/github.com/chaincode
+        - name: package-manager
+          mountPath: /scripts/package-manager.sh
+          subPath: package-manager.sh

--- a/platforms/hyperledger-fabric/configuration/add-orderer-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-orderer-organization.yaml
@@ -36,6 +36,19 @@
         release_dir: "{{ playbook_dir }}/../../../{{ item.gitops.release_dir }}/{{ item.name | lower }}"
       loop: "{{ network['organizations'] }}"
       when: item.org_status == 'new'
+
+    # Setup script for Vault and OS Package Manager
+    - name: "Setup script for Vault and OS Package Manager"
+      include_role:
+        name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
+      vars:
+        namespace: "{{ org.name | lower }}-net"
+        network_type: "{{ network.type | lower }}"
+        kubernetes: "{{ org.k8s }}"
+      loop: "{{ network['organizations'] }}"
+      loop_control:
+        loop_var: org
+      when: org.org_status == 'new'
     
     # Setup Vault-Kubernetes accesses and Regcred for docker registry for new organization
     - name: "Create vault-auth for new org"
@@ -78,6 +91,7 @@
         component: "{{ item.name | lower}}"
         component_type: "{{ item.type | lower}}"
         component_services: "{{ item.services }}"
+        sc_name: "{{ component }}-bevel-storageclass"
         kubernetes: "{{ item.k8s }}"
         vault: "{{ item.vault }}"
         ca: "{{ item.services.ca }}"
@@ -102,6 +116,7 @@
         component: "{{ item.name | lower}}"
         component_type: "{{ item.type | lower}}"
         component_services: "{{ item.services }}"
+        sc_name: "{{ component }}-bevel-storageclass"
         kubernetes: "{{ item.k8s }}"
         vault: "{{ item.vault }}"
         ca: "{{ item.services.ca }}"
@@ -109,7 +124,7 @@
         gitops: "{{ item.gitops }}"
         values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
       loop: "{{ network['organizations'] }}"
-      when: item.type == 'orderer'
+      when: item.type == 'orderer' and item.org_status == 'new' 
 
     # Creating channel artifacts and putting them in vault
     # This role creates configtx.yaml file as the requirements mentioned in network.yaml
@@ -146,7 +161,7 @@
       loop: "{{ network.organizations }}"
       loop_control:
         loop_var: neworg
-      when: neworg.type == 'orderer' and neworg.org_status == 'new'
+      when: neworg.type == 'orderer' and neworg.org_status == 'new' and '2.5.' not in network.version
 
     # This role creates value file for zk-kafka (if kafka consensus is chosen) and orderer
     - name: Create all orderers
@@ -157,6 +172,7 @@
         namespace: "{{ item.name | lower}}-net"
         component_type: "{{ item.type | lower}}"
         component_services: "{{ item.services }}"
+        sys_channel_name: "syschannel"
         vault: "{{ item.vault }}"
         git_protocol: "{{ item.gitops.git_protocol }}"
         git_url: "{{ item.gitops.git_url }}"
@@ -180,7 +196,7 @@
       loop: "{{ network.organizations }}"
       loop_control:
         loop_var: neworg
-      when: neworg.type == 'orderer' and neworg.org_status == 'new' 
+      when: neworg.type == 'orderer' and neworg.org_status == 'new' and '2.5.' not in network.version
 
     # This role adds the new org to the existing chnanel and updates the block with the application channel    
     - name: "Modify the application channel with tls and address information of new orderer"

--- a/platforms/hyperledger-fabric/configuration/cleanup.yaml
+++ b/platforms/hyperledger-fabric/configuration/cleanup.yaml
@@ -34,6 +34,7 @@
         name: "delete/genesis"
       vars:
         component_name: "{{ item.name | lower }}-net"
+        sys_channel_name: "syschannel"
       loop: "{{ network['organizations'] }}"
       when: 
       - item.type == "orderer"

--- a/platforms/hyperledger-fabric/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/deploy-network.yaml
@@ -174,7 +174,7 @@
       vars:
         build_path: "./build"
         genesis: "{{ item.genesis }}"
-        channel_name: "{{ item.channel_name | lower }}"
+        sys_channel_name: "syschannel"
       loop: "{{ network['channels'] }}"
     
     # This role creates value file for zk-kafka (if kafka consensus is chosen) and orderer
@@ -187,6 +187,7 @@
         component_type: "{{ item.type | lower}}"
         component_services: "{{ item.services }}"
         vault: "{{ item.vault }}"
+        sys_channel_name: "syschannel"
         git_protocol: "{{ item.gitops.git_protocol }}"
         git_url: "{{ item.gitops.git_url }}"
         git_branch: "{{ item.gitops.branch }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/configtx/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/configtx/tasks/main.yaml
@@ -75,7 +75,7 @@
     component_name: "{{ item.name }}"
     component_ns: "{{ item.name | lower }}-net"
     component_type: "{{ item.type | lower }}"
-    orderers: "{{ network.orderers }}"
+    orderers: "{{ item.services.orderers | default('') }}"
     provider: "{{ network.env.proxy }}"
     filename: configtxOrg_{{ 'custom' if network.configtx is defined and network.configtx.custom == true and cforg.stat.exists else 'default' }}.tpl
   loop: "{{ network['organizations'] }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrg_default.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/configtx/templates/configtxOrg_default.tpl
@@ -20,7 +20,7 @@
       # AnchorPeers defines the location of peers which can be used
       # for cross org gossip communication.  Note, this value is only
       # encoded in the genesis block in the Application section context
-{% for peer in  item.services.peers %}
+{% for peer in item.services.peers %}
 {% if peer.type == 'anchor' %}
 {% if provider == 'none' %}
       - Host: {{ peer.name }}.{{ component_ns }}
@@ -33,13 +33,13 @@
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if component_type == 'orderer' %}
+{% if component_type == 'orderer' and '2.5' in network.version  %}
     OrdererEndpoints:
 {% for orderer in orderers %}
 {% if provider == 'none' %}
       - {{ orderer.name }}.{{ orderer.org_name | lower }}-net:7050
 {% else %}
-      - {{ orderer.uri }}
+      - {{ orderer.ordererAddress }}
 {% endif %}
 {% endfor %}
 {% endif %} 

--- a/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
@@ -11,6 +11,18 @@
     path: "{{ build_path }}/channel-artifacts"
     state: directory
 
+# Set Variable channel_name
+- name: "Set Variable channel_name"
+  set_fact:
+    channel_name: "{{ sys_channel_name }}"
+  when: add_new_org == 'false' and ('2.2.' in network.version or '1.4.' in network.version)
+
+# Set Variable channel_name
+- name: "Set Variable channel_name"
+  set_fact:
+    channel_name: "{{ item.channel_name | lower }}"
+  when: add_new_org == 'false' and '2.5.' in network.version 
+
 # Remove old genesis block
 - name: Remove old genesis block
   file:
@@ -24,9 +36,9 @@
     {% if '2.5' in network.version %}
     ./configtxgen -profile {{ genesis.name }} -channelID {{ channel_name }} -outputBlock ./channel-artifacts/{{ channel_name }}.genesis.block
     {% elif '2.2' in network.version %}
-    ./configtxgen -profile {{ genesis.name }} -channelID syschannel  -outputBlock ./channel-artifacts/{{ channel_name }}.genesis.block
+    ./configtxgen -profile {{ genesis.name }} -channelID {{ sys_channel_name }}  -outputBlock ./channel-artifacts/{{ channel_name }}.genesis.block
     {% else %}
-    ./configtxgen -profile {{ genesis.name }} -channelID syschannel -outputBlock ./channel-artifacts/{{ channel_name }}.genesis.block
+    ./configtxgen -profile {{ genesis.name }} -channelID {{ sys_channel_name }} -outputBlock ./channel-artifacts/{{ channel_name }}.genesis.block
     {% endif %}
     cat ./channel-artifacts/{{ channel_name }}.genesis.block | base64 > ./channel-artifacts/{{ channel_name }}.genesis.block.base64
   when: add_new_org == 'false'

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/templates/update_channel_script.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/templates/update_channel_script.tpl
@@ -3,9 +3,19 @@
 set -x
 
 CURRENT_DIR=${PWD}
+NETWORK_VERSION="{{ version }}"
 
-echo "installing jq "
-apt-get install -y jq
+if [ "$NETWORK_VERSION" != "2.5.4" ]; then
+    echo "installing jq "
+    . /scripts/package-manager.sh
+    packages_to_install="jq"
+    install_packages "$packages_to_install"
+else
+    echo "installing jq and wget"
+    . /scripts/package-manager.sh
+    packages_to_install="jq wget"
+    install_packages "$packages_to_install"
+fi
 echo "installing configtxlator"
 mkdir temp
 cd temp/
@@ -17,11 +27,16 @@ rm -r temp
 
 configtxlator proto_decode --input {{ channel_name }}_config_block.pb --type common.Block | jq .data.data[0].payload.data.config > {{ channel_name }}_config_block.json
 
-jq -s '.[0] * {"channel_group":{"groups":{"Orderer":{"groups": {"{{ component_name }}MSP":.[1]}}}}}' {{ channel_name }}_config_block.json ./config.json > config1.json
-jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"{{ component_name }}MSP":.[1]}}}}}' config1.json ./config.json > config2.json
-cat config2.json | jq '.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters += ['$(cat ./orderer-tls)']' > config3.json
-cat config3.json | jq '.channel_group.values.OrdererAddresses.value.addresses += ['$(cat ./orderer)'] ' > {{ channel_name }}_modified_config.json
-
+if [ "$NETWORK_VERSION" != "2.5.4" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Orderer":{"groups": {"{{ component_name }}MSP":.[1]}}}}}' {{ channel_name }}_config_block.json ./config.json > config1.json
+    jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"{{ component_name }}MSP":.[1]}}}}}' config1.json ./config.json > config2.json
+    cat config2.json | jq '.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters += ['$(cat ./orderer-tls)']' > config3.json
+    cat config3.json | jq '.channel_group.values.OrdererAddresses.value.addresses += ['$(cat ./orderer)'] ' > {{ channel_name }}_modified_config.json
+else
+    jq -s '.[0] * {"channel_group":{"groups":{"Orderer":{"groups": {"{{ component_name }}MSP":.[1]}}}}}' {{ channel_name }}_config_block.json ./config.json > config1.json
+    cat config1.json | jq '.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters += ['$(cat ./orderer-tls)']' > config2.json
+    cat config2.json | jq '.channel_group.values.OrdererAddresses.value.addresses += ['$(cat ./orderer)'] ' > {{ channel_name }}_modified_config.json
+fi
 echo "converting the channel_config.json and channel_modified_config.json to .pb files"
 configtxlator proto_encode --input {{ channel_name }}_config_block.json --type common.Config --output {{ channel_name }}_config.pb
 configtxlator proto_encode --input {{ channel_name }}_modified_config.json --type common.Config --output {{ channel_name }}_modified_config.pb

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/create_orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/create_orderer.yaml
@@ -77,6 +77,7 @@
     kubernetes: "{{ org.k8s }}"
     ordererAddress: "{{ orderer.ordererAddress }}"
   when: network.env.proxy != 'none'
+
 - name: fetch, modify, sign and copy the configuration block from the blockchain for proxy none
   shell: |
     export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ component_ns }} | grep "cli" | head -n 1 | awk '{print $1}')

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/main.yaml
@@ -5,7 +5,7 @@
 ##############################################################################################
 
 ############################################################################################
-## Adding the New Orderer to the json file that will be used inside the orderer cli
+# Adding the New Orderer to the json file that will be used inside the orderer cli
 - name: "Creating JSON configuration for new organization"
   shell: |
     cd {{ build_path }}

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/nested_main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/tasks/nested_main.yaml
@@ -45,7 +45,7 @@
     then
       echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.name }}.{{ component_ns }}\",\"port\":{{ orderer.grpc.port }},\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name }}-consenter      
     else
-      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.ordererAddress.split(":")[0] | to_json }}\",\"port\":\"{{ orderer.ordererAddress.split(":")[1] | to_json }}\",\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
+      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.ordererAddress.split(":")[0] | to_json }}\",\"port\":{{ orderer.ordererAddress.split(":")[1] | to_json }},\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name }}-consenter 
     fi
   when: update_type == "tls"
 

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/templates/orderer_org.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/templates/orderer_org.tpl
@@ -5,7 +5,10 @@ set -x
 CURRENT_DIR=${PWD}
 
 echo "installing jq "
-apt-get install -y jq
+. /scripts/package-manager.sh
+packages_to_install="jq"
+install_packages "$packages_to_install"
+
 echo "installing configtxlator"
 mkdir temp
 cd temp/

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/templates/syschannel_update_address_script.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/syschannel/templates/syschannel_update_address_script.tpl
@@ -5,7 +5,10 @@ set -x
 CURRENT_DIR=${PWD}
 
 echo "installing jq "
-apt-get install -y jq
+. /scripts/package-manager.sh
+packages_to_install="jq"
+install_packages "$packages_to_install"
+
 echo "installing configtxlator"
 mkdir temp
 cd temp/

--- a/platforms/hyperledger-fabric/configuration/roles/create/orderers/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/orderers/tasks/main.yaml
@@ -8,20 +8,12 @@
 # This role creates value file for zkKafka and orderer
 #############################################################################################
 
-
-
-# Set Variable channel_name
-- name: "Set Variable channel_name"
-  set_fact:
-    channel_name: "{{ network['channels'] | map(attribute='channel_name') | first | lower }}"
-  when: item.type == 'orderer' and ('2.2.' in network.version or '1.4.' in network.version)
-
 # Fetch the genesis block from vault to the build directory
 - name: Fetch the genesis block from vault
   shell: |
-    vault kv get -field={{ network.env.type }}GenesisBlock {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/ordererOrganizations/{{ item.name | lower }}-net > {{ channel_name}}.genesis.block.base64
+    vault kv get -field={{ network.env.type }}GenesisBlock {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/ordererOrganizations/{{ item.name | lower }}-net > {{ sys_channel_name}}.genesis.block.base64
     mkdir -p ./build/channel-artifacts
-    mv {{ channel_name}}.genesis.block.base64 ./build/channel-artifacts/
+    mv {{ sys_channel_name}}.genesis.block.base64 ./build/channel-artifacts/
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -68,7 +60,7 @@
     component_name: "{{ orderer.name }}-{{ org_name }}"
     type: "orderers"
     consensus: "{{component_services.consensus}}"
-    genesis: "{{ lookup('file', '{{ build_path }}/channel-artifacts/{{ channel_name}}.genesis.block.base64') }}"
+    genesis: "{{ lookup('file', '{{ build_path }}/channel-artifacts/{{ sys_channel_name }}.genesis.block.base64') }}"
   loop: "{{ component_services.orderers }}"
   loop_control:
     loop_var: orderer

--- a/platforms/hyperledger-fabric/configuration/roles/delete/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/genesis/tasks/main.yaml
@@ -9,10 +9,21 @@
 #############################################################################################
 
 # Delete BASE 64 encoded genesis blocks for all channels
-- name: Delete genesis block from Vault
+- name: Delete genesis block from Vault for syschannel
   shell: |
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/ordererOrganizations/{{ component_name }}
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/ordererOrganizations/{{ component_name }}/{{ sys_channel_name }}
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"
     VAULT_TOKEN: "{{ item.vault.root_token }}"
   ignore_errors: yes
+
+# Delete genesis block to Vault
+- name: "Delete genesis block to Vault for app channel"  
+  shell: |
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}//{{ item.name | lower }}/ordererOrganizations/{{ component_name }}/{{ channel.channel_name | lower }}
+  environment:
+    VAULT_ADDR: "{{ item.vault.url }}"
+    VAULT_TOKEN: "{{ item.vault.root_token }}"
+  loop: "{{ network['channels'] }}"
+  loop_control:
+    loop_var: channel

--- a/platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -111,17 +111,6 @@
     VAULT_TOKEN: "{{ item.vault.root_token }}"
   ignore_errors: yes
 
-# Delete genesis block to Vault
-- name: "Delete genesis block to Vault"  
-  shell: |
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/ordererOrganizations/{{ component_name }}/{{ channel.channel_name | lower }}
-  environment:
-    VAULT_ADDR: "{{ item.vault.url }}"
-    VAULT_TOKEN: "{{ item.vault.root_token }}"
-  loop: "{{ network['channels'] }}"
-  loop_control:
-    loop_var: channel
-
 # Delete crypto materials from vault
 - name: Delete Crypto for users
   shell: |


### PR DESCRIPTION
**Primary Changes**

1. Fixed deployment add-orderer-organization.yaml playbook for fabric 2.2.2.
2. Added support for deploying add-orderer-organization.yaml playbook for Fabric 2.5.4.
3. Added deletion of genesis file in platforms/hyperledger-fabric/configuration/roles/delete/genesis role.

**Modifications**
platforms/hyperledger-fabric/configuration/add-orderer-organization.yaml 
platforms/hyperledger-fabric/configuration/cleanup.yaml 
platforms/hyperledger-fabric/configuration/deploy-network.yaml 
platforms/hyperledger-fabric/configuration/roles/create/configtx 
platforms/hyperledger-fabric/configuration/roles/create/genesis 
platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org 
platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org 
platforms/hyperledger-fabric/configuration/roles/create/orderers 
platforms/hyperledger-fabric/configuration/roles/delete/genesis 
platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets

fixes #2453