### PR TITLE
[fabric] Update ansible playbooks add-peer and add-cli

### DIFF
--- a/docs/source/guides/fabric/add-cli.md
+++ b/docs/source/guides/fabric/add-cli.md
@@ -22,29 +22,36 @@ This guide explains how to add a CLI to an existing Hyperledger Fabric network u
 1. **Update Configuration File**
 
     - Edit the `network.yaml` file to include the new organization with the following details:
+        - `peerstatus: new`
+        - `cli: enabled`      
 		- `org_status: new`
 		- Organization details (name, MSP ID, etc.)
 		- Orderer information
 	- Existing organizations should have `org_status: existing`
+	- Existing peer(s) with cli deployed should have `peerstatus: existing`
     - Refer to the [networkyaml-fabric.md](../networkyaml-fabric.md) guide for details on editing the configuration file.
 
 	Snippet from `network.channels` section below:
 	```yaml
-	--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml:65:139"
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml:57:105"
 	```
 
 	and from `network.organizations` section below:
 
 	```yaml
-	--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml:143:155"
-		..
-		..
-	--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml:406:414"
-		..
-		..
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml:107:122"
+          ..
+          ..
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml:161:161"
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml:171:177"
+              ..
+              ..
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml:203:209"
+              ..
+              ..
 	```
 
-1. **Run Playbook**
+2. **Run Playbook**
 	
 	Execute the following command to run the `add-cli.yaml` playbook:
 

--- a/docs/source/guides/fabric/add-new-peer.md
+++ b/docs/source/guides/fabric/add-new-peer.md
@@ -27,9 +27,9 @@ This guide explains how to add a new **general** (non-anchor) peer to an existin
     - There is a single Hashicorp Vault and both clusters (as well as ansible controller) can access it.
     - Admin User certs have been already generated and stored in Vault (this is taken care of by deploy-network.yaml playbook if you are using Bevel to setup the network).
     - The `network.env.type` is different for different clusters.
-    - The GitOps release directory `gitops.release_dir` is different for different clusters.
+    - The GitOps release directory `gitops.release_dir` and `gitops.component_dir` are different for different clusters.
 
-1. **Update Configuration File**
+2. **Update Configuration File**
 
     - Edit the `network.yaml` file to include the new peer with the following details:
 		- `peerstatus: new`
@@ -41,25 +41,25 @@ This guide explains how to add a new **general** (non-anchor) peer to an existin
 
     Snippet from `network.channels` section below:
     ```yaml
-    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:60:87"
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:57:105"
     ```
 
     and from `network.organizations` section below:
 
     ```yaml
-    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:94:103"
-        ..
-        ..
-    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:144:144"
-    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:153:159"
-            ..
-            ..
-    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:187:192"
-            ..
-            ..
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:107:122"
+          ..
+          ..
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:161:161"
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:171:177"
+              ..
+              ..
+    --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabric-add-peer.yaml:203:209"
+              ..
+              ..
     ```
 
-1. **Run Playbook**
+3. **Run Playbook**
 	
 	Execute the following command to run the `add-peer.yaml` playbook:
 

--- a/docs/source/guides/networkyaml-fabric.md
+++ b/docs/source/guides/networkyaml-fabric.md
@@ -165,6 +165,7 @@ Each `organization` field under `participants` field of the channel contains the
 | org_status         | `new` (for inital setup) or `existing` (for add new org) | 
 | ordererAddress     | URL of the orderer this peer connects to, including port                  |
 | peer.name          | Name of the peer                                           |
+| peer.type                          | Type can be `anchor` and `nonanchor` for Peer                                                                    |
 | peer.gossipAddress | Gossip address of the peer, including port                               |
 | peer.peerAddress | External address of the peer, including port                                  |
 
@@ -242,7 +243,7 @@ The `vault` field under each organization contains
 For gitops fields the snapshot from the sample configuration file with the example values is below
 
 ```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:203:215"
+--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:203:216"
 ```
 
 The gitops field under each organization contains
@@ -253,6 +254,7 @@ The gitops field under each organization contains
 | git_url                              | SSH or HTTPs url of the repository where flux should be synced                                                            |
 | branch                               | Branch of the repository where the Helm Charts and value files are stored                                        |
 | release_dir                          | Relative path where flux should sync files                                                                       |
+| component_dir                        | Relative path where values files are stored.files                                                                       |
 | chart_source                         | Relative path where the helm charts are stored                                                                   |
 | git_repo                         | Gitops git repo URL https URL for git push like "github.com/hyperledger/bevel.git"             |
 | username                             | Username which has access rights to read/write on repository                                                     |
@@ -263,7 +265,7 @@ The gitops field under each organization contains
 For Hyperledger Fabric, you can also generate different user certificates and pass the names and attributes in the specific section for `users`. This is only applicable if using Fabric CA. An example is below:
 
 ```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:338:344"
+--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:340:346"
 ```
 
 The fields under `user` are
@@ -279,7 +281,7 @@ The services field for each organization under `organizations` section of Fabric
 Each organization will have a CA service under the service field. The snapshot of CA service with example values is below
 
 ```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:217:225"
+--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:218:226"
 ```
 
 The fields under `ca` service are
@@ -295,7 +297,7 @@ The fields under `ca` service are
 Example of peer service. Below is a snapshot of the peer service with example values.
 
 ```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:354:387"
+--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:356:389"
 ```
 
 The fields under `peer` service are
@@ -342,7 +344,7 @@ The chaincodes section contains the list of chaincode for the peer, the fields u
 The organization with orderer type will have concensus service. The snapshot of consensus service with example values is below
 
 ```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:227:228"
+--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:228:229"
 ```
 
 The fields under `consensus` service are
@@ -357,7 +359,7 @@ The fields under `consensus` service are
 Example of ordering service. The snapshot of orderers service with example values is below
 
 ```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:229:253"
+--8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml:230:254"
 ```
 
 The fields under `orderer` service are

--- a/platforms/hyperledger-fabric/charts/fabric-channel-join/templates/anchorpeer.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-channel-join/templates/anchorpeer.yaml
@@ -3,7 +3,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
-{{- if eq .Values.peer.type "anchor" }}
+{{- if and (eq .Values.peer.type "anchor") (not .Values.peer.addPeerValue) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/platforms/hyperledger-fabric/configuration/add-cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-cli.yaml
@@ -28,7 +28,7 @@
       loop: "{{ network.organizations }}"
       loop_control:
         loop_var: org
-      when: org.type == "peer" and org.org_status == "new"
+      when: org.services.peers is defined and org.services.peers | length > 0 and org.org_status == "new"
 
   vars: #These variables can be overriden from the command line
     privilege_escalate: false           #Default to NOT escalate to root privledges

--- a/platforms/hyperledger-fabric/configuration/add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-peer.yaml
@@ -25,76 +25,7 @@
     file:
       path: "./build"
       state: absent
-  # Create Namespaces and Vault-rbac kubernetes-value files for new organization
-  - include_role:
-      name: "create/namespace"
-    vars:
-      component_name: "{{ item.name | lower }}-net"
-      component_type_name: "{{ item.type | lower }}"
-      kubernetes: "{{ item.k8s }}"
-      release_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
-    loop: "{{ network['organizations'] }}"
-
-  # Setup script for Vault and OS Package Manager
-  - name: "Setup script for Vault and OS Package Manager"
-    include_role:
-      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/scripts"
-    vars:
-      namespace: "{{ org.name | lower }}-net"
-      kubernetes: "{{ org.k8s }}"
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    when: org.org_status == 'new'
   
-  # Setup Vault-Kubernetes accesses and Regcred for docker registry for new organization
-  - include_role: 
-      name: "{{ playbook_dir }}/../../shared/configuration/roles/setup/vault_kubernetes"
-    vars:
-      name: "{{ org.name | lower }}"
-      component_name: "{{ org.name | lower }}-vaultk8s-job"
-      component_type: "{{ org.type | lower }}"
-      component_ns: "{{ org.name | lower }}-net"
-      component_auth: "{{ network.env.type }}{{ name }}"
-      kubernetes: "{{ org.k8s }}"
-      vault: "{{ org.vault }}"
-      gitops: "{{ org.gitops }}"
-      reset_path: "platforms/hyperledger-fabric/configuration"
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    when: org.org_status == 'new'
-  
-  # Create Storageclass for new organization
-  - include_role:
-      name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/setup/storageclass"  
-    vars:
-      org_name: "{{ org.name | lower }}"
-      sc_name: "{{ org_name }}-bevel-storageclass"
-      region: "{{ org.k8s.region | default('eu-west-1') }}"
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    
-  # Create Organization crypto materials for new organization
-  - include_role:
-      name: "create/ca_tools/peer"
-    vars:
-      component_name: "{{ item.name | lower}}-net"
-      component: "{{ item.name | lower}}"
-      component_type: "{{ item.type | lower}}"
-      component_services: "{{ item.services }}"
-      orderer_org: "{{ item.orderer_org | lower }}"
-      sc_name: "{{ component }}-bevel-storageclass"
-      kubernetes: "{{ item.k8s }}"
-      vault: "{{ item.vault }}"
-      ca: "{{ item.services.ca }}"
-      docker_url: "{{ network.docker.url }}"
-      gitops: "{{ item.gitops }}"
-      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
-    loop: "{{ network['organizations'] }}"
-    when: item.type == 'peer'
-
   # This role fetches block 0 and joins peers of new organizaion to the channel
   - include_role:
       name: "create/new_peer/update_block"
@@ -106,22 +37,26 @@
  
   # This role creates the value file for peers of organisations and write couch db credentials
   # to the vault.
-  - include_role:
+  - name: Create all peers
+    include_role:
       name: "create/peers"
     vars:
       build_path: "./build"
-      namespace: "{{ item.name | lower}}-net"
-      component_type: "{{ item.type | lower}}"
-      component_services: "{{ item.services }}"
-      vault: "{{ item.vault }}"
-      git_protocol: "{{ item.gitops.git_protocol }}"
-      git_url: "{{ item.gitops.git_url }}"
-      git_branch: "{{ item.gitops.branch }}"
+      namespace: "{{ org.name | lower}}-net"
+      component_type: "{{ org.type | lower}}"
+      component_services: "{{ org.services }}"
+      kubernetes: "{{ org.k8s }}"
+      vault: "{{ org.vault }}"
+      git_protocol: "{{ org.gitops.git_protocol }}"
+      git_url: "{{ org.gitops.git_url }}"
+      git_branch: "{{ org.gitops.branch }}"
       docker_url: "{{ network.docker.url }}"
-      charts_dir: "{{ item.gitops.chart_source }}"
-      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
+      charts_dir: "{{ org.gitops.chart_source }}"
+      values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
     loop: "{{ network['organizations'] }}"
-    when: item.type == 'peer'
+    loop_control:
+      loop_var: org
+    when: org.services.peers is defined and org.services.peers | length > 0
 
   # This role fetches block 0 and joins peers of new organizaion to the channel
   - include_role:
@@ -131,18 +66,6 @@
       participants: "{{ item.participants }}"
       docker_url: "{{ network.docker.url }}"
     loop: "{{ network['channels'] }}"
-
-  # Create CLI pod for peers with cli option enabled
-  - name: Create CLI pod for each peer when enabled
-    include_role:
-      name: "create/cli_pod"
-    vars:
-      peers: "{{ org.services.peers }}"
-      docker_url: "{{ network.docker.url }}"
-    loop: "{{ network.organizations }}"
-    loop_control:
-      loop_var: org
-    when: org.type == "peer"
 
   vars: #These variables can be overriden from the command line
     privilege_escalate: false           #Default to NOT escalate to root privledges

--- a/platforms/hyperledger-fabric/configuration/roles/create/channels/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/channels/tasks/valuefile.yaml
@@ -79,7 +79,7 @@
     git_url: "{{ org.gitops.git_url }}"
     git_branch: "{{ org.gitops.branch }}"
     charts_dir: "{{ org.gitops.chart_source }}"
-    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
+    values_dir: "{{playbook_dir}}/../../../{{org.gitops.component_dir}}/{{ org.name | lower }}"
     provider: "{{ org.cloud_provider }}"
     vault: "{{ org.vault }}"
     kubernetes: "{{ org.k8s }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/channels_join/tasks/nested_channel_join.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/channels_join/tasks/nested_channel_join.yaml
@@ -20,6 +20,12 @@
     - participant.type == 'creator' and ('2.2.' in network.version or '1.4.' in network.version)
     - participant.org_status is not defined or participant.org_status == 'new'
 
+# Set Variable charts_dir
+- name: "Set Variable charts_dir"
+  set_fact:
+    charts_dir: "{{ org.gitops.chart_source }}"
+  when: charts_dir is undefined
+
 # Get anchortx file from configmap obtener los datos del ordener en un task a aprte y despeus ahcer esto
 - name: Get anchortx file from config map 
   kubernetes.core.k8s_info:
@@ -72,7 +78,8 @@
     charts_dir: "{{ org.gitops.chart_source }}"
     vault: "{{ org.vault }}"
     k8s: "{{ org.k8s }}"
-    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
+    add_peer_value: "{{ add_peer | default('false') }}"
+    values_dir: "{{playbook_dir}}/../../../{{org.gitops.component_dir}}/{{ org.name | lower }}"
   loop: "{{ participant.peers }}"
   loop_control:
     loop_var: peer

--- a/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/valuefile.yaml
@@ -11,7 +11,7 @@
     kubernetes: "{{ org.k8s }}"
     vault: "{{ org.vault }}"
     charts_dir: "{{ org.gitops.chart_source }}"
-    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
+    values_dir: "{{playbook_dir}}/../../../{{org.gitops.component_dir}}/{{ org.name | lower }}"
     generateGenisisBLock: "{{ generateGenisis }}"
 
 # Git Push: Push the above generated files to git directory 

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_cli/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_cli/tasks/main.yaml
@@ -12,63 +12,13 @@
 #
 ############################################################################################
 
-# Check if pods are present or not
-- name: 'checking for job {{ component_name }} in {{ namespace }}'
-  k8s_info:
-    kind: "Pod"
-    namespace: "{{ component_ns }}"
-    kubeconfig: "{{ kubernetes.config_file }}"
-    context: "{{ kubernetes.context }}"
-    label_selectors:
-      - app = cli
-  vars:
-    name: "cli"
-    kubernetes: "{{ org.k8s }}"
-    component_name: "{{ peer.name | lower}}-{{ org.name | lower }}-cli"
-    component_ns: "{{ org.name | lower}}-net"
-    loop: "{{ peers }}"
-  loop_control:
-    loop_var: peer
-  register: existing_cli
-
-# Create the value file
-- name: "Create Value file for CLI Pod"
-  include_role:
-    name: helm_component
-  vars:
-    name: "cli"
-    component_name: "{{ peer.name | lower}}-{{ org.name | lower }}-cli"
-    orderer: "{{ network.orderers | first }}"
-    component_ns: "{{ org.name | lower}}-net"
-    git_protocol: "{{ org.gitops.git_protocol }}"
-    git_url: "{{ org.gitops.git_url }}"
-    git_branch: "{{ org.gitops.branch }}"
-    charts_dir: "{{ org.gitops.chart_source }}"
-    vault: "{{ org.vault }}"
-    sc_name: "{{ org.name | lower }}-bevel-storageclass"
-    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
-    type: "cli"
-    external_url_suffix: "{{ org.external_url_suffix }}"
+# Create values file for cli
+- name: Create values file for cli
+  include_tasks: valuefile.yaml
   loop: "{{ peers }}"
   loop_control:
     loop_var: peer
-  when:
-  - peer.peerstatus is not defined or peer.peerstatus == 'new'
-  - peer.cli is defined
-  - peer.cli == "enabled"
-  - existing_cli.resources|length == 0
-
-# Git Push : Push the above generated files to git directory
-- name: Git Push
-  include_role:
-    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
-  vars:
-    GIT_DIR: "{{ playbook_dir }}/../../../"
-    gitops: "{{ org.gitops }}"
-    msg: "[ci skip] Pushing CLI value files"
-  loop: "{{ peers }}"
-  loop_control:
-    loop_var: peer
-  when:
+  when: 
+    - peer.peerstatus is not defined or peer.peerstatus == 'new'
     - peer.cli is defined
     - peer.cli == "enabled"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_cli/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_cli/tasks/valuefile.yaml
@@ -1,0 +1,68 @@
+# Set Variable existing_cli and existing_cli_dependency to empty
+- name: "Set Variables existing_cli and existing_cli_dependency to empty"
+  set_fact:
+    existing_cli: ""
+    existing_cli_dependency: ""
+
+# Check if pods are present or not
+- name: 'checking for job {{ component_name }} in {{ component_ns }}'
+  k8s_info:
+    kind: "Pod"
+    namespace: "{{ component_ns }}"
+    kubeconfig: "{{ kubernetes.config_file }}"
+    context: "{{ kubernetes.context }}"
+    label_selectors:
+      - app = cli
+      - app.kubernetes.io/name={{ peer.name | lower}}
+  vars:
+    name: "cli"
+    kubernetes: "{{ org.k8s }}"
+    component_name: "{{ peer.name | lower}}-{{ org.name | lower }}"
+    component_ns: "{{ org.name | lower}}-net"
+  register: existing_cli_dependency
+
+# Check if pods are present or not
+- name: 'checking for job {{ component_name }} in {{ component_ns }}'
+  k8s_info:
+    kind: "Pod"
+    namespace: "{{ component_ns }}"
+    kubeconfig: "{{ kubernetes.config_file }}"
+    context: "{{ kubernetes.context }}"
+    label_selectors:
+      - app = cli
+      - app.kubernetes.io/name={{ component_name }}
+  vars:
+    name: "cli"
+    kubernetes: "{{ org.k8s }}"
+    component_name: "{{ peer.name | lower}}-{{ org.name | lower }}"
+    component_ns: "{{ org.name | lower}}-net"
+  register: existing_cli
+
+# Create the value file
+- name: "Create Value file for CLI Pod"
+  include_role:
+    name: helm_component
+  vars:
+    name: "cli"
+    component: "{{ org.name | lower}}"
+    component_name: "{{ peer.name | lower}}-{{ org.name | lower}}"
+    orderer: "{{ network.orderers | first }}"
+    component_ns: "{{ org.name | lower}}-net"
+    git_protocol: "{{ org.gitops.git_protocol }}"
+    git_url: "{{ org.gitops.git_url }}"
+    git_branch: "{{ org.gitops.branch }}"
+    vault: "{{ org.vault }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
+    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
+    type: "cli"
+  when:
+    - existing_cli.resources | length == 0 and existing_cli_dependency.resources | length == 0
+
+# Git Push : Push the above generated files to git directory
+- name: Git Push
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
+  vars:
+    GIT_DIR: "{{ playbook_dir }}/../../../"
+    gitops: "{{ org.gitops }}"
+    msg: "[ci skip] Pushing CLI value files"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_peer/update_block/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_peer/update_block/tasks/main.yaml
@@ -8,6 +8,12 @@
 # This task calls nested_sign_and_update and nested_update_channel tasks
 ##############################################################################################
 
+# create build directory
+- name: Check build directory exists
+  file:
+    path: "./build"
+    state: directory
+
 # Create the add_peer.sh file for new peer
 - name: "Create create-block-{{ item.channel_name | lower }}.sh script file for new peer"
   template:

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_peer/update_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_peer/update_block/tasks/nested_create_cli.yaml
@@ -13,14 +13,13 @@
   include_role:
     name: k8_component
   vars:
-    component_type_name: "{{ participant.name | lower }}"
+    component: "{{ participant.name | lower }}"
     component_type: "existing_peer_cli_job"    
-    component_name: "cli-{{ channel_name }}-{{ participant.name }}-{{ peer.name }}"
-    peer_name: "{{ peer.name }}"
+    component_name: "{{ peer.name | lower}}-cli"
+    orderer: "{{ network.orderers | first }}"
     component_ns: "{{ participant.name | lower}}-net"
     git_url: "{{ org.gitops.git_url }}"
     git_branch: "{{ org.gitops.branch }}"
     charts_dir: "{{ org.gitops.chart_source }}"
     vault: "{{ org.vault }}"
-    storage_class: "{{ participant.name | lower }}-bevel-storageclass"
-    release_dir: "./build"
+    release_dir: "./build/{{ participant.name }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_peer/update_block/tasks/nested_update_channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_peer/update_block/tasks/nested_update_channel.yaml
@@ -22,7 +22,7 @@
 # Create the value file for creater org first peer
 - name: "start cli for {{ peer.name }}-{{ org.name }} for updating the channel"
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} helm upgrade --install -f ./build/{{ participant.name }}/existing_peer_cli_job.yaml {{ peer.name }}-{{ participant.name }}-cli {{playbook_dir}}/../../../{{org.gitops.chart_source}}/fabric-cli
+    KUBECONFIG={{ org.k8s.config_file }} helm upgrade --install -f ./build/{{ participant.name }}/existing_peer_cli_job.yaml {{ peer.name }}-{{ participant.name }} {{playbook_dir}}/../../../{{org.gitops.chart_source}}/fabric-cli --namespace {{ participant.name | lower}}-net
   when: existing_cli.resources|length == 0
 
 # Wait for fabric cli
@@ -73,7 +73,7 @@
   loop: "{{ org.services.peers }}"
   loop_control:
     loop_var: peerx
-  when: peerx.type == 'anchor'  
+  when: peerx.type == 'anchor' 
 
 # update the blockchain after signature from the first peer of the creator
 - name: updating the channel with the new configuration block
@@ -86,13 +86,13 @@
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} --  sh ./add_peer.sh
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name | lower }}-net ${PEER_CLI} -- peer channel update -f {{ channel_name }}_update_in_envelope.pb -c {{ channel_name | lower}} -o {{ participant.ordererAddress }} --tls --cafile ${ORDERER_CA}
   environment:
-    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/orderer/tls/orderer.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
   register: update_channel
 
 # Delete the cli
-- name: "delete cli {{ peer.name }}-{{ participant.name }}-cli"
+- name: "delete cli {{ peer.name }}-{{ participant.name }}"
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} helm uninstall {{ peer.name }}-{{ participant.name }}-cli
+    KUBECONFIG={{ org.k8s.config_file }} helm uninstall {{ peer.name }}-{{ participant.name }} --namespace {{ participant.name | lower}}-net
   when: existing_cli.resources|length == 0

--- a/platforms/hyperledger-fabric/configuration/roles/create/osnchannels/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/osnchannels/tasks/valuefile.yaml
@@ -23,7 +23,7 @@
     name: create/refresh_certs/reset_pod
   vars:
     pod_name: "osn-createchannel-{{ channel_name }}"
-    file_path: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}/{{ org.name | lower }}/{{ channel_name }}.yaml"
+    file_path: "{{playbook_dir}}/../../../{{org.gitops.component_dir}}/{{ org.name | lower }}/{{ org.name | lower }}/{{ channel_name }}.yaml"
     gitops_value: "{{ org.gitops }}"
     component_ns: "{{ org.name | lower }}-net"
     kubernetes: "{{ org.k8s }}"
@@ -46,7 +46,7 @@
     vault: "{{ org.vault }}"
     k8s: "{{ org.k8s }}"
     orderers_list: "{{ org.services.orderers }}"
-    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
+    values_dir: "{{playbook_dir}}/../../../{{org.gitops.component_dir}}/{{ org.name | lower }}"
     add_orderer_value: "{{ add_orderer | default('false') }}"
   when: add_orderer is not defined or add_orderer == false
 

--- a/platforms/hyperledger-fabric/configuration/roles/create/peers/tasks/nested_main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/peers/tasks/nested_main.yaml
@@ -76,6 +76,7 @@
     provider: "{{ org.cloud_provider }}"
     orderer: "{{ network.orderers | first }}"
     user_list: "{{ org.users | default('') }}"
+    add_peer_value: "{{ add_peer | default('false') }}"
     enabled_cli: "{{ true if peer.cli == 'enabled' else false }}"
     sc_enabled: "{{ false if storage_classes_info.resources | selectattr('metadata.name', 'equalto', sc_name) | list else true }}"
     create_configmaps: "{{ true if (first_peer == peer.name) and (crypto_scripts_data.resources | length == 0) else false }}"

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
@@ -70,7 +70,7 @@ spec:
       settings:
         createConfigMaps: {{ create_configmaps }}
         refreshCertValue: false
-        addPeerValue: false
+        addPeerValue: {{ add_peer_value }}
         removeCertsOnDelete: true
         removeOrdererTlsOnDelete: true
 

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/vars/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/vars/main.yaml
@@ -42,8 +42,3 @@ ca_image:
   1.4.8: bevel-fabric-ca:1.4.8
   2.2.2: bevel-fabric-ca:1.4.8
   2.5.4: bevel-fabric-ca:latest
-
-fabric_tools_image:
-  1.4.8: bevel-fabric-tools:1.4.8
-  2.2.2: bevel-fabric-tools:2.2.2
-  2.5.4: bevel-fabric-tools:2.5.4

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/vars/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/vars/main.yaml
@@ -11,8 +11,5 @@ k8_templates:
   operator_mainchannel: operator_mainchannel.tpl
   operator_followerchannel: operator_followerchannel.tpl
 
-alpine_image: bevel-alpine:latest
-fabric_tools_image:
-  1.4.8: bevel-fabric-tools:1.4.8
-  2.2.2: bevel-fabric-tools:2.2.2
-  2.5.4: bevel-fabric-tools:2.5.4
+bevel_alpine_version: latest # Change to tag version when using tag specific images
+fabric_tools_image: bevel-fabric-tools

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-cli.yaml
@@ -6,7 +6,7 @@
 
 ---
 # yaml-language-server: $schema=../../../../platforms/network-schema.json
-# This is a sample configuration file to add new Peers to existing Organizations and channels.
+# This is a sample configuration file to add new peer Cli to existing Organizations and channels.
 network:
   # Network level configuration specifies the attributes required for each organization
   # to join an existing network.
@@ -70,7 +70,7 @@ network:
     - organization:
       name: carrier
       type: creator       # creator organization will create the channel and instantiate chaincode, in addition to joining the channel and install chaincode
-      org_status: existing  # org_status must be existing when adding peer
+      org_status: new  # org_status must be existing when adding peer
       peers:
       - peer:
         name: peer0
@@ -116,7 +116,7 @@ network:
       location: London
       subject: "O=Carrier,OU=Carrier,L=51.50/-0.13/London,C=GB"
       external_url_suffix: org3proxy.blockchaincloudpoc.com
-      org_status: existing  # org_status must be existing when adding peer
+      org_status: new  # org_status must be existing when adding peer
       orderer_org: supplychain # Name of the organization that provides the ordering service
       ca_data:
         certificate: /path/carrier/server.crt                           # CA Server public cert must be provided when adding peer on new cluster
@@ -165,16 +165,16 @@ network:
           type: ca
           grpc:
             port: 7054      
-        # When adding peer on new cluster, ca as a service is removed
-        # Ensure existing peers are listed with peerstatus = existing
+
+        # Peers that already have a CLI deployed must have peerstatus = existing
         peers:
         - peer:
           name: peer0
           type: anchor    # This can be anchor/nonanchor. Atleast one peer should be anchor peer.    
           gossippeeraddress: peer1.carrier-net.org3proxy.blockchaincloudpoc.com:443 # No change from original configuration
           peerAddress: peer0.carrier-net.org3proxy.blockchaincloudpoc.com:443 # Must include port, External URI of the peer
-          peerstatus: existing    # old peers should have status as existing
-          cli: disabled           # Creates a peer cli pod depending upon the (enabled/disabled) tag.          
+          peerstatus: existing    # Peers that already have a cli deployed must have status as existing
+          cli: enabled           # Creates a peer cli pod depending upon the (enabled/disabled) tag.          
           grpc:
             port: 7051
           events:
@@ -205,8 +205,8 @@ network:
           type: nonanchor    # This can be anchor/nonanchor. Atleast one peer should be anchor peer.    
           gossippeeraddress: peer0.carrier-net.org3proxy.blockchaincloudpoc.com:443 # Must include port, External address of the existing anchor peer
           peerAddress: peer1.carrier-net.org3proxy.blockchaincloudpoc.com:443 # Must include port, External URI of the peer
-          peerstatus: new     # new peers should have status as new
-          cli: disabled       # Creates a peer cli pod depending upon the (enabled/disabled) tag.          
+          peerstatus: new     # new peer cli should have status as new
+          cli: enabled       # Creates a peer cli pod depending upon the (enabled/disabled) tag.          
           grpc:
             port: 7051
           events:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
@@ -11,7 +11,7 @@ network:
   # Network level configuration specifies the attributes required for each organization
   # to join an existing network.
   type: fabric
-  version: 2.2.2                   # currently tested 1.4.8, 2.2.2 and 2.5.4
+  version: 2.2.2                   # currently tested 2.2.2 and 2.5.4
 
   frontend: enabled #Flag for frontend to enabled for nodes/peers
 
@@ -268,7 +268,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -388,7 +389,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -472,7 +474,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -556,7 +559,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-ordererorg.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-ordererorg.yaml
@@ -174,7 +174,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -257,7 +258,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored.
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -333,7 +335,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -419,7 +422,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -503,7 +507,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -587,7 +592,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
@@ -148,7 +148,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -232,7 +233,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -318,7 +320,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -402,7 +405,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -486,7 +490,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-external-chaincode.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-external-chaincode.yaml
@@ -176,7 +176,8 @@ network:
         git_protocol: "ssh" # Option for git over https or ssh
         git_url: "ssh://git@github.com/<username>/bevel.git"         # Gitops ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops https URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -255,7 +256,8 @@ network:
         git_protocol: "ssh" # Option for git over https or ssh
         git_url: "ssh://git@github.com/<username>/bevel.git"         # Gitops ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops https URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -348,7 +350,8 @@ network:
         git_protocol: "ssh" # Option for git over https or ssh
         git_url: "ssh://git@github.com/<username>/bevel.git"         # Gitops ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops https URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -439,7 +442,8 @@ network:
         git_protocol: "ssh" # Option for git over https or ssh
         git_url: "ssh://git@github.com/<username>/bevel.git"         # Gitops ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops https URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -529,7 +533,8 @@ network:
         git_protocol: "ssh" # Option for git over https or ssh
         git_url: "ssh://git@github.com/<username>/bevel.git"         # Gitops ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops https URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-kafka.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-kafka.yaml
@@ -152,7 +152,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -234,7 +235,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -321,7 +323,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -405,7 +408,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -490,7 +494,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
@@ -154,7 +154,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -11,7 +11,7 @@ network:
   # Network level configuration specifies the attributes required for each organization
   # to join an existing network.
   type: fabric
-  version: 2.2.2                 # currently tested 1.4.8, 2.2.2 and 2.5.4
+  version: 2.2.2                 # currently tested 2.2.2 and 2.5.4
   upgrade: false # true : To upgrading Hyperledger Fabric version from 1.4.x to 2.2.x
   frontend: enabled #Flag for frontend to enabled for nodes/peers
 
@@ -207,6 +207,7 @@ network:
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored.
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -328,7 +329,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -423,7 +425,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -515,7 +518,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches
@@ -608,7 +612,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-proxy-none.yaml
@@ -136,6 +136,7 @@ network:
         git_url: "https://github.com/<username>/bevel.git"  # Gitops https or ssh url for flux value files 
         branch: "local"                                          # Git branch where release is being made
         release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored.
         chart_source: "platforms/hyperledger-fabric/charts"      # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"              # Gitops git repository URL for git push  (without https://)
         username: "github_username"                              # Git user who has rights to check-in in all branches
@@ -207,6 +208,7 @@ network:
         git_url: "https://github.com/<username>/bevel.git"  # Gitops https or ssh url for flux value files 
         branch: "local"                                          # Git branch where release is being made
         release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored.
         chart_source: "platforms/hyperledger-fabric/charts"      # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"              # Gitops git repository URL for git push  (without https://)
         username: "github_username"                              # Git user who has rights to check-in in all branches
@@ -304,6 +306,7 @@ network:
         git_url: "https://github.com/<username>/bevel.git"  # Gitops https or ssh url for flux value files 
         branch: "local"                                          # Git branch where release is being made
         release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored.
         chart_source: "platforms/hyperledger-fabric/charts"      # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"              # Gitops git repository URL for git push  (without https://)
         username: "github_username"                              # Git user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/network-user-certificate.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-user-certificate.yaml
@@ -69,7 +69,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/<username>/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "develop"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/<username>/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "git_username"          # Git Service user who has rights to check-in in all branches

--- a/platforms/hyperledger-fabric/configuration/samples/workflow/network-fabric-workflow.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/workflow/network-fabric-workflow.yaml
@@ -185,7 +185,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "GIT_BRANCH"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
@@ -269,7 +270,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "GIT_BRANCH"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
@@ -364,7 +366,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "GIT_BRANCH"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
@@ -456,7 +459,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "GIT_BRANCH"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches
@@ -549,7 +553,8 @@ network:
         git_protocol: "https" # Option for git over https or ssh
         git_url: "https://github.com/GIT_USERNAME/bevel.git"         # Gitops https or ssh url for flux value files 
         branch: "GIT_BRANCH"           # Git branch where release is being made
-        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
+        release_dir: "platforms/hyperledger-fabric/releases/dev" # Relative Path in the Git repo for flux sync per environment.
+        component_dir: "platforms/hyperledger-fabric/releases/k8sComponent" # Relative path where values files are stored. 
         chart_source: "platforms/hyperledger-fabric/charts"     # Relative Path where the Helm charts are stored in Git repo
         git_repo: "github.com/GIT_USERNAME/bevel.git"   # Gitops git repository URL for git push  (without https://)
         username: "GIT_USERNAME"          # Git Service user who has rights to check-in in all branches

--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -625,6 +625,11 @@
           "pattern": "(^[A-Za-z0-9]+)(/[A-Za-z0-9-]+)*([A-Za-z0-9])$",
           "description": "Relative path where flux should sync files."
         },
+        "component_dir": {
+          "type": "string",
+          "pattern": "(^[A-Za-z0-9]+)(/[A-Za-z0-9-]+)*([A-Za-z0-9])$",
+          "description": "Relative path where values are stored."
+        },
         "chart_source": {
           "type": "string",
           "pattern": "(^[A-Za-z0-9]+)(/[A-Za-z0-9-]+)*([A-Za-z0-9])$",

--- a/platforms/shared/configuration/delete-network.yaml
+++ b/platforms/shared/configuration/delete-network.yaml
@@ -31,6 +31,7 @@
       organization: "{{ organizationItem.name | lower }}"
       organization_ns: "{{ organization }}-{{ namespace_suffix | map(attribute=network.type) | first }}"
       release_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}/{{ organization }}"
+      component_dir: "{{ playbook_dir }}/../../../{{ gitops.component_dir }}/{{ organization }}"
       release_ns_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}/{{ organization_ns }}"
       flux_mainfest_dir: "{{ playbook_dir }}/../../../{{ gitops.release_dir }}/flux-{{ network.env.type }}"
     loop: "{{ network['organizations'] }}"

--- a/platforms/shared/configuration/roles/create/job_component/templates/join_channel_job.tpl
+++ b/platforms/shared/configuration/roles/create/job_component/templates/join_channel_job.tpl
@@ -39,3 +39,4 @@ peer:
   tlsStatus: true
   channelName: {{ channel_name }}  
   ordererAddress: {{ participant.ordererAddress }}
+  addPeerValue: {{ add_peer_value }}

--- a/platforms/shared/configuration/roles/delete/gitops/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/delete/gitops/tasks/main.yaml
@@ -15,6 +15,14 @@
     path: "{{ release_dir }}"
     state: absent
 
+# This task deletes all the files from the component directory with org name
+- name: Delete release files
+  file:
+    path: "{{ component_dir }}"
+    state: absent
+  when: 
+  - network.type == "fabric"
+
 # This task deletes all the files from the release directory with org-namespace name
 - name: Delete release files
   file:


### PR DESCRIPTION
**Primary Changes**

1 .Updated playbook platforms/hyperledger-fabric/configuration/add-cli.yaml
2. Updated playbook platforms/hyperledger-fabric/configuration/add-peer.yaml
3. Added the component_dir field to the gitops section. This directory stores the values.yaml files created with the role platforms/shared/configuration/roles/create/job_component because storing them in the same directory as the flux manifests causes incompatibility.

fixes #2584