### PR TITLE
chore: Updated kubeconfig configuration in storage class helm chart

### DIFF
--- a/platforms/shared/configuration/roles/setup/storageclass/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/storageclass/tasks/main.yaml
@@ -51,6 +51,7 @@
     values_files:
       - "{{ playbook_dir }}/../../../platforms/shared/configuration/build/{{ sc_name }}-storageclass.yaml"
     force: true
+    kubeconfig: "{{ org.k8s.config_file }}"
   when: storageclass_state.resources|length == 0
   
 #############################################################################################


### PR DESCRIPTION
chore: Added kubeconfig configuration for creating storage class using Helm chart

This commit adds the `kubeconfig` configuration field to the task responsible for creating a storage class using a Helm chart. 

