### PR TITLE
[substrate] enable platform deployment via ansible server

### DIFF
--- a/docs/source/guides/networkyaml-substrate.md
+++ b/docs/source/guides/networkyaml-substrate.md
@@ -3,8 +3,8 @@
 [//]: # (SPDX-License-Identifier: Apache-2.0)
 [//]: # (##############################################################################################)
 
-# Configuration file specification: Substrate
-A `network.yaml` file is the base configuration file designed in Hyperledger Bevel for setting up a Substrate DLT network. This file contains all the configurations related to the network that has to be deployed. 
+# `Configuration file specification: Substrate`
+A `network.yaml` file is the base configuration file designed in Hyperledger Bevel for setting up a Substrate DLT network. This file contains all the configurations related to the network that has to be deployed. Below shows its structure. ![](./../_static/TopLevelClass-Substrate.png)
 
 ??? note "Schema Definition"
 
@@ -28,38 +28,41 @@ The configurations are grouped in the following sections for better understandin
 
 Before setting up a Substrate DLT/Blockchain network, this file needs to be updated with the required specifications.  
 
-Use this [sample configuration file](https://github.com/hyperledger/bevel/blob/main/platforms/substrate/configuration/samples/network-sample.yaml) as a base. 
+Use this [sample configuration file](https://github.com/hyperledger/bevel/blob/main/platforms/substrate/configuration/samples/substrate-network-config.yaml) as a base. 
 
 
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:7:15"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:7:15"
 ```
 
-The sections in the sample configuration file are  
+**The sections in the sample configuration file are**: 
 
 <a name="type"></a>
-type
-: `type` defines the platform choice like corda/fabric/indy/substrate, here in the example its **substrate**.
+
+## type
+- `type` defines the platform choice like corda/fabric/indy/substrate, here in the example its **substrate**.
 
 <a name="version"></a>
-version
-: `version` defines the version of platform being used. The current substrate version support is for **latest**
+
+## version
+- `version` defines the version of platform being used. The current substrate version support is for **latest**
 
 <a name="env"></a>
-env
-: `env` section contains the environment type and additional (other than 443) Ambassador port configuration. Value for proxy field under this section can only be Ambassador as haproxy has not been implemented for substrate.
+
+## env
+- `env` section contains the environment type and additional (other than 443) Ambassador port configuration. Value for proxy field under this section can only be Ambassador as haproxy has not been implemented for substrate.
 
 The snapshot of the `env` section with example value is below
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:18:30"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:18:30"
 ```
 
-The fields under `env` section are 
+**The fields under `env` section are**:
 
-| Field      | Description                                 |
-|------------|---------------------------------------------|
+| **Field**      | **Description**                                 |
+|------------    |---------------------------------------------|
 | type       | Environment type. Can be like dev/test/prod.|
-| proxy      | Choice of the Cluster Ingress controller. Currently supports 'ambassador' only as 'haproxy' has not been implemented for Substrate |
+| proxy     | Choice of the Cluster Ingress controller. Currently supports 'ambassador' only as 'haproxy' has not been implemented for Substrate |
 | proxy_namespace      | Namespace in which the pods of the Cluster Ingress controller were deployed |
 | ambassadorPorts   | Any additional Ambassador ports can be given here. This is only valid if `proxy: ambassador`. These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports to be opened on Ambassador. Our sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified in the `organization` section.     |
 | retry_count       | Retry count for the checks. Use a high number if your cluster is slow. |
@@ -67,38 +70,40 @@ The fields under `env` section are
 
 
 <a name="docker"></a>
-docker
-: `docker` section contains the credentials of the repository where all the required images are built and stored.
+
+## docker
+- `docker` section contains the credentials of the repository where all the required images are built and stored.
 
 The snapshot of the `docker` section with example values is below
 
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:32:38"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:32:38"
 ```
 
-The fields under `docker` section are
+**The fields under `docker` section are**:
 
-| Field    | Description                            |
+| **Field**| **Description**                        |
 |----------|----------------------------------------|
 | url      | Docker registry url                    |
 | username | Username required for login to docker registry (remove this for public registry)|
 | password | Password required for login to docker registry (remove this for public registry)|
 
 <a name="config"></a>
-config
-: `config` section contains the common configurations for the Substrate network.
+
+## config
+- `config` section contains the common configurations for the Substrate network.
 
 The snapshot of the `config` section with example values is below
 
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:40:55"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:40:55"
 ```
 
-The fields under `config` are
+**The fields under `config` are**:
 
-| Field       | Description                                              |
+| **Field**   | **Description**                                              |
 |-------------|----------------------------------------------------------|
-| subject     | This is the subject of the root CA which will be created for the Substrate network. The root CA is for development purposes only, production networks should already have the root certificates.   |
+| subject    | This is the subject of the root CA which will be created for the Substrate network. The root CA is for development purposes only, production networks should already have the root certificates.   |
 | node_image | This is image name in which will be pulled from the specified docker registry. |
 | command | This is the command which will run on the substrate node once it is alive.|
 | chain | This is the name of the chain which is used for the substrate nodes and genesis.|
@@ -108,96 +113,95 @@ The fields under `config` are
 
 
 <a name="organizations"></a>
-organizations
-: The `organizations` section contains the specifications of each organization.  
- 
-In the sample configuration example, we have four organization under the `organizations` section.
 
-The snapshot of an organization field with sample values is below
-```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:57:65"
-```
+## Organizations
 
-Each `organization` under the `organizations` section has the following fields. 
+- The `organizations` section contains the specifications for the organization.
 
-| Field                                    | Description                                 |
-|------------------------------------------|-----------------------------------------------------|
-| name                                        | Name of the organization     |
-| type                                        | Specifies the organization as the superuser/owner.    |
-| persona                         | This is used for DSCP app and can be buyer, supplier or thirdparty.    |
-| external_url_suffix                         | Public url suffix of the cluster.         |
-| cloud_provider                              | Cloud provider of the Kubernetes cluster for this organization. This field can be aws, azure, gcp or minikube |
-| aws                                         | When the organization cluster is on AWS |
-| k8s                                         | Kubernetes cluster deployment variables.|
-| vault                                       | Contains Hashicorp Vault server address and root-token in the example |
-| gitops                                      | Git Repo details which will be used by GitOps/Flux. |
-| services                                    | Contains list of services which could ca/peer/orderers/concensus based on the type of organization |
+- In the sample configuration example, we have and support only one organization under the `organizations` section.
+
+### Organization Field Snapshot with Sample Values:
+
+The `organization` under the `organizations` section has the following fields. 
+
+| **Field**            | **Description** |
+|----------------------|-------------|
+| name                 | Name of the organization |
+| type                 | Specifies the organization as the superuser/owner. |
+| persona              | This is used for DSCP app and can be buyer, supplier or thirdparty. |
+| external_url_suffix  | Public url suffix of the cluster. |
+| cloud_provider  | Cloud provider of the Kubernetes cluster for this organization. This field can be `aws`, `azure`, `gcp` or `minikube` |
+| aws                  | When the organization cluster is on `AWS` |
+| k8s                  | Kubernetes cluster deployment variables.|
+| vault                | Contains Hashicorp Vault server address and root-token in the example |
+| gitops               | Git Repo details which will be used by GitOps/Flux. |
+| services             | Contains list of services which could ca/peer/orderers/concensus based on the type of organization |
 
 For the `aws`, `k8s` and `vault` field the snapshot with sample values is below
 
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:66:80"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:66:80"
 ```
 
-The `aws` field under each organization contains: (This will be ignored if cloud_provider is not `aws`)
+**The `aws` field under each organization contains**:
 
-| Field       | Description                                              |
-|-------------|----------------------------------------------------------|
-| access_key                              | AWS Access key  |
-| secret_key                              | AWS Secret key  |
+> NOTE: This will be ignored if cloud_provider is not `aws`
 
-The `k8s` field under each organization contains
+| **Field**     | **Description** |
+|-------------  |-----------------|
+|  access_key   | AWS Access key  |
+|  secret_key   | AWS Secret key  |
 
-| Field       | Description                                              |
-|-------------|----------------------------------------------------------|
-| context                                 | Context/Name of the cluster where the organization entities should be deployed  |
-| config_file                             | Path to the kubernetes cluster configuration file  |
+**The `k8s` field under each organization contains**:
 
-The `vault` field under each organization contains
+| **Field**       | **Description**                                                                 |
+|-------------    |----------------------------------------------------------                       |
+| context         | Context/Name of the cluster where the organization entities should be deployed  |
+| config_file     | Path to the kubernetes cluster configuration file                               |
 
-| Field       | Description                                              |
-|-------------|----------------------------------------------------------|
-| url                                 | url of the vault server including port  |
-| root_token                             | root token of the vault server required to access the contents of the vault    |
-| secret_path                             | the path in which secrets are stored, used to store and retrieve secrets from the vault   |
+**The `vault` field under each organization contains**:
+
+| **Field**     | **Description**                                              |
+|-------------  |----------------------------------------------------------|
+| url           | url of the vault server including port  |
+| root_token    | root token of the vault server required to access the contents of the vault    |
+| secret_path   | the path in which secrets are stored, used to store and retrieve secrets from the vault   |
 
 For gitops fields the snapshot from the sample configuration file with the example values is below
 
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:84:96"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:84:96"
 ```
 
-The gitops field under each organization contains
+**The gitops field under each organization contains**: 
 
-| Field       | Description                                              |
-|-------------|----------------------------------------------------------|
-| git_protocol | Option for git over https or ssh. Can be `https` or `ssh` |
-| git_url                              | SSH or HTTPs url of the repository where flux should be synced                                                            |
-| branch                               | Branch of the repository where the Helm Charts and value files are stored                                        |
-| release_dir                          | Relative path where flux should sync files                                                                       |
-| chart_source                         | Relative path where the helm charts are stored                                                                   |
-| git_repo                         | Gitops git repo URL https URL for git push like "github.com/hyperledger/bevel.git"             |
-| username                             | Username which has access rights to read/write on repository                                                     |
-| password                             | Password of the user which has access rights to read/write on repository (Optional for ssh; Required for https) |
-| email                                | Email of the user to be used in git config                                                                       |
-| private_key                          | Path to the private key file which has write-access to the git repo (Optional for https; Required for ssh) |
+| **Field**       | **Description**                                              |
+|-------------    |----------------------------------------------------------|
+| git_protocol    | Option for git over https or ssh. Can be `https` or `ssh` |
+| git_url         | SSH or HTTPs url of the repository where flux should be synced |
+| branch          | Branch of the repository where the Helm Charts and value files are stored |
+| release_dir     | Relative path where flux should sync files |
+| chart_source    | Relative path where the helm charts are stored |
+| git_repo        | Gitops git repo URL https URL for git push like "github.com/hyperledger/bevel.git" |
+| username        | Username which has access rights to read/write on repository |
+| password        | Password of the user which has access rights to read/write on repository (Optional for ssh; Required for https) |
+| email           | Email of the user to be used in git config |
+| private_key     | Path to the private key file which has write-access to the git repo (Optional for https; Required for ssh) |
 
-The services field for each organization under `organizations` section of Substrate contains list of `services`.
-
-Each organization will have a services section which includes details of all the peers, all participating nodes are names as peers. The snapshot of peers service with example values is below
+Within the organizations section, there is one listed organization. This organization contains a services section that provides details for all peers, where each participating node is named as a peer. Below is a snapshot of the peers service with example values:
 
 ```yaml
---8<-- "platforms/substrate/configuration/samples/network-sample.yaml:98:177"
+--8<-- "platforms/substrate/configuration/samples/substrate-network-config.yaml:98:173"
 ```
 
 The fields under `peer` are
 
-| Field       | Description                                              |
-|-------------|----------------------------------------------------------|
-| name            | Name of the peer                |
-| subject     | This is the alternative identity of the peer node    |
-| type           | Type can be `bootnode`, `validator`, `ipfs-bootnode` or `member` |
-| p2p.port   | P2P port |
-| p2p.ambassador | The P2P Port when exposed on ambassador service|
-| rpc.port   | RPC port |
-| ws.port | WebSocket port |
+| **Field**         | **Description**                                              |
+|-------------      |----------------------------------------------------------|
+| name              | Name of the peer                |
+| subject           | This is the alternative identity of the peer node    |
+| type              | Type can be `bootnode`, `validator` or `member` |
+| p2p.port          | P2P port |
+| p2p.ambassador    | The P2P Port when exposed on ambassador service|
+| rpc.port          | RPC port |
+| ws.port           | WebSocket port |

--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -1296,6 +1296,9 @@
         },
         "apiPort": {
           "type": "number"
+        },
+        "enabled": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/platforms/shared/configuration/roles/setup/edge-stack/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/edge-stack/tasks/main.yaml
@@ -47,7 +47,7 @@
 - name: Create custom values for aes helm chart
   vars:
     ports: "{{ network.env.ambassadorPorts.ports | default([]) }}"
-    elastic_ip: "{{ allocation_ips_stdout | default(item.publicIps[0]) }}"
+    elastic_ip: "{{ allocation_ips_stdout | default(item.publicIps[0] | default('')) }}"
     lbSourceRangeDefault:
       - 0.0.0.0/0
     loadBalancerSourceRanges: "{{ network.env.loadBalancerSourceRanges | default(lbSourceRangeDefault) }}"

--- a/platforms/substrate/charts/dscp-ipfs-node/Chart.yaml
+++ b/platforms/substrate/charts/dscp-ipfs-node/Chart.yaml
@@ -2,7 +2,9 @@
 #  This Chart is a fork from https://github.com/digicatapult/helm-charts/tree/main/charts/dscp-ipfs
 #  Please update if needed
 ##############################################################################################
-apiVersion: v1
+
+---
+apiVersion: v2
 name: dscp-ipfs-node
 appVersion: '2.6.1'
 description: dscp-ipfs is a component of the DSCP project that provides a distributed IPFS based storage solution for the DSCP platform.

--- a/platforms/substrate/charts/dscp-ipfs-node/requirements.yaml
+++ b/platforms/substrate/charts/dscp-ipfs-node/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: 4.x.x
     condition: dscpNode.enabled
   - name: bevel-storageclass
-    alias: storage
+    alias: substrate-storage
     repository: "file://../../../shared/charts/bevel-storageclass"
     tags:
       - storage

--- a/platforms/substrate/charts/dscp-ipfs-node/templates/secret.yaml
+++ b/platforms/substrate/charts/dscp-ipfs-node/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dscp-ipfs.fullname" . }}-secret
+  name: "substrate-node-{{ include "dscp-ipfs.fullname" . }}-keys"
   labels:
     {{- include "dscp-ipfs.labels" . | nindent 4 }}
 {{- if and .Values.config.publicKey .Values.config.privateKey }}

--- a/platforms/substrate/charts/dscp-ipfs-node/templates/statefulset.yaml
+++ b/platforms/substrate/charts/dscp-ipfs-node/templates/statefulset.yaml
@@ -169,7 +169,7 @@ spec:
                 jq -r 'if .errors then . else .auth.client_token end')
 
               validateVaultResponse 'vault login token' "${VAULT_CLIENT_TOKEN}"
-              vault_secret_key="${VAULT_SECRET_ENGINE}"/"${VAULT_SECRET_PREFIX}/ipfs"
+              vault_secret_key="${VAULT_SECRET_ENGINE}"/"${VAULT_SECRET_PREFIX}-ipfs-keys"
               # Save the generated keys to VAULT
               LOOKUP_SECRET_RESPONSE=$(curl -sS -H "X-Vault-Token: ${VAULT_CLIENT_TOKEN}" \
                 -H "Content-Type: application/json" \
@@ -263,7 +263,7 @@ spec:
       spec:
         accessModes: [ "ReadWriteOnce" ]
         {{- if .Values.storage.storageClass }}
-        storageClassName: storage-{{ .Release.Name }}
+        storageClassName: substrate-storage-{{ .Release.Name }}
         {{- end }}
         resources:
           requests:

--- a/platforms/substrate/charts/substrate-genesis/Chart.yaml
+++ b/platforms/substrate/charts/substrate-genesis/Chart.yaml
@@ -3,7 +3,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
-apiVersion: v1
+
+---
+apiVersion: v2
 name: substrate-genesis
 description: A Helm chart to generate the genesis for Substrate Nodes
 type: application

--- a/platforms/substrate/charts/substrate-genesis/templates/generate-keys.yaml
+++ b/platforms/substrate/charts/substrate-genesis/templates/generate-keys.yaml
@@ -16,6 +16,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
+    app: genesis
     app.kubernetes.io/name: pre-install-hook
     app.kubernetes.io/component: keygen
     app.kubernetes.io/namespace: {{ .Release.Namespace }}

--- a/platforms/substrate/charts/substrate-genesis/templates/genesis.yaml
+++ b/platforms/substrate/charts/substrate-genesis/templates/genesis.yaml
@@ -15,6 +15,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
+    app: genesis
     app: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -201,9 +202,10 @@ spec:
           # Initialize the token
           . /scripts/bevel-vault.sh
           vaultBevelFunc "init"
+          
           vault_secret_key="${VAULT_SECRET_ENGINE}/${VAULT_SECRET_PREFIX}/genesis"
           vaultBevelFunc "readJson" "$vault_secret_key"
-
+          
           # The vault CLI is required for this job as the genesis file is too large to be passed in via a vault API call
           echo "Installing Vault CLI"
           curl -O -L https://releases.hashicorp.com/vault/1.7.1/vault_1.7.1_linux_amd64.zip

--- a/platforms/substrate/charts/substrate-node/Chart.yaml
+++ b/platforms/substrate/charts/substrate-node/Chart.yaml
@@ -2,9 +2,26 @@
 #  This Chart is a fork from https://github.com/paritytech/helm-charts
 #  Please update if needed
 ##############################################################################################
-apiVersion: v1
+
+---
+apiVersion: v2 
 name: substrate-node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 1.2.0
-appVersion: "0.0.1"
+version: 1.0.0
+appVersion: latest
+keywords:
+  - bevel
+  - ethereum
+  - substrate
+  - hyperledger
+  - enterprise
+  - blockchain
+  - deployment
+  - accenture
+home: https://hyperledger-bevel.readthedocs.io/en/latest/
+sources:
+  - https://github.com/hyperledger/bevel
+maintainers:
+  - name: Hyperledger Bevel maintainers
+    email: bevel@lists.hyperledger.org

--- a/platforms/substrate/charts/substrate-node/requirements.yaml
+++ b/platforms/substrate/charts/substrate-node/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: bevel-storageclass
-    alias: storage
+    alias: substrate-storage
     repository: "file://../../../shared/charts/bevel-storageclass"
     tags:
       - storage

--- a/platforms/substrate/charts/substrate-node/templates/_helpers.tpl
+++ b/platforms/substrate/charts/substrate-node/templates/_helpers.tpl
@@ -50,6 +50,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "node.selectorLabels" -}}
+name: {{ include "node.name" . }}
 app.kubernetes.io/name: {{ include "node.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/platforms/substrate/charts/substrate-node/templates/statefulset.yaml
+++ b/platforms/substrate/charts/substrate-node/templates/statefulset.yaml
@@ -198,25 +198,21 @@ spec:
 
             #!/bin/sh
 
-              # STEP-1
               echo "Step 1: Install necessary packages using custom package manager script"
               . /scripts/package-manager.sh
               packages_to_install="jq curl"
               install_packages "$packages_to_install"
 
-              # STEP-2
               echo "STEP-2: Download and set up kubectl for Kubernetes management"
               curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
               chmod +x kubectl
               mv kubectl /usr/local/bin/
               kubectl version --client
 
-              # STEP-3
               echo "Step 3: Extract chain specification (genesis) from Kubernetes ConfigMap and store it"
               chain_spec=$(kubectl get configmap "substrate-genesis" --namespace {{ .Release.Namespace }} -o json | jq -r '.data["genesis"]')
               echo "${chain_spec}" | base64 -d > {{ .Values.node.customChainspecPath }}
 
-              # STEP-4
               echo "Step 4: Retrieve secret keys from Kubernetes Secrets if available"
               secretName="substrate-node-{{ .Release.Name }}-keys"
               if kubectl get secret "${secretName}" --namespace {{ .Release.Namespace }} >/dev/null 2>&1; then
@@ -233,14 +229,12 @@ spec:
                 BOOTNODE_ID=$(kubectl get secret "substrate-node-{{ .Values.node.isBootnode.bootnodeName }}-keys" --namespace {{ .Release.Namespace }} -o json | jq -r '.data["substrate-node-keys"]' | base64 -d | jq -r '.data.node_id')
               {{- end }}
 
-              # STEP-5
               echo "Step 5: Insert keys into Keystore using dscp-node command-line tool"
               # Insert AURA key into Keystore
               ./{{ .Values.node.command }} key insert --base-path=/data --chain=/data/chainspec.json --key-type=aura --scheme=Sr25519 --suri="${AURA_SECRETPHRASE}" && echo "Inserted key aura into Keystore" || echo "Failed to insert key aura into Keystore."
               # Insert GRANPA key into Keystore
               ./{{ .Values.node.command }} key insert --base-path=/data --chain=/data/chainspec.json --key-type=gran --scheme=Ed25519 --suri="${GRAN_SECRETPHRASE}" && echo "Inserted key gran into Keystore" || echo "Failed to insert key gran into Keystore."
 
-              # STEP-6
               echo "Step 6: Determine various ports and external addresses for P2P communication"
               POD_INDEX="${HOSTNAME##*-}"
               {{- if and (.Values.node.perNodeServices.createP2pService) (eq .Values.node.perNodeServices.p2pServiceType "NodePort") }}
@@ -259,21 +253,14 @@ spec:
                 EXTERNAL_ADDRESS=$(curl -sS {{ .Values.node.perNodeServices.setPublicAddressToExternal.ipRetrievalServiceUrl }})
               {{- else if and .Values.node.perNodeServices.setPublicAddressToExternal.enabled (eq .Values.node.perNodeServices.p2pServiceType "LoadBalancer") }}
                 EXTERNAL_ADDRESS=$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-rc-p2p -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-              {{- else if eq .Values.node.perNodeServices.p2pServiceType "ClusterIP" }}
-                EXTERNAL_ADDRESS={{ $fullname }}-${POD_INDEX}-rc-p2p.{{ .Release.Namespace }}.svc.cluster.local
-                EXTERNAL_P2P_PORT="{{ .Values.node.ports.p2p }}"
               {{- else if eq .Values.proxy.provider "ambassador" }}
                 EXTERNAL_ADDRESS="{{ $fullname }}-${POD_INDEX}.{{ .Values.proxy.external_url }}"
                 EXTERNAL_P2P_PORT="{{ .Values.proxy.p2p }}"
-                echo "test-one"
+              {{- else if eq .Values.node.perNodeServices.p2pServiceType "ClusterIP" }}
+                EXTERNAL_ADDRESS={{ $fullname }}-${POD_INDEX}-rc-p2p.{{ .Release.Namespace }}.svc.cluster.local
+                EXTERNAL_P2P_PORT="{{ .Values.node.ports.p2p }}"
               {{- end }}
 
-              echo "PARA_CHAIN_P2P_PORT:$PARA_CHAIN_P2P_PORT"
-              echo "RELAY_CHAIN_P2P_PORT:$RELAY_CHAIN_P2P_PORT"
-              echo "EXTERNAL_ADDRESS:$EXTERNAL_ADDRESS"
-              echo "EXTERNAL_P2P_PORT:$EXTERNAL_P2P_PORT"
-
-              # STEP-7
               echo "Step 7: Start the node"
               exec {{ .Values.node.command }} \
               --name=${POD_NAME} \
@@ -475,7 +462,7 @@ spec:
           kind: VolumeSnapshot
           apiGroup: snapshot.storage.k8s.io
         {{- end }}
-        storageClassName: storage-{{ .Release.Name }}
+        storageClassName: substrate-storage-{{ .Release.Name }}
         resources:
           requests:
             storage: {{ .Values.storage.size }}

--- a/platforms/substrate/configuration/deploy-network.yaml
+++ b/platforms/substrate/configuration/deploy-network.yaml
@@ -1,20 +1,21 @@
 ##############################################################################################
-#  Copyright Accenture. All Rights Reserved.
+# Copyright Accenture. All Rights Reserved.
 #
-#  SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
 
 ##############################################################################################
-# This playbook deploys a DLT network on existing Kubernetes clusters
-# The Kubernetes clusters should already be created and the infomation to connect to the
-#  clusters be updated in the network.yaml file that is used as an input to this playbook
+# This Ansible playbook deploys a Distributed Ledger Technology (DLT) network on existing 
+# Kubernetes clusters. The Kubernetes clusters must already be provisioned, and the necessary 
+# connection information should be updated in the `network.yaml` file, which serves as input 
+# for this playbook.
 ##############################################################################################
 
 ##############################################################################################
-# To Run this playbook from this directory, use the following command (network.yaml also in this directory)
-#  ansible-playbook deploy-network.yaml -e "@./network.yaml"
+# Usage:
+# To execute this playbook from the current directory, use the following command:
+# ansible-playbook deploy-network.yaml -e "@./network.yaml"
 ##############################################################################################
-
 
 # Please ensure that the ../../shared/configuration playbooks have been run using the same network.yaml
 - hosts: ansible_provisioners
@@ -27,7 +28,7 @@
       path: "./build"
       state: absent
 
-  # Create namespace
+  # Create Kubernetes namespaces for each organization
   - name: "Create namespace"
     include_role: 
       name: create/namespace
@@ -38,46 +39,19 @@
       gitops: "{{ item.gitops }}"
     loop: "{{ network['organizations'] }}"
 
-  # Create Storageclass
-  - name: Create Storage Class
+  # Create necessary Kubernetes secrets for each organization
+  - name: "Create k8s secrets"
     include_role:
-      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"
+      name: create/secrets
     vars:
-      sc_name: "{{ org.name | lower }}-bevel-storageclass"
-      region: "{{ org.k8s.region | default('eu-west-1') }}"
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-        loop_var: org
-
-  # Setup script for Vault and OS Package Manager
-  - name: "Setup script for Vault and OS Package Manager"
-    include_role:
-      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
-    vars:
-      namespace: "{{ org.name | lower }}-subs"
-      kubernetes: "{{ org.k8s }}"
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-
-  # Setup Vault-Kubernetes accesses and Regcred for docker registry
-  - name: "Setup vault"   
-    include_role: 
-      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault_kubernetes"
-    vars:
-      name: "{{ org.name | lower }}"
       component_ns: "{{ org.name | lower }}-subs"
-      component_name: "{{ org.name | lower }}-vaultk8s-job"
-      component_auth: "{{ network.env.type }}{{ name }}"
-      component_type: "organization"
       kubernetes: "{{ org.k8s }}"
       vault: "{{ org.vault }}"
-      gitops: "{{ org.gitops }}"
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: org
 
-  # Generate Ambassador certificate for nodes
+  # Generate Ambassador certificates for nodes (if using Ambassador as proxy)
   - name: "Create ambassador certificates for Nodes" 
     include_role: 
       name: create/certificates/ambassador
@@ -93,51 +67,13 @@
     loop: "{{ network['organizations']}}"
     when: network.env.proxy == "ambassador"
 
-  # Generate the key materials and stores them in vault
-  - name: "Generate key materials for Nodes"
+  # Generate Genesis file that will contain the record of all nodes
+  - name: "Generate Genesis"
     include_role:
-      name: create/keys
-    vars:
-      name: "{{ item.name | lower }}"        
-      component_name: "{{ item.name | lower }}"
-      component_ns: "{{ item.name | lower }}-subs"
-      vault: "{{ item.vault }}"
-      peers: "{{ item.services.peers }}"
-      charts_dir: "{{ item.gitops.chart_source }}"
-      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
-      org: "{{ item }}"
-      gitops: "{{ item.gitops }}"
-      kubernetes: "{{ item.k8s }}"
-    loop: "{{ network['organizations'] }}"
+      name: create/generate_genesis
 
-  # Generate the genesis.json for all orgs of the network
-  - name: "Generate genesis for the network"
-    include_role:
-      name: create/genesis
-    vars:
-      build_path: "./build"
-      sudo_org_query: "organizations[?type=='superuser']"
-      org: "{{ network | json_query(sudo_org_query) | first }}"
-
-  # Deploy Substrate bootnodes
-  - name: "Deploy Bootnodes"
-    include_role:
-      name: create/bootnode
-    vars:
-      build_path: "./build"
-      kubernetes: "{{ item.k8s }}"
-      component_ns: "{{ item.name | lower }}-subs"
-      name: "{{ item.name | lower }}"
-      peers: "{{ item.services.peers }}"
-    loop: "{{ network['organizations'] }}"
-
-  # Generate the bootnode list file
-  - name: "Generate bootnode file list for the network"
-    include_role:
-      name: create/bootnodefile
-
-  # Deploy Substrate validator nodes
-  - name: "Deploy Substrate validators"
+  # Deploy Bootnodes or Validator nodes
+  - name: "Deploy Bootnode or Validator nodes"
     include_role:
       name: create/validator_node
     vars:
@@ -148,32 +84,8 @@
       peers: "{{ item.services.peers }}"
     loop: "{{ network['organizations'] }}"
 
-  # Deploy ipfs bootnodes
-  - name: "Deploy ipfs bootnodes"
-    include_role: 
-      name: create/ipfs_bootnode
-    vars:
-      build_path: "./build"
-      charts_dir: "{{ item.gitops.chart_source }}"
-      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
-      org: "{{ item }}"
-      vault: "{{ item.vault }}"
-      peers: "{{ item.services.peers }}"
-      gitops: "{{ item.gitops }}"
-      component_name: "{{ item.name | lower }}"
-      component_ns: "{{ item.name | lower }}-subs"
-      name: "{{ item.name | lower }}"
-    loop: "{{ network['organizations'] }}"
-    when: network.config.node_image == "inteli-poc/dscp-node"
-
-  # Generate the ipfsbootnode list file
-  - name: "Generate ipfsbootnode file list for the network"
-    include_role:
-      name: create/ipfsbootnodefile
-    when: network.config.node_image == "inteli-poc/dscp-node"
-
-  # Deploy Substrate member nodes
-  - name: "Deploy Substrate members"
+  # Deploy Member nodes, including IPFS node if enabled
+  - name: "Deploy Member nodes, including IPFS node if enabled"
     include_role:
       name: create/member_node
     vars:
@@ -184,7 +96,7 @@
       name: "{{ item.name | lower }}"
       peers: "{{ item.services.peers }}"
     loop: "{{ network['organizations'] }}"
-  
+
   # These variables can be overriden from the command line
   vars:
     install_os: "linux"           # Default to linux OS

--- a/platforms/substrate/configuration/roles/create/certificates/ambassador/tasks/main.yaml
+++ b/platforms/substrate/configuration/roles/create/certificates/ambassador/tasks/main.yaml
@@ -11,12 +11,13 @@
 ##############################################################################################
 
 ---
-# check if ambassadortls dir is there
+# Check if Ambassador TLS directory exists
 - name: "check if dir exists or not"
   stat:
     path: "{{ ambassadortls }}"
   register: ambassadortlsdir_check
 
+# Ensure Ambassador TLS directory exists
 - name: Ensure ambassador tls dir exists
   include_role: 
     name: "{{ playbook_dir }}/../../shared/configuration/roles/check/directory"
@@ -24,47 +25,25 @@
     path: "{{ ambassadortls }}"
   when: not ambassadortlsdir_check.stat.exists
 
-# Check ambassador tls certs already created
-- name: Check if ambassador tls already created
-  shell: |
-    vault kv get -field=tlscacerts {{ vault.secret_path | default('secretsv2') }}/{{ organisation }}/tlscerts
-  environment:
-    VAULT_ADDR: "{{ vault.url }}"
-    VAULT_TOKEN: "{{ vault.root_token }}"
-  register: ambassador_tls_certs
-  ignore_errors: yes
-  tags:
-  - notest
+# Check if Ambassador credentials secret already exists
+- name: Check Ambassador cred exists
+  k8s_info:
+    kind: Secret
+    namespace: "{{ component_ns }}"
+    name: "{{ component_name }}-ambassador-certs"
+    kubeconfig: "{{ kubernetes.config_file }}"
+    context: "{{ kubernetes.context }}"
+  register: get_ambassador_secret
 
-# Gets the existing ambassador tls certs
-- name: Get ambassador and tls certs from Vault
-  shell: |
-    vault kv get -format=yaml {{ vault.secret_path | default('secretsv2') }}/{{ organisation }}/tlscerts
-  environment:
-    VAULT_ADDR: "{{ vault.url }}"
-    VAULT_TOKEN: "{{ vault.root_token }}"
-  register: ambassador_tls_certs_yaml
-  when: not ambassador_tls_certs.failed
-
-# Get ambassador tls certs
-- name: Get ambassador tls certs
-  include_role: 
-    name: "setup/get_crypto"
-  vars:
-    vault_output: "{{ ambassador_tls_certs_yaml.stdout | from_yaml }}"
-    type: "ambassador"
-    cert_path: "{{ ambassadortls }}"
-  when: ambassador_tls_certs.failed == False
-
-
-# check if ambassadortls dir is there
+# Check OpenSSL configuration file exists for Ambassador TLS if Ambassador secret does not exist
 - name: "check if openssl conf file exists or not"
   stat:
     path: "./build/openssl{{ component_name }}.conf"
   register: openssl_conf_check
+  when: get_ambassador_secret.resources|length == 0
 
-# Generates the openssl file for domain
-- name: Generate openssl conf file
+# Generate OpenSSL configuration file for domain if Ambassador secret does not exist
+- name: Generate OpenSSL conf file
   shell: |
     cd ./build
     cat <<EOF >openssl{{ component_name }}.conf
@@ -86,44 +65,32 @@
     domain_name: "{{ component_name }}.{{ item.external_url_suffix }}"
     domain_name_api: "{{ component_name }}api.{{ item.external_url_suffix }}"
     domain_name_web: "{{ component_name }}web.{{ item.external_url_suffix }}"   
-  when: ambassador_tls_certs.failed == True  and (not openssl_conf_check.stat.exists)
+  when: get_ambassador_secret.resources|length == 0
 
-# Generates the ambassador tls certificates if already not generated
-- name: Generate ambassador tls certs
+# Generate Ambassador TLS certificates if Ambassador secret does not exist
+- name: Generate Ambassador TLS certs
   shell: |
     openssl req -x509 -out {{ ambassadortls }}/ambassador.crt -keyout {{ ambassadortls }}/ambassador.key -newkey rsa:2048 -nodes -sha256 -subj "/CN={{ domain_name }}" -extensions EXT -config "{{playbook_dir}}/build/openssl{{ component_name }}.conf" 
   vars:
     domain_name: "{{ component_name }}.{{ item.external_url_suffix }}"
-  when: ambassador_tls_certs.failed == True and (not openssl_conf_check.stat.exists)
+  when: get_ambassador_secret.resources|length == 0
 
-# Stores the genreated ambassador tls certificates to vault
-- name: Putting tls certs to vault
+# Store the generated Ambassador TLS certificates in Vault if Ambassador secret does not exist
+- name: Putting TLS certs to vault
   shell: |
-    vault kv put {{ vault.secret_path | default('secretsv2') }}/{{ organisation }}/tlscerts tlscacerts="$(cat {{ ambassadortls }}/ambassador.crt | base64)" tlskey="$(cat {{ ambassadortls }}/ambassador.key | base64)"
+    vault kv put {{ vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ organisation }}/tlscerts tlscacerts="$(cat {{ ambassadortls }}/ambassador.crt | base64)" tlskey="$(cat {{ ambassadortls }}/ambassador.key | base64)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
-  when: ambassador_tls_certs.failed == True
-  tags:
-  - notest  
+  when: get_ambassador_secret.resources|length == 0
 
-# Check if Ambassador credentials exist already
-- name: Check Ambassador cred exists
-  k8s_info:
-    kind: Secret
-    namespace: "{{ component_ns }}"
-    name: "{{ component_name }}-ambassador-certs"
-    kubeconfig: "{{ kubernetes.config_file }}"
-    context: "{{ kubernetes.context }}"
-  register: get_ambassador_secret
-
-# Create the Ambassador TLS credentials for ambassador
+# Create the Ambassador credentials secret if it does not exist
 - name: Create the Ambassador credentials
   shell: |
     KUBECONFIG={{ kubernetes.config_file }} kubectl create secret tls {{ component_name }}-ambassador-certs --cert={{ ambassadortls }}/ambassador.crt --key={{ ambassadortls }}/ambassador.key -n {{ component_ns }}
   when: get_ambassador_secret.resources|length == 0
 
-# Copy generated crt to build location for doorman and networkmap
+# Copy generated Ambassador TLS certificate to specified build location if defined
 - name: Copy generated ambassador tls certs to given build location
   copy:
     src: "{{ ambassadortls }}/ambassador.crt"

--- a/platforms/substrate/configuration/roles/create/generate_genesis/tasks/main.yaml
+++ b/platforms/substrate/configuration/roles/create/generate_genesis/tasks/main.yaml
@@ -1,0 +1,68 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# Set organization variable based on the first organization in the network
+- name: Set organization variable
+  set_fact:
+    organization: "{{ network.organizations[0] }}"
+
+# Initialize counts for validator and member nodes
+- name: Initialize counts
+  set_fact:
+    validator_count: 0
+    member_count: 0
+
+# Loop through each organization to count nodes
+- name: Count nodes
+  include_tasks: nodes.yaml
+  vars:
+    peers: "{{ item.services.peers }}"
+  loop: "{{ network['organizations'] }}"
+
+
+# Retrieve kubernetes server url
+- name: Get the kubernetes server url
+  shell: |
+    KUBECONFIG={{ organization.k8s.config_file }} kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " "
+  register: kubernetes_server_url
+
+# Generate keys and genesis file
+- name: Generate keys and genesis file
+  include_role:
+    name: create/helm_component
+  vars:
+    name: "{{ organization.name }}"
+    org_name: "{{ organization.name }}"
+    type: "genesis_job"
+    component_name: "genesis"
+    component_ns: "{{ organization.name }}-subs"
+    vault: "{{ organization.vault }}"
+    kubernetes_url: "{{ kubernetes_server_url.stdout }}"
+    charts_dir: "{{ organization.gitops.chart_source }}"
+    values_dir: "{{playbook_dir}}/../../../{{ organization.gitops.release_dir }}"
+
+# Push the created deployment files to the Git repository
+- name: "Push the created deployment files to the Git repository"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
+  vars:
+    component_ns: "{{ organization.name }}"
+    GIT_DIR: "{{ playbook_dir }}/../../../"
+    msg: "[ci skip] Pushing key management job files for {{ component_ns }}"
+    gitops: "{{ organization.gitops }}"
+  tags: notest
+
+# Check if the Genesis job is completed
+- name: Check if the Genesis job is completed
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/helm_component"
+  vars:
+    component_name: "genesis"
+    component_type: Job
+    namespace: "{{ organization.name }}-subs"
+    kubernetes: "{{ organization.k8s }}"
+  tags:
+  - notest

--- a/platforms/substrate/configuration/roles/create/generate_genesis/tasks/nodes.yaml
+++ b/platforms/substrate/configuration/roles/create/generate_genesis/tasks/nodes.yaml
@@ -1,0 +1,23 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# Increment the validator_count for each peer that is a 'bootnode' or 'validator'
+- name: Count validator nodes
+  set_fact:
+    validator_count: "{{ validator_count | int + 1 }}"
+  loop: "{{ peers }}"
+  loop_control:
+    loop_var: peer
+  when: peer.type == 'bootnode' or peer.type == 'validator'
+
+# Increment the member_count for each peer that is a 'member'
+- name: Count member nodes
+  set_fact:
+    member_count: "{{ member_count | int  + 1 }}"
+  loop: "{{ peers }}"
+  loop_control:
+    loop_var: peer
+  when: peer.type == 'member'

--- a/platforms/substrate/configuration/roles/create/helm_component/templates/dscp_ipfs_node.tpl
+++ b/platforms/substrate/configuration/roles/create/helm_component/templates/dscp_ipfs_node.tpl
@@ -17,6 +17,16 @@ spec:
         namespace: flux-{{ network.env.type }}
       chart: {{ charts_dir }}/dscp-ipfs-node
   values:
+    global:
+        serviceAccountName: vault-auth
+        vault:
+          type: hashicorp
+          role: vault-role
+          network: substrate
+          address: {{ vault.url }}
+          authPath: {{ network.env.type }}
+          secretEngine: {{ vault.secret_path | default("secretsv2") }}
+          secretPrefix: "data/{{ network.env.type }}{{ vault_key }}"
     fullnameOverride: {{ peer.name }}-ipfs
     namespace: {{ component_ns }}
     config:
@@ -66,9 +76,3 @@ spec:
       external_url: {{ peer.name }}-ipfs-swarm.{{ external_url }}
       port: {{ peer.ipfs.ambassador }}
       certSecret: {{ org.name | lower }}-ambassador-certs
-    vault:
-      address: {{ vault.url }}
-      role: vault-role
-      authpath: {{ network.env.type }}{{ name }}
-      serviceaccountname: vault-auth
-      certsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/{{ name }}/{{ peer.name }}

--- a/platforms/substrate/configuration/roles/create/helm_component/templates/genesis_job.tpl
+++ b/platforms/substrate/configuration/roles/create/helm_component/templates/genesis_job.tpl
@@ -1,13 +1,13 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: {{ component_name }}
+  name: {{ component_name | replace('_','-') }}
   namespace: {{ component_ns }}
   annotations:
     fluxcd.io/automated: "false"
 spec:
   interval: 1m
-  releaseName: {{ component_name }}
+  releaseName: {{ component_name | replace('_','-') }}
   chart:
     spec:
       interval: 1m
@@ -17,23 +17,36 @@ spec:
         namespace: flux-{{ network.env.type }}
       chart: {{ charts_dir }}/substrate-genesis
   values:
+    global:
+      serviceAccountName: vault-auth
+      cluster:
+        provider: azure
+        cloudNativeServices: false
+        kubernetesUrl: {{ kubernetes_url }}
+      vault:
+        type: hashicorp
+        role: vault-role
+        network: substrate
+        address: {{ vault.url }}
+        authPath: {{ network.env.type }}
+        secretEngine: {{ vault.secret_path | default("secretsv2") }}
+        certPrefix: {{ network.env.type }}{{ org_name }}
+        secretPrefix: "data/{{ network.env.type }}{{ org_name }}"
+    removeGenesisOnDelete:
+      enabled: true
+      image:
+        repository: ghcr.io/hyperledger/bevel-k8s-hooks
+        tag: qgt-0.2.12
+        pullPolicy: IfNotPresent
+    chain: {{ network.config.chain }}
     node:
       name: {{ component_name }}
       image: {{ network.docker.url }}/{{ network.config.node_image }}
       imageTag: {{ network.version }}
       pullPolicy: IfNotPresent
       command: {{ network.config.command }}
-    metadata:
-      name: {{ component_name }}
-      namespace: {{ component_ns }}
-    vault:
-      address: {{ vault.url }}
-      role: vault-role
-      authpath: {{ network.env.type }}{{ name }}
-      serviceaccountname: vault-auth
-      certsecretprefix: {{ vault.secret_path | default('secretsv2') }}/{{ name }}
-    chain: {{ network.config.chain }}
-    aura_keys: {{ aura_key_list }}
-    grandpa_keys: {{ grandpa_key_list }}
-    members: 
-      {{ member_list | to_nice_yaml | indent(width=6) }}
+      validator:
+        count: {{ validator_count }}
+      member:
+        count: {{ member_count }}
+        balance: 1152921504606846976

--- a/platforms/substrate/configuration/roles/create/ipfsbootnodefile/tasks/get_bootnode_data.yaml
+++ b/platforms/substrate/configuration/roles/create/ipfsbootnodefile/tasks/get_bootnode_data.yaml
@@ -19,7 +19,7 @@
 # Fetch the bootnode's peer id from vault
 - name: Fetch bootnode peer id from vault
   shell: |
-    vault kv get -field=peer_id {{ vault.secret_path | default('secretsv2') }}/{{ org.name }}/{{ peer.name }}/ipfs
+    vault kv get -field=peer_id "{{ vault.secret_path | default('secretsv2') }}/{{ network.env.type }}/{{ peer.name }}-ipfs"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/substrate/configuration/roles/create/member_node/tasks/ipfs_node.yaml
+++ b/platforms/substrate/configuration/roles/create/member_node/tasks/ipfs_node.yaml
@@ -1,0 +1,68 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# Set node_list to empty
+- name: Set node_list to []
+  set_fact:
+    node_list: []
+
+# Fetch the bootnode's node ID from Vault
+- name: Fetch node_id of {{ peer.name }} node
+  shell: |
+    KUBECONFIG={{ kubernetes.config_file }} kubectl get secret "substrate-node-{{ peer.name | lower }}-keys" --namespace {{ component_ns }} -o jsonpath="{.data['substrate-node-keys']}" | base64 -d | jq -r '.data.node_id'
+  register: node_id
+  ignore_errors: true
+
+# Append bootnode information to node_list
+- name: Collect Bootnode data
+  set_fact:
+    node_list={{ node_list|default([]) + [ {'bootnode_id':node_id.stdout, 'external_url':internal_url, 'p2p_port':peer.ipfs.swarmPort} ] }}
+  vars:
+    internal_url: "{{ peer.name }}-ipfs-swarm.{{ component_ns }}.svc.cluster.local"
+
+# Create a file to store bootnode information only if not already available
+- name: Create bootnode file
+  template:
+    src: "ipfsbootnode.tpl"
+    dest: "{{ network.config.ipfsbootnodes }}"
+
+# Generate IPFS node HelmRelease file
+- name: "Create ipfs node release file"
+  include_role:
+    name: create/helm_component
+  vars:    
+    component_name: "{{ peer.name }}-ipfs-node"
+    type: "dscp_ipfs_node"
+    storageclass_name: "{{ item.name | lower }}-bevel-storageclass"
+    external_url: "{{ item.external_url_suffix }}"
+    vault_key: "{{ name }}/substrate-node-{{ peer.name | lower }}"
+    git_url: "{{ item.gitops.git_url }}"
+    git_branch: "{{ item.gitops.branch }}"
+    org: "{{ item }}"
+    docker_url: "{{ network.docker.url }}"
+    charts_dir: "{{ item.gitops.chart_source }}"
+    values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
+    ipfs_bootnode: "{{ lookup('file', '{{ network.config.ipfsbootnodes }}').splitlines() }}"
+
+# Git Push : Push the above generated files to git directory 
+- name: Git Push
+  include_role: 
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
+  vars:
+    GIT_DIR: "{{ playbook_dir }}/../../../"
+    gitops: "{{ item.gitops }}"
+    msg: "[ci skip] Pushing Peer files"
+
+# Check if IPFS-bootnode is running
+- name: Check if {{ peer.name }} is running
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/helm_component"
+  vars:
+    component_name: "{{ peer.name }}-ipfs"
+    component_type: Pod
+    label_selectors:
+      - name = {{ component_name }}
+    namespace: "{{ component_ns }}"

--- a/platforms/substrate/configuration/roles/create/member_node/tasks/main.yaml
+++ b/platforms/substrate/configuration/roles/create/member_node/tasks/main.yaml
@@ -4,56 +4,18 @@
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
 
-# Generate member node helmrelease file
-- name: Create value file for member nodes
-  include_role:
-    name: create/helm_component
-  vars:
-    component_name: "{{ name }}{{ peer.name }}membernode"
-    type: "node_substrate"
-    storageclass_name: "{{ item.name | lower }}-bevel-storageclass"
-    external_url: "{{ item.external_url_suffix }}"
-    vault: "{{ item.vault }}"
-    git_url: "{{ item.gitops.git_url }}"
-    git_branch: "{{ item.gitops.branch }}"
-    org: "{{ item }}"
-    docker_url: "{{ network.docker.url }}"
-    charts_dir: "{{ item.gitops.chart_source }}"
-    values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"    
-    bootnode_data: "{{ lookup('file', '{{ network.config.bootnodes }}').splitlines() }}"
-    command: "{{ network.config.command }}"
-    role: "full"
+# Generate member node HelmRelease files
+- name: "Create value file for member nodes"
+  include_tasks: member_node.yaml
   loop: "{{ peers }}"
   loop_control:
     loop_var: peer
   when: peer.type == "member"
 
-# Generate ipfs node helmrelease file
-- name: "Create ipfs node release file"
-  include_role:
-    name: create/helm_component
-  vars:    
-    component_name: "{{ peer.name }}-ipfs-node"
-    type: "dscp_ipfs_node"
-    storageclass_name: "{{ item.name | lower }}-bevel-storageclass"
-    external_url: "{{ item.external_url_suffix }}"
-    git_url: "{{ item.gitops.git_url }}"
-    git_branch: "{{ item.gitops.branch }}"
-    org: "{{ item }}"
-    docker_url: "{{ network.docker.url }}"
-    charts_dir: "{{ item.gitops.chart_source }}"
-    values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
-    ipfs_bootnode: "{{ lookup('file', '{{ network.config.ipfsbootnodes }}').splitlines() }}"
+# Generate IPFS node HelmRelease files
+- name: "Create value file for ipfs nodes"
+  include_tasks: ipfs_node.yaml
   loop: "{{ peers }}"
   loop_control:
     loop_var: peer
-  when: peer.type == "member" and peer.ipfs is defined
-
-# Git Push : Push the above generated files to git directory 
-- name: Git Push
-  include_role: 
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
-  vars:
-    GIT_DIR: "{{ playbook_dir }}/../../../"
-    gitops: "{{ item.gitops }}"
-    msg: "[ci skip] Pushing Peer files"
+  when: peer.type == "member" and peer.ipfs.enabled

--- a/platforms/substrate/configuration/roles/create/member_node/tasks/member_node.yaml
+++ b/platforms/substrate/configuration/roles/create/member_node/tasks/member_node.yaml
@@ -4,14 +4,14 @@
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
 
-# Create the value files for each validator node of organization
-- name: Create value file for validator for each node
+# Generate member node helmrelease file
+- name: Create value file for member nodes
   include_role:
     name: create/helm_component
   vars:
     component_name: "{{ peer.name }}"
     type: "node_substrate"
-    storageclass_name: "{{ item.cloud_provider }}storageclass"
+    storageclass_name: "{{ item.name | lower }}-bevel-storageclass"
     external_url: "{{ item.external_url_suffix }}"
     vault: "{{ item.vault }}"
     git_url: "{{ item.gitops.git_url }}"
@@ -20,13 +20,10 @@
     docker_url: "{{ network.docker.url }}"
     charts_dir: "{{ item.gitops.chart_source }}"
     values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"    
+    bootnode_data: "{{ lookup('file', '{{ network.config.bootnodes }}').splitlines() }}"
     command: "{{ network.config.command }}"
-    role: "validator"
-    isBootnode: "{{ false if peer.type == 'bootnode' else true }}"
-  loop: "{{ peers }}"
-  loop_control:
-    loop_var: peer
-  when: peer.type in ['validator', 'bootnode']
+    role: "full"
+    isBootnode: true
 
 # Git Push : Push the above generated files to git directory 
 - name: Git Push
@@ -36,3 +33,15 @@
     GIT_DIR: "{{ playbook_dir }}/../../../"
     gitops: "{{ item.gitops }}"
     msg: "[ci skip] Pushing Peer files"
+
+# Check if ipfs-bootnode is running
+- name: Check if {{ peer.name }} is running
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/helm_component"
+  vars:
+    component_name: "{{ peer.name }}"
+    component_type: Pod
+    label_selectors:
+      - name = {{ component_name }}
+    namespace: "{{ component_ns }}"
+  tags: notest

--- a/platforms/substrate/configuration/roles/create/member_node/templates/ipfsbootnode.tpl
+++ b/platforms/substrate/configuration/roles/create/member_node/templates/ipfsbootnode.tpl
@@ -1,0 +1,4 @@
+ipfsbootnodes:
+{%- for enode in node_list %}    
+/dns4/{{ enode.external_url }}/tcp/{{ enode.p2p_port }}/p2p/{{ enode.bootnode_id }}
+{%- endfor %}  

--- a/platforms/substrate/configuration/roles/create/secrets/tasks/main.yaml
+++ b/platforms/substrate/configuration/roles/create/secrets/tasks/main.yaml
@@ -1,0 +1,32 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# Wait for namespace to be created by flux
+- name: "Wait for the namespace {{ component_ns }} to be created"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/k8_component"
+  vars:
+    component_type: "Namespace"
+    component_name: "{{ component_ns }}"
+    type: "retry"
+
+# Create the vault roottoken secret
+- name: "Create vault token secret"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/create/shared_k8s_secrets"
+  vars: 
+    namespace: "{{ component_ns }}"    
+    check: "token_secret"
+
+# Create the docker pull credentials for image registry
+- name: "Create docker credentials secret"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/create/shared_k8s_secrets"
+  vars: 
+    namespace: "{{ component_ns }}"    
+    check: "docker_credentials"
+  when: 
+  - network.docker.username is defined

--- a/platforms/substrate/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/substrate/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -8,7 +8,6 @@
 # This role deletes the Vault configurations
 #############################################################################################
 
-#############################################################################################
 # Delete the Docker credentials
 - name: Delete docker creds
   k8s:
@@ -34,11 +33,15 @@
     loop_var: peer
   ignore_errors: yes
 
-# Delete Peer Crypto material
-- name: Delete Peer Crypto material 
+# Delete Peer Crypto material (including IPFS keys if applicable)
+- name: Delete Peer Crypto material
   shell: |
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name }}/{{ peer.name }}/substrate  
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name }}/{{ peer.name }}/ipfs
+    {% if peer.type == "member" %}
+      {% if peer.ipfs is defined %}
+        vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ org_name }}/substrate-node-{{ peer.name }}-ipfs-keys
+      {% endif %}
+    {% endif %}
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ org_name }}/substrate-node-{{ peer.name }}-keys
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"
     VAULT_TOKEN: "{{ item.vault.root_token }}"
@@ -47,24 +50,12 @@
     loop_var: peer
   ignore_errors: yes
 
-# Delete Organization's Crypto material 
-- name: Delete Org Crypto material 
+# Delete Genesis and Ambassador crypto material
+- name: Delete genesis & ambassador crypto material
   shell: |
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name }}/genesis
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name }}/tlscerts
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ org_name }}/tlscerts
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ org_name }}/genesis
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"
     VAULT_TOKEN: "{{ item.vault.root_token }}"
-  ignore_errors: yes
-
-  # Delete application crypto material
-- name: Delete Application Crypto material 
-  shell: |
-    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name }}/application
-  loop: "{{ services.peers }}"
-  environment:
-    VAULT_ADDR: "{{ item.vault.url }}"
-    VAULT_TOKEN: "{{ item.vault.root_token }}"
-  loop_control:
-    loop_var: peer
   ignore_errors: yes

--- a/platforms/substrate/configuration/samples/substrate-network-config.yaml
+++ b/platforms/substrate/configuration/samples/substrate-network-config.yaml
@@ -1,0 +1,173 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+---
+# yaml-language-server: $schema=../../../../platforms/network-schema.json
+# This is a sample configuration file for Substrate based Inteli network which has 3 organizations.
+# All text values are case-sensitive
+network:
+  # Network level configuration specifies the attributes required for each organization
+  # to join an existing network.
+  type: substrate
+  version: v4.3.1  #this is the version of Substrate docker image that will be deployed.
+
+  #Environment section for Kubernetes setup
+  env:
+    type: "substrate"               # tag for the environment. Important to run multiple flux on single cluster
+    proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Substrate
+    proxy_namespace: "ambassador"
+    #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
+    #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
+    ambassadorPorts:                # Any additional Ambassador ports can be given here, this is valid only if proxy='ambassador'
+      portRange:                    # For a range of ports 
+        from: 15010
+        to: 15043
+    # ports: 15020,15021            # For specific ports
+    retry_count: 20                 # Retry count for the checks on Kubernetes cluster
+    external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
+  
+  # Docker registry details where images are stored. This will be used to create k8s secrets
+  # Please ensure all required images are built and stored in this registry. 
+  # Do not check-in docker_password.
+  docker:
+    url: "ghcr.io"
+    # username: "docker_username"
+    # password: "docker_password"
+  
+  # Following are the configurations for the common Substrate network
+  config:
+    ## Certificate subject for the root CA of the network. 
+    #  This is for development usage only where we create self-signed certificates and the truststores are generated automatically.
+    #  Production systems should generate proper certificates and configure truststores accordingly.
+    subject: "CN=DLT Root CA,OU=DLT,O=DLT,L=London,C=GB"
+    # Provide the docker image which will be used for the Substrate Nodes in this network. (will be downloaded from docker.url)
+    node_image: "inteli-poc/dscp-node"
+    # Provide the command which is used to start the node
+    command: "./dscp-node"     # Please ensure the command corresponds to the node_image above
+    # provide a chain name for Substrate nodes
+    chain: "inteli"
+    # NOTE for the below paths, the directories should exist
+    genesis: "/BUILD_DIR/substrate_genesis"     # Location where information is read or saved if empty
+    bootnodes: "/BUILD_DIR/substrate_bootnodes" # Location where bootnodes information is read or saved if empty
+    ipfsbootnodes: "/BUILD_DIR/ipfs_bootnodes"  # Location where IPFS bootnodes information is read or saved if empty    
+  
+  # Allows specification of one or many organizations that will be connecting to a network.
+  organizations:
+    # Specification for the 1st organization. Each organization should map to a VPC and a separate k8s cluster for production deployments
+    - organization:
+      name: supplychain
+      type: superuser
+      persona: buyer
+      external_url_suffix: test.subs.blockchaincloudpoc.com   # This is the url suffix that will be added in DNS recordset. Must be different for different clusters
+      cloud_provider: aws   # Options: aws, azure, gcp
+      aws:
+        access_key: "AWS_ACCESS_KEY"        # AWS Access key, only used when cloud_provider=aws
+        secret_key: "AWS_SECRET_KEY"        # AWS Secret key, only used when cloud_provider=aws
+
+      # Kubernetes cluster deployment variables. The config file path and name has to be provided in case
+      # the cluster has already been created.
+      k8s:
+        context: "CLUSTER_CONTEXT"
+        config_file: "/BUILD_DIR/config"
+      # Hashicorp Vault server address and root-token. Vault should be unsealed.
+      # Do not check-in root_token
+      vault:
+        url: "http://VAULT_URL:VAULT_PORT"
+        root_token: "VAULT_TOKEN"
+        secret_path: "secretsv2"
+      # these are the Auth0 API values that will be used for authentication to substrate api endpoints. Eg. tokenUrl: https://example.eu.auth0.com/oauth/token
+      auth:
+        type: NONE
+      # Git Repo details which will be used by GitOps/Flux.
+      # Do not check-in git_access_token
+      gitops:
+        git_protocol: "https" # Option for git over https or ssh
+        git_url: "https://github.com/<username>/bevel.git"    # Gitops https or ssh url for flux value files 
+        branch: "substrate"                                   # Git branch where release is being made
+        release_dir: "platforms/substrate/releases/dev"       # Relative Path in the Git repo for flux sync per environment. 
+        chart_source: "platforms/substrate/charts"            # Relative Path where the Helm charts are stored in Git repo
+        git_repo: "github.com/<username>/bevel.git"           # Gitops git repository URL for git push 
+        username: "GIT_USERNAME"                              # Git Service user who has rights to check-in in all branches
+        password: "GIT_TOKEN"                                 # Git Server user password/token (Optional for ssh; Required for https)
+        email: "git@email.com"                                # Email to use in git config
+        private_key: "/BUILD_DIR/gitops"                      # Path to private key file which has write-access to the git repo (Optional for https; Required for ssh)
+      # The participating nodes are named as peers
+      services:
+        peers:
+        - peer:
+          name: validator-1
+          subject: "O=validator-1,OU=validator-1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          type: bootnode        # value can be validator or bootnode ( or ipfs, for vitalAM)
+          p2p:
+            port: 30333
+            ambassador: 15010   # Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 9933
+          ws:
+            port: 9944
+        - peer:
+          name: validator-2
+          subject: "O=validator-2,OU=validator-2,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          type: validator       # value can be validator or bootnode ( or ipfs, for vitalAM)
+          p2p:
+            port: 30333
+            ambassador: 15011   # Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 9933
+          ws:
+            port: 9944
+        - peer:
+          name: validator-3
+          subject: "O=validator-3,OU=validator-3,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          type: validator       # value can be validator or bootnode ( or ipfs, for vitalAM)
+          p2p:
+            port: 30333
+            ambassador: 15012   # Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 9933
+          ws:
+            port: 9944
+        - peer:
+          name: validator-4
+          subject: "O=validator-4,OU=validator-4,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
+          type: validator       # value can be validator or bootnode ( or ipfs, for vitalAM)
+          p2p:
+            port: 30333
+            ambassador: 15013   #Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 9933
+          ws:
+            port: 9944
+        - peer:
+          name: member-1
+          subject: "O=member-1,OU=member-1,London,C=GB" # This is the node subject.
+          type: member         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          nodeHost: oem        # peer name of substrate node for IPFS API-WS connection
+          p2p:
+            port: 30333
+            ambassador: 15014  # Port exposed on ambassador service (use one port per org if using single cluster)
+          rpc:
+            port: 9933
+          ws:
+            port: 9944
+          ipfs:
+            enabled: true       # Set to true if an IPFS node is required, otherwise set to false
+            swarmPort: 4001
+            ambassador: 15016   # Port exposed on ambassador service (use one port per org if using single cluster)
+            apiPort: 5001
+          api:
+            port: 80
+          postgresql:
+            port: 5432
+            user: postgres
+            password: "postgres123"
+          id_service:
+            db_name: "id-service"
+            port: 3001
+          inteli_api:
+            db_name: "inteli-api"
+            port: 3000
+            ambassador: 443


### PR DESCRIPTION
### **Commit to be reviewed**
---

**feat(substrate): enable platform deployment via ansible server**

```
This commit introduces support for deploying a decentralized ledger technology (DLT) network using Ansible automation. The changes include:

- Added a new network configuration file to define nodes (Bootnode, Validator, Member, IPFS) within a single organization.
- Updated the `deployment-network.yaml` to support the new network configuration.
- Updated multiple Ansible roles, Helm release templates, and charts to align with the new network configuration.
- Updated the user guide documentation to assist users/developers in correctly configuring the network.
```

**fixes #2547**