### PR TITLE
feat(fabric): update manage-user-certificate playbook to refresh user certificates

### DIFF
--- a/platforms/hyperledger-fabric/charts/fabric-catools/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-catools/templates/deployment.yaml
@@ -357,6 +357,8 @@ spec:
             value: {{ $.Values.metadata.org_name }}
           - name: REFRESH_CERTS
             value: "{{ $.Values.checks.refresh_cert_value }}"
+          - name: REFRESH_USER_CERTS
+            value: "{{ $.Values.checks.refresh_user_cert_value }}"
           - name: ADD_PEER
             value: "{{ $.Values.checks.add_peer_value }}"
           - name: ORDERERS_NAMES
@@ -453,7 +455,7 @@ spec:
                 list=$(echo "$USERS_IDENTITIES" | tr "-" "\n")         
                 for USER in $list
                 do
-                  if ([ "$USERS" ] && [ -e  ${MOUNT_PATH}/absent_msp_${USER}.txt ]) || [ "$REFRESH_CERTS" = "true" ]
+                  if ([ "$USERS" ] && [ -e  ${MOUNT_PATH}/absent_msp_${USER}.txt ]) || [ "$REFRESH_CERTS" = "true" || [ "$REFRESH_USER_CERTS" = "true" ]
                   then
                     cd /root/ca-tools/${ORG_NAME_EXT}
                     ./generate-user-crypto.sh peer ${USERS}

--- a/platforms/hyperledger-fabric/charts/fabric-catools/values.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-catools/values.yaml
@@ -140,5 +140,6 @@ users:
 checks:
   #Provides the need to refresh user certificates
   refresh_cert_value: false
+  refresh_user_cert_value: false
   #Add a peer to an existing network
   add_peer_value: False

--- a/platforms/hyperledger-fabric/configuration/manage-user-certificate.yaml
+++ b/platforms/hyperledger-fabric/configuration/manage-user-certificate.yaml
@@ -54,22 +54,30 @@
       loop: "{{ network['organizations'] }}"
 
     ############################################################################################
-    # This task generates the crypto material by executing the generate-user-crypto.sh script file
-    # present in the Organization's CA Tools CLI
+    # This task generates the crypto material by running the ca_tools/peer playbook
     - name: Generate crypto material for user
       include_role:
-        name: "create/users"
+        name: "create/ca_tools/peer"
       vars:
         component_name: "{{ item.name | lower}}-net"
+        component: "{{ item.name | lower}}"
         component_type: "{{ item.type | lower}}"
-        org_name: "{{ item.name }}"
-        services: "{{ item.services }}"
-        subject: "{{ item.subject }}"
-        cert_subject: "{{ item.subject | regex_replace('/', ';') | regex_replace(',', '/') | regex_replace(';', ',') }}" # replace , to / and / to , for certpath
+        component_services: "{{ item.services }}"
+        orderer_org: "{{ item.orderer_org | lower }}"
+        sc_name: "{{ component }}-bevel-storageclass"
         kubernetes: "{{ item.k8s }}"
         vault: "{{ item.vault }}"
-        users: "{{ item.users }}"
-        proxy: "{{ network.env.proxy }}"
-        ca_url: "{{ item.ca_data.url }}"
+        ca: "{{ item.services.ca }}"
+        docker_url: "{{ network.docker.url }}"
+        gitops: "{{ item.gitops }}"
+        values_dir: "{{ playbook_dir }}/../../../{{ item.gitops.release_dir }}/{{ item.name | lower }}"
       loop: "{{ network['organizations'] }}"
-      when: item.type == 'peer' and item.users is defined
+      when: item.type == 'peer'
+
+  vars: #These variables can be overriden from the command line
+    privilege_escalate: false           #Default to NOT escalate to root privledges
+    install_os: "linux"                 #Default to linux OS
+    install_arch:  "amd64"              #Default to amd64 architecture
+    refresh_user_cert: 'true'                #Default for this playbook is true
+    bin_install_dir:  "~/bin"            #Default to ~/bin install directory for binaries
+    add_new_org: "false"

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca_tools/peer/tasks/delete_old_certs.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca_tools/peer/tasks/delete_old_certs.yaml
@@ -19,10 +19,28 @@
     vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/peerOrganizations/{{ component_name }}/peers/{{peer.name}}.{{ component_name }}/tls
     vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/peerOrganizations/{{ component_name }}/peers/{{peer.name}}.{{ component_name }}/msp
     {% endfor %}
+    {% for user in users %}
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/peerOrganizations/{{ component_name }}/users/{{user.identity}}/tls
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/peerOrganizations/{{ component_name }}/users/{{user.identity}}/msp
+    {% endfor %}
     vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/credentials/{{ component_name }}/couchdb/{{ org_name }}
   vars:
     peers: "{{ item.services.peers }}"
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"
     VAULT_TOKEN: "{{ item.vault.root_token }}"
-  when: component_type == 'peer'
+  when: component_type == 'peer' and refresh_cert is defined and refresh_cert == 'true'
+
+# Delete crypto materials from vault only for users
+- name: Delete Crypto for peers
+  shell: |
+    {% for user in users %}
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/peerOrganizations/{{ component_name }}/users/{{user.identity}}/tls
+    vault kv delete {{ item.vault.secret_path | default('secretsv2') }}/{{ item.name | lower }}/peerOrganizations/{{ component_name }}/users/{{user.identity}}/msp
+    {% endfor %}
+  vars:
+    peers: "{{ item.services.peers }}"
+  environment:
+    VAULT_ADDR: "{{ item.vault.url }}"
+    VAULT_TOKEN: "{{ item.vault.root_token }}"
+  when: component_type == 'peer' and refresh_user_cert is defined and refresh_user_cert == 'true'

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca_tools/peer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca_tools/peer/tasks/main.yaml
@@ -31,14 +31,15 @@
     component_ns: "{{ component_name }}"
     kubernetes: "{{ item.k8s }}"
     hr_name: "{{ component_name }}-ca-tools"
-  when: (add_peer is defined and add_peer == 'true') or (refresh_cert is defined and refresh_cert == 'true')
+  when: (add_peer is defined and add_peer == 'true') or (refresh_cert is defined and refresh_cert == 'true')  or (refresh_user_cert is defined and refresh_user_cert == 'true')
 
 # Delete old certificates
 - name: "Delete old certificates"
   include_tasks: delete_old_certs.yaml
   vars:
     org_name: "{{ item.name | lower }}"
-  when: refresh_cert is defined and refresh_cert == 'true'
+    users: "{{ item.users }}"
+  when: (refresh_cert is defined and refresh_cert == 'true') or (refresh_user_cert is defined and refresh_user_cert == 'true')
 
 # Get Orderer certificates
 - name: "Get Orderer certificates"
@@ -105,6 +106,7 @@
     component_location: "{{ item.location }}"
     ca_url: "{{ item.ca_data.url }}"
     refresh_cert_value: "{{ refresh_cert | default(false) | quote }}"
+    refresh_user_cert_value: "{{ refresh_user_cert | default(false) | quote }}"
     proxy: "{{ network.env.proxy }}"
     git_protocol: "{{ item.gitops.git_protocol }}"
     git_url: "{{ gitops.git_url }}"

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-tools.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-tools.tpl
@@ -114,5 +114,6 @@ spec:
 {% endif %}
     checks:
       refresh_cert_value: {{ refresh_cert_value }}
+      refresh_user_cert_value: {{ refresh_user_cert_value }}
       add_peer_value: {{ add_peer_value }}
 {% endif %}


### PR DESCRIPTION
This PR contains updates in the manage-user-certificate playbook, as well as minor changes in the ca-tools role to consider the refresh-user-certs variable so whenever this playbook is run, only the user certificates will be affected (updated).