### PR TITLE
feat(besu): updated  image versions for quorum engineering, besu-node and mysql

### DIFF
--- a/platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
+++ b/platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
@@ -27,8 +27,7 @@ data:
     node-private-key-file={{.Values.node.besu.privateKeyPath | quote }}
 
     # Transaction Pool
-    tx-pool-retention-hours={{ .Values.node.besu.txPool.retentionHours }}
-    tx-pool-max-size={{ .Values.node.besu.txPool.maxSize }}
+    tx-pool-layer-max-capacity={{ .Values.node.besu.txPool.maxCapacity }}
 
     {{ if  .Values.node.besu.p2p.enabled -}}
     # P2P network

--- a/platforms/hyperledger-besu/charts/besu-node/values.yaml
+++ b/platforms/hyperledger-besu/charts/besu-node/values.yaml
@@ -49,7 +49,7 @@ image:
   pullPolicy: IfNotPresent
   besu:
     repository: hyperledger/besu
-    tag: 22.10.2
+    tag: 23.10.2
   hooks:
     repository: ghcr.io/hyperledger/bevel-k8s-hooks
     tag: qgt-0.2.12
@@ -104,8 +104,7 @@ node:
       port: 8547
       corsOrigins: '["all"]'
     txPool:
-      retentionHours: 999
-      maxSize: 1024
+      maxCapacity: 12
     http:
       allowlist: '["*"]'
     metrics:

--- a/platforms/hyperledger-besu/charts/besu-tessera-node/values.yaml
+++ b/platforms/hyperledger-besu/charts/besu-tessera-node/values.yaml
@@ -50,13 +50,13 @@ image:
   #Eg. tessera: quorumengineering/tessera:0.9.2
   tessera: 
     repository: quorumengineering/tessera
-    tag: 22.1.7
+    tag: 23.4.0
   #Provide the valid image name and version for busybox
   busybox: busybox
   #Provide the valid image name and version for MySQL. This is used as the DB for TM
   mysql: 
     repository: mysql/mysql-server
-    tag: 5.7
+    tag: 8.0.32
   hooks:
     repository: ghcr.io/hyperledger/bevel-k8s-hooks
     tag: qgt-0.2.12


### PR DESCRIPTION
Changes:

Updated image versions as follows:
Tessera: from 22.1.7 to 23.4.0
MySQL: from 5.7 to 8.0.32
Besu Node: from 22.10.2 to 23.10.2

Files changed:

platforms/hyperledger-besu/charts/besu-tessera-node/values.yaml
platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
platforms/hyperledger-besu/charts/besu-node/values.yaml
   