### PR TITLE
feat(fabric): Support of add orderer node operation

### DIFF
--- a/docs/source/guides/fabric/add-new-orderer-peer.md
+++ b/docs/source/guides/fabric/add-new-orderer-peer.md
@@ -3,66 +3,127 @@
 [//]: # (SPDX-License-Identifier: Apache-2.0)
 [//]: # (##############################################################################################)
 
-<a name = "adding-new-orderer-to-existing-organization-in-a-running-fabric-network"></a>
-# Adding a new RAFT orderer to existing Orderer organization in Hyperledger Fabric
+# Add Orderer Node to an existing organization
 
-- [Prerequisites](#prerequisites)
-- [Modifying Configuration File](#modifying-configuration-file)
-- [Run playbook](#run-playbook)
+This guide explains how to add an orderer node to an existing Hyperledger Fabric network using two methods:
 
+1. Using the `add-orderer.yaml` playbook: This method involves running an Ansible playbook that automates the process of adding an orderer node to the network.
 
-<a name = "prerequisites"></a>
+1. Using `helm install`: This method involves using the helm install command to directly install the orderer node chart.
+
 ## Prerequisites
-To add a new Orderer node, a fully configured Fabric network must be present already, i.e. a Fabric network which has Orderers, Peers, Channels (with all Peers already in the channels) and the organization to which the peer is being added. The corresponding crypto materials should also be present in their respective Hashicorp Vault. 
 
----
-**NOTE**: Addition of a new Orderer node has been tested on an existing network which is created by Bevel. Networks created using other methods may be suitable but this has not been tested by Bevel team.
-This works only for RAFT Orderer.
+- A fully configured Fabric network with Orderers and Peers. 
+- Corresponding crypto materials present in Hashicorp Vault or Kubernetes secrets.
+- Hyperledger Bevel configured.
 
----
+## Method 1: Using the `add-cli.yaml` playbook
 
-<a name = "modifying-configuration-file"></a>
-## Modifying Configuration File
+1. **Update Configuration File**
 
-A Sample configuration file for adding new orderer is available [here](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml). Please go through this file and all the comments there and edit accordingly.
+      To add a new Orderer node, a fully configured Fabric network must be present already, i.e. a Fabric network which has Orderers, Peers, Channels (with all Peers already in the channels) and the organization to which the peer is being added. The corresponding crypto materials should also be present in their respective Hashicorp Vault. 
 
-For generic instructions on the Fabric configuration file, refer [this guide](../networkyaml-fabric.md).
+      ---
+      **NOTE**: Addition of a new Orderer node has been tested on an existing network which is created by Bevel. Networks created using other methods may be suitable but this has not been tested by Bevel team.
+      This works only for RAFT Orderer.
 
-While modifying the configuration file(`network.yaml`) for adding new peer, all the existing orderers should have `status` tag as `existing` and the new orderers should have `status` tag as `new` under `network.organizations` as
+      ---
 
-```yaml
+1. **Update Configuration File**
 
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:126:135"
-      ..
-      ..
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:174:174"
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:185:220"
+      A Sample configuration file for adding new orderer is available [here](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml). Please go through this file and all the comments there and edit accordingly.
 
-```
-and under `network.orderers` the new orderer must be added.
+      For generic instructions on the Fabric configuration file, refer [this guide](../networkyaml-fabric.md).
 
-```yaml
---8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:42:66"
-```
-          
-The `network.yaml` file should contain the specific `network.organization` details.
+      While modifying the configuration file(`network.yaml`) for adding new peer, all the existing orderers should have `status` tag as `existing` and the new orderers should have `status` tag as `new` under `network.organizations` as
 
-Ensure the following is considered when adding the new orderer on a different cluster:
-- The CA server is accessible publicly or at least from the new cluster.
-- The CA server public certificate is stored in a local path and that path provided in network.yaml.
-- There is a single Hashicorp Vault and both clusters (as well as ansible controller) can access it.
-- Admin User certs have been already generated and store in Vault (this is taken care of by deploy-network.yaml playbook if you are using Bevel to setup the network).
-- The `network.env.type` is different for different clusters.
-- The GitOps release directory `gitops.release_dir` is different for different clusters.
+      ```yaml
 
-<a name = "run-playbook"></a>
-## Run playbook
+      --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:126:135"
+            ..
+            ..
+      --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:174:174"
+      --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:185:220"
 
-The [add-orderer.yaml](https://github.com/hyperledger/bevel/tree/main/platforms/hyperledger-fabric/configuration/add-orderer.yaml) playbook is used to add a new peer to an existing organization in the existing network. This can be done using the following command
+      ```
+      and under `network.orderers` the new orderer must be added.
 
-```
-ansible-playbook platforms/hyperledger-fabric/configuration/add-orderer.yaml --extra-vars "@path-to-network.yaml"
-```
+      ```yaml
+      --8<-- "platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml:42:66"
+      ```
+            
+      The `network.yaml` file should contain the specific `network.organization` details.
 
----
-**NOTE:** The `orderer.status` is not required when the network is deployed for the first time but is mandatory for addition of new orderer.
+      Ensure the following is considered when adding the new orderer on a different cluster:
+      - The CA server is accessible publicly or at least from the new cluster.
+      - The CA server public certificate is stored in a local path and that path provided in network.yaml.
+      - There is a single Hashicorp Vault and both clusters (as well as ansible controller) can access it.
+      - Admin User certs have been already generated and store in Vault (this is taken care of by deploy-network.yaml playbook if you are using Bevel to setup the network).
+      - The `network.env.type` is different for different clusters.
+      - The GitOps release directory `gitops.release_dir` is different for different clusters.
+
+1. **Run playbook**
+
+      The [add-orderer.yaml](https://github.com/hyperledger/bevel/tree/main/platforms/hyperledger-fabric/configuration/add-orderer.yaml) playbook is used to add a new peer to an existing organization in the existing network. This can be done using the following command
+
+      ```
+      ansible-playbook platforms/hyperledger-fabric/configuration/add-orderer.yaml --extra-vars "@path-to-network.yaml"
+      ```
+
+      ---
+      **NOTE:** The `orderer.status` is not required when the network is deployed for the first time but is mandatory for addition of new orderer.
+
+
+## Method 2: Using `helm install`
+
+1. **Update the orderernode values.yaml file**
+
+    Following changes are must in the `values.yaml` file for a new orderer node to be added to the network:
+
+    - `certs.settings.createConfigMaps: false` as the ConfigMaps for certs are already generated in the same namespace.
+
+    Refer to the [fabric-orderernode chart documentation](https://github.com/hyperledger/bevel/tree/main/platforms/hyperledger-fabric/charts/fabric-orderernode) for a complete list of available configuration options.
+
+1. **Install the orderernode chart**
+    
+    Execute the following command to install the Peer chart:
+	```bash
+	helm dependency update ./fabric-orderernode
+	helm install <release-name> ./fabric-orderernode --namespace <namespace> --values <values-file.yaml>
+	```
+	Replace the following placeholders:
+
+	- `<release-name>`: The desired name for the orderer node release.
+	- `<namespace>`: The Kubernetes namespace where the Peer should be deployed.
+	- `<values-file.yaml>`: The path to a YAML file containing the new peer configuration values.
+
+1. **Update the osnadmin-channel-create values.yaml file**
+
+    Following changes are must in the `values.yaml` file for a new orderer node to be added to the network:
+      ```
+      orderer:
+            addOrderer: true
+            name: orderer5
+            localMspId: orgNameMSP
+            ordererAddress: orderer1.orgname-net:443
+      ```
+
+    Refer to the [fabric-osn-channel-create chart documentation](https://github.com/hyperledger/bevel/tree/main/platforms/hyperledger-fabric/charts/fabric-osn-channel-create) for a complete list of available configuration options.
+
+1. **Install the osnadmin-channel-create chart**
+    
+    Execute the following command to install the fabric-osnadmin-channel-create chart:
+	```bash
+    cd ../..
+	helm install <release-name> ./fabric-osnadmin-channel-create --namespace <namespace> --values <values-file.yaml>
+	```
+	Replace the following placeholders:
+
+	- `<release-name>`: The desired name for the Peer release.
+	- `<namespace>`: The Kubernetes namespace where the Peer should be deployed.
+	- `<values-file.yaml>`: The path to a YAML file containing the new peer configuration values.
+
+
+## Additional Notes
+- The `add-orderer.yaml playbook` and `helm install` method has been tested on networks created by Bevel. Networks created using other methods may be suitable, but this has not been tested by the Bevel team.
+- Ensure that the network.yaml file contains the specific network.organization details along with the orderer information.

--- a/platforms/hyperledger-fabric/charts/fabric-cli/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-cli/templates/deployment.yaml
@@ -117,6 +117,26 @@ spec:
             fi     
           }
 
+          function getAdminTlsSecret {
+            KEY=$1
+
+            echo "Getting TLS certificates from Vault."
+            vaultBevelFunc "readJson" "${VAULT_SECRET_ENGINE}/${VAULT_SECRET_PREFIX}/users/${KEY}"
+            if [ "$SECRETS_AVAILABLE" == "yes" ]
+            then
+              OSN_TLS_CA_ROOT_CERT=$(echo ${VAULT_SECRET} | jq -r '.["ca_crt"]')
+              ADMIN_TLS_SIGN_CERT=$(echo ${VAULT_SECRET} | jq -r '.["client_crt"]')
+              ADMIN_TLS_PRIVATE_KEY=$(echo ${VAULT_SECRET} | jq -r '.["client_key"]')
+
+              echo "${OSN_TLS_CA_ROOT_CERT}" > ${OUTPUT_TLS_PATH}/tlsca.crt
+              echo "${ADMIN_TLS_SIGN_CERT}" > ${OUTPUT_TLS_PATH}/server.crt
+              echo "${ADMIN_TLS_PRIVATE_KEY}" > ${OUTPUT_TLS_PATH}/server.key
+              ADMIN_TLS_SECRET=true
+            else
+              ADMIN_TLS_SECRET=false
+            fi     
+          }
+
 {{- else }}
 
           function getAdminMspSecret {
@@ -140,6 +160,23 @@ spec:
             fi            
           }
 
+          function getAdminTlsSecret {
+            KEY=$1
+            KUBENETES_SECRET=$(kubectl get secret ${KEY} --namespace {{ .Release.Namespace }} -o json)
+            if  [ "$KUBENETES_SECRET" = "" ]; then
+              ADMIN_TLS_SECRET=false
+            else
+              OSN_TLS_CA_ROOT_CERT=$(echo ${KUBENETES_SECRET} | jq -r '.data.ca_crt'  | base64 -d)
+              ADMIN_TLS_SIGN_CERT=$(echo ${KUBENETES_SECRET} | jq -r '.data.client_crt'  | base64 -d)
+              ADMIN_TLS_PRIVATE_KEY=$(echo ${KUBENETES_SECRET} | jq -r '.data.client_key'  | base64 -d)
+
+              echo "${OSN_TLS_CA_ROOT_CERT}" > ${OUTPUT_TLS_PATH}/tlsca.crt
+              echo "${ADMIN_TLS_SIGN_CERT}" > ${OUTPUT_PATH}/cacerts/server.crt
+              echo "${ADMIN_TLS_PRIVATE_KEY}" > ${OUTPUT_PATH}/keystore/server.key 
+              ADMIN_TLS_SECRET=true
+            fi            
+          }
+
 {{- end }} 
 
           COUNTER=1
@@ -147,14 +184,17 @@ spec:
           do
 
             OUTPUT_PATH="${MOUNT_PATH}/admin/msp"
+            OUTPUT_TLS_PATH="${MOUNT_PATH}/tls/msp"
+            mkdir -p ${OUTPUT_TLS_PATH}
             mkdir -p ${OUTPUT_PATH}/admincerts
             mkdir -p ${OUTPUT_PATH}/cacerts
             mkdir -p ${OUTPUT_PATH}/keystore
             mkdir -p ${OUTPUT_PATH}/signcerts
             mkdir -p ${OUTPUT_PATH}/tlscacerts
-            getAdminMspSecret admin-msp  
+            getAdminMspSecret admin-msp
+            getAdminTlsSecret admin-tls
 
-            if [ "$ADMIN_MSP_SECRET" = "true" ]
+            if [ "$ADMIN_MSP_SECRET" = "true" ] && [ "$ADMIN_TLS_SECRET" = "true" ]
             then
               echo "Peer certificates have been obtained correctly"
               break
@@ -214,6 +254,8 @@ spec:
           value: "{{ .Values.ordererAddress }}"
         - name: CORE_PEER_MSPCONFIGPATH
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp
+        - name: CORE_PEER_TLSCONFIGPATH
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/tls
         volumeMounts:
         - name: certificates
           mountPath: /opt/gopath/src/github.com/hyperledger/fabric/crypto

--- a/platforms/hyperledger-fabric/configuration/add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-orderer.yaml
@@ -24,25 +24,6 @@
       path: "./build"
       state: absent
 
-  # Create CA Tools helm-value files and check-in
-  - name: Create CA tools for each organization
-    include_role:
-      name: "create/ca_tools/orderer"
-    vars:
-      component_name: "{{ item.name | lower}}-net"
-      component: "{{ item.name | lower}}"
-      component_type: "{{ item.type | lower}}"
-      component_services: "{{ item.services }}"
-      sc_name: "{{ component }}-bevel-storageclass"
-      kubernetes: "{{ item.k8s }}"
-      vault: "{{ item.vault }}"
-      ca: "{{ item.services.ca }}"
-      docker_url: "{{ network.docker.url }}"
-      gitops: "{{ item.gitops }}"
-      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
-    loop: "{{ network['organizations'] }}"
-    when: item.type == 'orderer'
-
   # Generate script to modify the fetched configuration block
   - name: "Modify the system channel with tls information of new orderer"
     include_role:
@@ -65,18 +46,22 @@
       name: "create/orderers"
     vars:
       build_path: "./build"
-      namespace: "{{ item.name | lower}}-net"
-      component_type: "{{ item.type | lower}}"
-      component_services: "{{ item.services }}"
-      vault: "{{ item.vault }}"
-      git_protocol: "{{ item.gitops.git_protocol }}"
-      git_url: "{{ item.gitops.git_url }}"
-      git_branch: "{{ item.gitops.branch }}"
+      namespace: "{{ org.name | lower}}-net"
+      component_type: "{{ org.type | lower}}"
+      org_name: "{{ org.name | lower }}"
+      component_services: "{{ org.services }}"
+      kubernetes: "{{ org.k8s }}"
+      vault: "{{ org.vault }}"
+      git_protocol: "{{ org.gitops.git_protocol }}"
+      git_url: "{{ org.gitops.git_url }}"
+      git_branch: "{{ org.gitops.branch }}"
       docker_url: "{{ network.docker.url }}"
-      charts_dir: "{{ item.gitops.chart_source }}"
-      values_dir: "{{playbook_dir}}/../../../{{item.gitops.release_dir}}/{{ item.name | lower }}"
+      charts_dir: "{{ org.gitops.chart_source }}"
+      values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
     loop: "{{ network['organizations'] }}"
-    when: item.type == 'orderer'
+    loop_control:
+        loop_var: org
+    when: org.services.orderers is defined and org.services.orderers | length > 0
 
   # Generate script to modify the fetched configuration block
   - name: "Modify the system channel with endpoint information of new orderer"
@@ -112,10 +97,15 @@
     vars:
       build_path: "./build"
       channel_name: "{{ channel.channel_name | lower }}"
+      org_peer: "{{ channel.participants | first}}"
+      vault: "{{ org.vault }}"
+      existingOrdererAddress: "{{ org_peer.ordererAddress }}"
+      peer: "{{ org_peer.peers | first }}"
       docker_url: "{{ network.docker.url }}"
     loop: "{{ network.channels }}"
     loop_control:
       loop_var: channel
+    when: '2.5.' not in network.version
 
   vars: #These variables can be overriden from the command line
     add_new_org: 'false'                #Default for this playbook is false

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_appchannel_block.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_appchannel_block.yaml
@@ -38,6 +38,16 @@
     path: "{{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls"
     state: touch
 
+# Copy tls server.crt from vault to the build directory
+- name: Fetch the tls server.crt from vault
+  shell: |
+    vault kv get -field=server_crt {{ vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ org.name }}/orderers/{{ orderer.name }}-tls > server.crt
+    mkdir -p {{ build_path }}/tls-cert/{{ orderer.name }}
+    mv server.crt {{ build_path }}/tls-cert/{{ orderer.name }}
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+
 # Create orderer-tls for tls certificate information
 - name: "adding tls certificate information"
   shell: |
@@ -45,7 +55,7 @@
     then
       echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.name|lower }}.{{ component_ns }}\",\"port\":{{ orderer.grpc.port }},\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
     else
-      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.ordererAddress.split(":")[0] | to_json }}\",\"port\":\"{{ orderer.ordererAddress.split(":")[1] | to_json }}\",\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
+      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/tls-cert/{{ orderer.name }}/server.crt | base64 -w 0))\",\"host\":\"{{ orderer.ordererAddress.split(":")[0] | to_json }}\",\"port\":{{ orderer.ordererAddress.split(":")[1] | to_json }},\"server_tls_cert\":\"$(cat {{ build_path }}/tls-cert/{{ orderer.name }}/server.crt | base64 -w 0))\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
     fi
 
 # Create orderer file for adding new endpoint information
@@ -71,6 +81,8 @@
     dest: "{{ build_path }}/update-channel-script.sh"
   vars:
     component_name: "{{ org.name | lower }}"
+    ordererAddress: "{{ orderer.ordererAddress }}"
+    ordererOrg: "{{ org.name | lower }}MSP"
     os: "{{ fabric.os }}"
     arch: "{{ fabric.arch }}"
     version: "{{ network.version }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/tasks/nested_create_cli.yaml
@@ -14,7 +14,9 @@
     name: k8_component
   vars:
     component_type_name: "{{ org.name | lower }}"
+    name: "{{ orderer.name | lower }}"
     component_type: "orderer_cli_job"    
+    component: "{{ org.name | lower }}"
     component_name: "cli-{{ channel_name }}-{{ org.name }}-{{ orderer.name }}"
     orderer_name: "{{ orderer.name }}"
     component_ns: "{{ org.name | lower}}-net"
@@ -22,9 +24,10 @@
     git_branch: "{{ org.gitops.branch }}"
     charts_dir: "{{ org.gitops.chart_source }}"
     vault: "{{ org.vault }}"
-    channel_name: "{{ channel_name }}"
+    k8s: "{{ org.k8s }}"
     storage_class: "{{ org.name | lower }}-bevel-storageclass"
     release_dir: "{{ build_path }}"
+    values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"
     orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
     orderer_address: "{{ orderer.ordererAddress }}"
 
@@ -32,7 +35,7 @@
 # Create the value first orderer in orderer organization
 - name: "start cli"
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} helm upgrade --install -f {{ build_path }}/{{ org.name }}/orderer_cli_job.yaml {{ orderer.name }}-{{ org.name }}-cli {{playbook_dir}}/../../../{{org.gitops.chart_source}}/fabric-cli
+    KUBECONFIG={{ org.k8s.config_file }} helm upgrade --install -f {{ build_path }}/orderer_cli_job.yaml {{ orderer.name }}-{{ org.name }}-cli --namespace {{ org.name | lower}}-net {{playbook_dir}}/../../../{{org.gitops.chart_source}}/fabric-cli
 
 # Waiting for fabric cli
 - name: "Check if fabric cli is present"
@@ -52,7 +55,7 @@
 # from first orderer of orderer organization
 - name: fetch and update the configuration block from the blockchain
   shell: |
-    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
+    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "fabric-cli" | head -n 1 | awk '{print $1}')
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_config_block.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ build_path }}/update-channel-script.sh {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/update_consenter.sh
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/orderer
@@ -62,7 +65,7 @@
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel update -f {{ channel_name }}_update_in_envelope.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name }}_modified_config.json {{ build_path }}/{{ channel_name }}_config_block_with_added_content.json  
   environment:
-    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/orderer/tls/orderer.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
     ordererAddress: "{{ orderer.ordererAddress }}"
@@ -71,7 +74,7 @@
 # Fetch and update the configuration block from the blockchain for proxy none
 - name: Fetch and update the configuration block from the blockchain for proxy none
   shell: |
-    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
+    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "fabric-cli" | head -n 1 | awk '{print $1}')
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_config_block.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ build_path }}/update-channel-script.sh {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/update_consenter.sh
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/orderer
@@ -81,7 +84,7 @@
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel update -f {{ channel_name }}_update_in_envelope.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name }}_modified_config.json {{ build_path }}/{{ channel_name }}_config_block_with_added_content.json  
   environment:
-    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/orderer/tls/orderer.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
     ordererAddress: "{{ orderer.name | lower }}.{{ component_ns }}:{{ orderer.grpc.port }}"
@@ -90,11 +93,11 @@
 # Fetch the latest config block from the orderer cli of first orderer in orderer organization
 - name: fetch the latest block from the blockchain
   shell: |
-    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
+    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "fabric-cli" | head -n 1 | awk '{print $1}')
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_latest_config_block.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name }}_latest_config_block.pb {{ build_path }}/{{ channel_name }}_config_block.pb
   environment:
-    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/orderer/tls/orderer.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
     ordererAddress: "{{ orderer.ordererAddress }}"
@@ -103,11 +106,11 @@
 # Fetch the latest block from the blockchain for proxy none
 - name: Fetch the latest block from the blockchain for proxy none
   shell: |
-    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
+    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "fabric-cli" | head -n 1 | awk '{print $1}')
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_latest_config_block.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name }}_latest_config_block.pb {{ build_path }}/{{ channel_name }}_config_block.pb
   environment:
-    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/orderer/tls/orderer.crt"
   vars: 
     kubernetes: "{{ org.k8s }}"
     ordererAddress: "{{ orderer.name | lower }}.{{ component_ns }}:{{ orderer.grpc.port }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/templates/update_channel_script.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_appchannel_block/templates/update_channel_script.tpl
@@ -7,6 +7,7 @@ NETWORK_VERSION="{{ version }}"
 
 echo "installing jq "
 apt-get install -y jq
+
 if [ "$NETWORK_VERSION" != "2.5.4" ]; then
     echo "installing configtxlator"
     mkdir temp
@@ -27,8 +28,7 @@ if [ "$NETWORK_VERSION" != "2.5.4" ]; then
     jq --argjson a "$(cat ./orderer-tls)" '.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters += $a' {{ channel_name }}_modified_intermediate_config.json > {{ channel_name }}_modified_config.json
 else
     echo "version 2.5.4++++"
-    jq --argjson a "$(cat ./orderer)" '.channel_group.values.OrdererAddresses.value.addresses += $a' {{ channel_name }}_config.json > {{ channel_name }}_modified_intermediate_address_config.json
-    jq --argjson a "$(cat ./orderer)" '.channel_group.groups.Orderer.groups.{{ component_name }}MSP.values.Endpoints.value.addresses += $a' {{ channel_name }}_modified_intermediate_address_config.json > {{ channel_name }}_modified_intermediate_endpoints_config.json
+    jq --argjson a "$(cat ./orderer)" '.channel_group.groups.Orderer.groups.{{ component_name }}MSP.values.Endpoints.value.addresses += $a' {{ channel_name }}_config.json > {{ channel_name }}_modified_intermediate_endpoints_config.json
     jq --argjson a "$(cat ./orderer-tls)" '.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters += $a' {{ channel_name }}_modified_intermediate_endpoints_config.json > {{ channel_name }}_modified_config.json
 fi
 echo "converting the channel_config.json and channel_modified_config.json to .pb files"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/tasks/nested_main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/orderer_org/appchannel/tasks/nested_main.yaml
@@ -32,6 +32,16 @@
     path: "{{ build_path }}/channel-artifacts/{{ channel_name }}-orderer-tls"
     state: absent
 
+# Copy tls server.crt from vault to the build directory
+- name: Fetch the tls server.crt from vault
+  shell: |
+    vault kv get -field=server_crt {{ vault.secret_path | default('secretsv2') }}/{{ network.env.type }}{{ org.name }}/orderers/{{ orderer.name }}-tls > server.crt
+    mkdir -p {{ build_path }}/tls-cert/{{ orderer.name }}
+    mv server.crt {{ build_path }}/tls-cert/{{ orderer.name }}
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+    
 # creating new orderer-tls file
 - name: Creating new orderer-tls file
   file:
@@ -43,9 +53,9 @@
   shell: |
     if [ {{ network.env.proxy }} == 'none' ]
     then
-      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.name|lower }}.{{ component_ns }}\",\"port\":{{ orderer.grpc.port }},\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name }}-orderer-tls 
+      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.name|lower }}.{{ component_ns }}\",\"port\":{{ orderer.grpc.port }},\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
     else
-      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\",\"host\":\"{{ orderer.ordererAddress.split(":")[0] | to_json }}\",\"port\":\"{{ orderer.ordererAddress.split(":")[1] | to_json }}\",\"server_tls_cert\":\"$(cat {{ build_path }}/crypto-config/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer.name|lower }}.{{ component_ns }}/tls/server.crt | base64 -w 0)\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
+      echo -n "{\"client_tls_cert\":\"$(cat {{ build_path }}/tls-cert/{{ orderer.name }}/server.crt | base64 -w 0))\",\"host\":\"{{ orderer.ordererAddress.split(":")[0] | to_json }}\",\"port\":{{ orderer.ordererAddress.split(":")[1] | to_json }},\"server_tls_cert\":\"$(cat {{ build_path }}/tls-cert/{{ orderer.name }}/server.crt | base64 -w 0))\"}"  >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer-tls 
     fi
 
 # Create orderer file for adding new endpoint information
@@ -53,9 +63,9 @@
   shell: |
     if [ {{ network.env.proxy }} == 'none' ]
     then
-      echo -n '"{{ orderer.name }}.{{ component_ns }}:{{ orderer.grpc.port }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-orderer
+      echo -n '"{{ orderer.name }}.{{ component_ns }}:{{ orderer.grpc.port }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
     else
-      echo -n '"{{ orderer.ordererAddress }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name }}-orderer
+      echo -n '"{{ orderer.ordererAddress }}"' >> {{ build_path }}/channel-artifacts/{{ channel_name | lower}}-orderer
     fi
 
 ############################################################################################
@@ -64,7 +74,9 @@
   template:
     src: "update_channel_script.tpl"
     dest: "{{ build_path }}/update-channel-script.sh"
-  vars:    
+  vars:
+    ordererAddress: "{{ orderer.ordererAddress }}"
+    ordererOrg: "{{ org.name | lower }}MSP"
     os: "{{ fabric.os }}"
     arch: "{{ fabric.arch }}"
     version: "{{ network.version }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/orderers/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/orderers/tasks/main.yaml
@@ -66,7 +66,7 @@
     type: "orderers"
     consensus: "{{component_services.consensus}}"
     component_subject: "{{ org.subject | quote }}"
-    create_configmaps: "{{ true if first_orderer == orderer.name else false }}"
+    create_configmaps: "{{ true if first_orderer == orderer.name and (add_orderer is not defined or add_orderer == 'false') else false }}"
   loop: "{{ component_services.orderers }}"
   loop_control:
     loop_var: orderer

--- a/platforms/hyperledger-fabric/configuration/roles/create/osnchannels/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/osnchannels/tasks/valuefile.yaml
@@ -50,6 +50,14 @@
     add_orderer_value: "{{ add_orderer | default('false') }}"
   when: add_orderer is not defined or add_orderer == false
 
+- name: Delete Helm releases
+  kubernetes.core.helm:
+    kubeconfig: "{{ kubernetes.config_file }}"
+    name: "{{ channel_name }}"
+    release_namespace: "{{ org.name | lower }}-net"
+    state: absent
+  when: add_orderer is defined and add_orderer == 'true'
+
 # Create the value file for creator Organization
 - name: "Create Create_Channel value file osnadmin"
   include_role:
@@ -65,6 +73,8 @@
     charts_dir: "{{ org.gitops.chart_source }}"
     vault: "{{ org.vault }}"
     k8s: "{{ org.k8s }}"
+    existing_orderer: "{{ network.orderers | first }}"
+    existingOrdererAddress: "{{ existing_orderer.uri }}"
     orderers_list: "{{ org.services.orderers }}"
     first_orderer: "{{ org.services.orderers | first }}"
     values_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name | lower }}"

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/orderer_cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/orderer_cli.tpl
@@ -1,30 +1,56 @@
-metadata:
-  namespace: {{ component_ns }}
-  images:
-    fabrictools: {{ docker_url }}/{{ fabric_tools_image[network.version] }}
-    alpineutils: {{ docker_url }}/{{ alpine_image }}
-storage:
-  class: {{ storage_class }}
-  size: 256Mi
-vault:
-  role: vault-role
-  address: {{ vault.url }}
-  authpath: {{ org.k8s.cluster_id | default('')}}{{ network.env.type }}{{ org.name | lower }}
-  adminsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/{{ org.name | lower }}/ordererOrganizations/{{ component_ns }}/users/admin
-  orderersecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/{{ org.name | lower }}/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer_component }}
-  serviceaccountname: vault-auth
-  imagesecretname: regcred
-  tls: false
-peer:
-  name: {{ orderer_name }}
-  localmspid: {{ org.name | lower}}MSP
-  tlsstatus: true
-{% if network.env.proxy == 'none' %}
-  address: {{ orderer_name }}.{{ component_ns }}:7051
-orderer:
-  address: {{ orderer_name }}.{{ component_ns }}:7051
+global:
+  version: {{ network.version }}
+  serviceAccountName: vault-auth
+  cluster:
+    provider: {{ org.cloud_provider }}
+    cloudNativeServices: false
+  vault:
+    type: hashicorp
+    network: fabric
+    address: {{ vault.url }}
+    authPath: {{ network.env.type }}{{ component }}
+    secretEngine: {{ vault.secret_path | default("secretsv2") }}
+    secretPrefix: "data/{{ network.env.type }}{{ component }}"
+    role: vault-role
+    tls: false
+    
+image:
+  fabricTools: {{ docker_url }}/{{ fabric_tools_image }}
+  alpineUtils: {{ docker_url }}/bevel-alpine:{{ bevel_alpine_version }}
+{% if network.docker.username is defined and network.docker.password is defined %}
+  pullSecret: regcred
 {% else %}
-  address: {{ orderer_address }}
-orderer:
-  address: {{ orderer_address }}
+  pullSecret: ""
+{% endif %}
+
+peerName: {{ orderer.name }}
+storageClass: storage-{{ orderer.name }}
+storageSize: 256Mi
+localMspId: {{ org.name | lower}}MSP
+tlsStatus: true
+ports:
+  grpc:
+    clusterIpPort: {{ orderer.grpc.port }}
+ordererAddress: {{ orderer.ordererAddress }}
+
+{% if network.env.labels is defined %}
+labels:
+{% if network.env.labels.service is defined %}
+  service:
+{% for key in network.env.labels.service.keys() %}
+    - {{ key }}: {{ network.env.labels.service[key] | quote }}
+{% endfor %}
+{% endif %}
+{% if network.env.labels.pvc is defined %}
+  pvc:
+{% for key in network.env.labels.pvc.keys() %}
+    - {{ key }}: {{ network.env.labels.pvc[key] | quote }}
+{% endfor %}
+{% endif %}
+{% if network.env.labels.deployment is defined %}
+  deployment:
+{% for key in network.env.labels.deployment.keys() %}
+    - {{ key }}: {{ network.env.labels.deployment[key] | quote }}
+{% endfor %}
+{% endif %}
 {% endif %}

--- a/platforms/shared/configuration/roles/create/job_component/templates/osn_create_channel_job.tpl
+++ b/platforms/shared/configuration/roles/create/job_component/templates/osn_create_channel_job.tpl
@@ -38,9 +38,9 @@ orderers:
 
 addOrderer: {{ add_orderer_value }}
 
-{% if add_orderer is defined and add_orderer is sameas true  %}
+{% if add_orderer_value is defined and add_orderer_value is sameas true  %}
 orderer:
   name: {{ first_orderer.name }}
   localMspId: {{ org.name | lower}}MSP
-  address: {{ first_orderer.ordererAddress }}
+  address: {{ existingOrdererAddress }}
 {% endif %}

--- a/platforms/shared/configuration/roles/create/job_component/vars/main.yaml
+++ b/platforms/shared/configuration/roles/create/job_component/vars/main.yaml
@@ -27,10 +27,11 @@ charts:
   osn_create_channel_job: fabric-osnadmin-channel-create
   create_channel_job: fabric-channel-create
   join_channel_job: fabric-channel-join
-  bevel_alpine_version: latest
-  fabric_tools_image: bevel-fabric-tools
-  indy_genesis: indy-genesis
-  indy_endorser: indy-register-identity
-  corda_ent_init: enterprise-init
-  corda_ent_secondary_init: enterprise-init
-  corda_ent_cenm: cenm
+
+bevel_alpine_version: latest
+fabric_tools_image: bevel-fabric-tools
+indy_genesis: indy-genesis
+indy_endorser: indy-register-identity
+corda_ent_init: enterprise-init
+corda_ent_secondary_init: enterprise-init
+corda_ent_cenm: cenm


### PR DESCRIPTION
This PR includes the following changes:

 - Updates on charts to support  ___add orderer node___ operation using helm charts
 - Updates on playbooks to support ___add orderer node___ operation using playbooks
 - Updates on documentation
 - Other minor adjustments on tpl files



As a side note:

The new orderer added is a follower. Possible future improvements: *Make the new orderer as consenter*

![Screenshot 2024-08-05 at 11 12 57](https://github.com/user-attachments/assets/e1672190-80b1-4e16-8035-fc5011ccf886)

